### PR TITLE
[#59] Example Object interface should be added

### DIFF
--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Example.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Example.java
@@ -1,0 +1,56 @@
+package com.reprezen.kaizen.oasparser.model3;
+
+import com.reprezen.kaizen.oasparser.model3.OpenApiObject;
+import java.util.Map;
+import javax.annotation.Generated;
+
+public interface Example extends OpenApiObject {
+
+    // Summary
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    String getSummary();
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    void setSummary(String summary);
+
+    // Description
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    String getDescription();
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    void setDescription(String description);
+
+    // Value
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    Object getValue();
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    void setValue(Object value);
+
+    // ExternalValue
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    String getExternalValue();
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    void setExternalValue(String externalValue);
+
+    // Extension
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    Map<String, Object> getExtensions();
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    boolean hasExtension(String name);
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    Object getExtension(String name);
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    void setExtensions(Map<String, Object> extensions);
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    void setExtension(String name, Object extension);
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    void removeExtension(String name);
+
+}

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/MediaType.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/MediaType.java
@@ -1,9 +1,9 @@
 package com.reprezen.kaizen.oasparser.model3;
 
 import com.reprezen.kaizen.oasparser.model3.EncodingProperty;
+import com.reprezen.kaizen.oasparser.model3.Example;
 import com.reprezen.kaizen.oasparser.model3.OpenApiObject;
 import com.reprezen.kaizen.oasparser.model3.Schema;
-import java.util.Collection;
 import java.util.Map;
 import javax.annotation.Generated;
 
@@ -18,25 +18,22 @@ public interface MediaType extends OpenApiObject {
 
     // Example
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    Collection<Object> getExamples();
+    Map<String, ? extends Example> getExamples();
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    boolean hasExamples();
+    boolean hasExample(String name);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    Object getExample(int index);
+    Example getExample(String name);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    void setExamples(Collection<Object> examples);
+    void setExamples(Map<String, ? extends Example> examples);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    void setExample(int index, Object example);
+    void setExample(String name, Example example);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    void addExample(Object example);
-
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    void removeExample(int index);
+    void removeExample(String name);
 
     // Example
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/OpenApi3.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/OpenApi3.java
@@ -2,6 +2,7 @@ package com.reprezen.kaizen.oasparser.model3;
 
 import com.reprezen.kaizen.oasparser.OpenApi;
 import com.reprezen.kaizen.oasparser.model3.Callback;
+import com.reprezen.kaizen.oasparser.model3.Example;
 import com.reprezen.kaizen.oasparser.model3.ExternalDocs;
 import com.reprezen.kaizen.oasparser.model3.Header;
 import com.reprezen.kaizen.oasparser.model3.Info;
@@ -164,19 +165,19 @@ public interface OpenApi3 extends OpenApiObject, OpenApi {
 
     // Example
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    Map<String, Object> getExamples();
+    Map<String, ? extends Example> getExamples();
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     boolean hasExample(String name);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    Object getExample(String name);
+    Example getExample(String name);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    void setExamples(Map<String, Object> examples);
+    void setExamples(Map<String, ? extends Example> examples);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    void setExample(String name, Object example);
+    void setExample(String name, Example example);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     void removeExample(String name);

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Parameter.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Parameter.java
@@ -1,9 +1,9 @@
 package com.reprezen.kaizen.oasparser.model3;
 
+import com.reprezen.kaizen.oasparser.model3.Example;
 import com.reprezen.kaizen.oasparser.model3.MediaType;
 import com.reprezen.kaizen.oasparser.model3.OpenApiObject;
 import com.reprezen.kaizen.oasparser.model3.Schema;
-import java.util.Collection;
 import java.util.Map;
 import javax.annotation.Generated;
 
@@ -103,25 +103,22 @@ public interface Parameter extends OpenApiObject {
 
     // Example
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    Collection<Object> getExamples();
+    Map<String, ? extends Example> getExamples();
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    boolean hasExamples();
+    boolean hasExample(String name);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    Object getExample(int index);
+    Example getExample(String name);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    void setExamples(Collection<Object> examples);
+    void setExamples(Map<String, ? extends Example> examples);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    void setExample(int index, Object example);
+    void setExample(String name, Example example);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    void addExample(Object example);
-
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    void removeExample(int index);
+    void removeExample(String name);
 
     // ContentMediaType
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Schema.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Schema.java
@@ -1,5 +1,6 @@
 package com.reprezen.kaizen.oasparser.model3;
 
+import com.reprezen.kaizen.oasparser.model3.Example;
 import com.reprezen.kaizen.oasparser.model3.ExternalDocs;
 import com.reprezen.kaizen.oasparser.model3.OpenApiObject;
 import com.reprezen.kaizen.oasparser.model3.Schema;
@@ -358,25 +359,22 @@ public interface Schema extends OpenApiObject {
 
     // Example
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    Collection<Object> getExamples();
+    Map<String, ? extends Example> getExamples();
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    boolean hasExamples();
+    boolean hasExample(String name);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    Object getExample(int index);
+    Example getExample(String name);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    void setExamples(Collection<Object> examples);
+    void setExamples(Map<String, ? extends Example> examples);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    void setExample(int index, Object example);
+    void setExample(String name, Example example);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    void addExample(Object example);
-
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    void removeExample(int index);
+    void removeExample(String name);
 
     // Example
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ExampleImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ExampleImpl.java
@@ -1,0 +1,138 @@
+package com.reprezen.kaizen.oasparser.ovl3;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlayFactory;
+import com.reprezen.kaizen.oasparser.jsonoverlay.coll.ValMapOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.std.AnyObjectOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.std.StringOverlay;
+import com.reprezen.kaizen.oasparser.model3.Example;
+import com.reprezen.kaizen.oasparser.ovl3.OpenApiObjectImpl;
+import java.util.Map;
+import javax.annotation.Generated;
+
+public class ExampleImpl extends OpenApiObjectImpl implements Example {
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public ExampleImpl(String key, JsonNode json, JsonOverlay<?> parent) {
+        super(key, json, parent);
+    }
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public ExampleImpl(String key, JsonOverlay<?> parent) {
+        super(key, parent);
+    }
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private StringOverlay summary = registerField("summary", "summary", null, new StringOverlay("summary", this));
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private StringOverlay description = registerField("description", "description", null, new StringOverlay("description", this));
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private AnyObjectOverlay value = registerField("value", "value", null, new AnyObjectOverlay("value", this));
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private StringOverlay externalValue = registerField("externalValue", "externalValue", null, new StringOverlay("externalValue", this));
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private ValMapOverlay<Object,AnyObjectOverlay> extensions = registerField("", "extensions", "x-.+", new ValMapOverlay<Object, AnyObjectOverlay>("", this, AnyObjectOverlay.factory, "x-.+"));
+
+    // Summary
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public String getSummary() {
+        return summary.get();
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public void setSummary(String summary) {
+        this.summary.set(summary);
+    }
+
+    // Description
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public String getDescription() {
+        return description.get();
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public void setDescription(String description) {
+        this.description.set(description);
+    }
+
+    // Value
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public Object getValue() {
+        return value.get();
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public void setValue(Object value) {
+        this.value.set(value);
+    }
+
+    // ExternalValue
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public String getExternalValue() {
+        return externalValue.get();
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public void setExternalValue(String externalValue) {
+        this.externalValue.set(externalValue);
+    }
+
+    // Extension
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public Map<String, Object> getExtensions() {
+        return extensions.get();
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public boolean hasExtension(String name) {
+        return extensions.containsKey(name);
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public Object getExtension(String name) {
+        return extensions.get(name);
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public void setExtensions(Map<String, Object> extensions) {
+        this.extensions.set(extensions);
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public void setExtension(String name, Object extension) {
+        extensions.set(name, extension);
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public void removeExtension(String name) {
+        extensions.remove(name);
+    }
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public static JsonOverlayFactory<ExampleImpl> factory = new JsonOverlayFactory<ExampleImpl>() {
+    @Override
+    public ExampleImpl create(String key, JsonNode json, JsonOverlay<?> parent) {
+        return isEmptyRecursive(parent, ExampleImpl.class) ? null : new ExampleImpl(key, json, parent);
+    }
+};
+
+}

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/MediaTypeImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/MediaTypeImpl.java
@@ -4,16 +4,16 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlayFactory;
 import com.reprezen.kaizen.oasparser.jsonoverlay.coll.MapOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.coll.ValListOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.coll.ValMapOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.std.AnyObjectOverlay;
 import com.reprezen.kaizen.oasparser.model3.EncodingProperty;
+import com.reprezen.kaizen.oasparser.model3.Example;
 import com.reprezen.kaizen.oasparser.model3.MediaType;
 import com.reprezen.kaizen.oasparser.model3.Schema;
 import com.reprezen.kaizen.oasparser.ovl3.EncodingPropertyImpl;
+import com.reprezen.kaizen.oasparser.ovl3.ExampleImpl;
 import com.reprezen.kaizen.oasparser.ovl3.OpenApiObjectImpl;
 import com.reprezen.kaizen.oasparser.ovl3.SchemaImpl;
-import java.util.Collection;
 import java.util.Map;
 import javax.annotation.Generated;
 
@@ -33,7 +33,7 @@ public class MediaTypeImpl extends OpenApiObjectImpl implements MediaType {
     private SchemaImpl schema = registerField("schema", "schema", null, SchemaImpl.factory.create("schema", this));
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private ValListOverlay<Object, AnyObjectOverlay> examples = registerField("examples", "examples", null, new ValListOverlay<Object, AnyObjectOverlay>("examples", this, AnyObjectOverlay.factory));;
+    private MapOverlay<ExampleImpl> examples = registerField("examples", "examples", "[a-zA-Z0-9\\._-]+", new MapOverlay<ExampleImpl>("examples", this, ExampleImpl.factory, "[a-zA-Z0-9\\._-]+"));
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     private AnyObjectOverlay example = registerField("example", "example", null, new AnyObjectOverlay("example", this));
@@ -60,44 +60,40 @@ public class MediaTypeImpl extends OpenApiObjectImpl implements MediaType {
     // Example
     @Override
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public Collection<Object> getExamples() {
+    public Map<String, ? extends Example> getExamples() {
         return examples.get();
     }
 
     @Override
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public boolean hasExamples() {
-        return !examples.isMissing();
+    public boolean hasExample(String name) {
+        return examples.containsKey(name);
     }
 
     @Override
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public Object getExample(int index) {
-        return examples.get(index);
+    public Example getExample(String name) {
+        return examples.get(name);
     }
 
     @Override
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void setExamples(Collection<Object> examples) {
-        this.examples.set((Collection<Object>) examples);
+    public void setExamples(Map<String, ? extends Example> examples) {
+        @SuppressWarnings("unchecked")
+            Map<String,ExampleImpl> implExamples = (Map<String, ExampleImpl>) examples;
+            this.examples.set(implExamples);
     }
 
     @Override
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void setExample(int index, Object example) {
-        examples.set(index, example);
+    public void setExample(String name, Example example) {
+        examples.set(name, (ExampleImpl) example);
     }
 
     @Override
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void addExample(Object example) {
-        examples.add(example);
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void removeExample(int index) {
-        examples.remove(index);
+    public void removeExample(String name) {
+        examples.remove(name);
     }
 
     // Example

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/OpenApi3Impl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/OpenApi3Impl.java
@@ -10,6 +10,7 @@ import com.reprezen.kaizen.oasparser.jsonoverlay.coll.ValMapOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.std.AnyObjectOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.std.StringOverlay;
 import com.reprezen.kaizen.oasparser.model3.Callback;
+import com.reprezen.kaizen.oasparser.model3.Example;
 import com.reprezen.kaizen.oasparser.model3.ExternalDocs;
 import com.reprezen.kaizen.oasparser.model3.Header;
 import com.reprezen.kaizen.oasparser.model3.Info;
@@ -25,6 +26,7 @@ import com.reprezen.kaizen.oasparser.model3.SecurityScheme;
 import com.reprezen.kaizen.oasparser.model3.Server;
 import com.reprezen.kaizen.oasparser.model3.Tag;
 import com.reprezen.kaizen.oasparser.ovl3.CallbackImpl;
+import com.reprezen.kaizen.oasparser.ovl3.ExampleImpl;
 import com.reprezen.kaizen.oasparser.ovl3.ExternalDocsImpl;
 import com.reprezen.kaizen.oasparser.ovl3.HeaderImpl;
 import com.reprezen.kaizen.oasparser.ovl3.InfoImpl;
@@ -115,7 +117,7 @@ public class OpenApi3Impl extends OpenApiObjectImpl implements OpenApi3 {
     private MapOverlay<ParameterImpl> parameters = registerField("components/parameters", "parameters", "[a-zA-Z0-9\\._-]+", new MapOverlay<ParameterImpl>("components/parameters", this, ParameterImpl.factory, "[a-zA-Z0-9\\._-]+"));
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private ValMapOverlay<Object,AnyObjectOverlay> examples = registerField("components/examples", "examples", "[a-zA-Z0-9\\._-]+", new ValMapOverlay<Object, AnyObjectOverlay>("components/examples", this, AnyObjectOverlay.factory, "[a-zA-Z0-9\\._-]+"));
+    private MapOverlay<ExampleImpl> examples = registerField("components/examples", "examples", "[a-zA-Z0-9\\._-]+", new MapOverlay<ExampleImpl>("components/examples", this, ExampleImpl.factory, "[a-zA-Z0-9\\._-]+"));
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     private MapOverlay<RequestBodyImpl> requestBodies = registerField("components/requestBodies", "requestBodies", "[a-zA-Z0-9\\._-]+", new MapOverlay<RequestBodyImpl>("components/requestBodies", this, RequestBodyImpl.factory, "[a-zA-Z0-9\\._-]+"));
@@ -414,7 +416,7 @@ public class OpenApi3Impl extends OpenApiObjectImpl implements OpenApi3 {
     // Example
     @Override
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public Map<String, Object> getExamples() {
+    public Map<String, ? extends Example> getExamples() {
         return examples.get();
     }
 
@@ -426,20 +428,22 @@ public class OpenApi3Impl extends OpenApiObjectImpl implements OpenApi3 {
 
     @Override
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public Object getExample(String name) {
+    public Example getExample(String name) {
         return examples.get(name);
     }
 
     @Override
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void setExamples(Map<String, Object> examples) {
-        this.examples.set(examples);
+    public void setExamples(Map<String, ? extends Example> examples) {
+        @SuppressWarnings("unchecked")
+            Map<String,ExampleImpl> implExamples = (Map<String, ExampleImpl>) examples;
+            this.examples.set(implExamples);
     }
 
     @Override
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void setExample(String name, Object example) {
-        examples.set(name, example);
+    public void setExample(String name, Example example) {
+        examples.set(name, (ExampleImpl) example);
     }
 
     @Override

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ParameterImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ParameterImpl.java
@@ -4,18 +4,18 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlayFactory;
 import com.reprezen.kaizen.oasparser.jsonoverlay.coll.MapOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.coll.ValListOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.coll.ValMapOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.std.AnyObjectOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.std.BooleanOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.std.StringOverlay;
+import com.reprezen.kaizen.oasparser.model3.Example;
 import com.reprezen.kaizen.oasparser.model3.MediaType;
 import com.reprezen.kaizen.oasparser.model3.Parameter;
 import com.reprezen.kaizen.oasparser.model3.Schema;
+import com.reprezen.kaizen.oasparser.ovl3.ExampleImpl;
 import com.reprezen.kaizen.oasparser.ovl3.MediaTypeImpl;
 import com.reprezen.kaizen.oasparser.ovl3.OpenApiObjectImpl;
 import com.reprezen.kaizen.oasparser.ovl3.SchemaImpl;
-import java.util.Collection;
 import java.util.Map;
 import javax.annotation.Generated;
 
@@ -65,7 +65,7 @@ public class ParameterImpl extends OpenApiObjectImpl implements Parameter {
     private AnyObjectOverlay example = registerField("example", "example", null, new AnyObjectOverlay("example", this));
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private ValListOverlay<Object, AnyObjectOverlay> examples = registerField("examples", "examples", null, new ValListOverlay<Object, AnyObjectOverlay>("examples", this, AnyObjectOverlay.factory));;
+    private MapOverlay<ExampleImpl> examples = registerField("examples", "examples", "[a-zA-Z0-9\\._-]+", new MapOverlay<ExampleImpl>("examples", this, ExampleImpl.factory, "[a-zA-Z0-9\\._-]+"));
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     private MapOverlay<MediaTypeImpl> contentMediaTypes = registerField("content", "contentMediaTypes", null, new MapOverlay<MediaTypeImpl>("content", this, MediaTypeImpl.factory, null));
@@ -249,44 +249,40 @@ public class ParameterImpl extends OpenApiObjectImpl implements Parameter {
     // Example
     @Override
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public Collection<Object> getExamples() {
+    public Map<String, ? extends Example> getExamples() {
         return examples.get();
     }
 
     @Override
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public boolean hasExamples() {
-        return !examples.isMissing();
+    public boolean hasExample(String name) {
+        return examples.containsKey(name);
     }
 
     @Override
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public Object getExample(int index) {
-        return examples.get(index);
+    public Example getExample(String name) {
+        return examples.get(name);
     }
 
     @Override
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void setExamples(Collection<Object> examples) {
-        this.examples.set((Collection<Object>) examples);
+    public void setExamples(Map<String, ? extends Example> examples) {
+        @SuppressWarnings("unchecked")
+            Map<String,ExampleImpl> implExamples = (Map<String, ExampleImpl>) examples;
+            this.examples.set(implExamples);
     }
 
     @Override
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void setExample(int index, Object example) {
-        examples.set(index, example);
+    public void setExample(String name, Example example) {
+        examples.set(name, (ExampleImpl) example);
     }
 
     @Override
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void addExample(Object example) {
-        examples.add(example);
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void removeExample(int index) {
-        examples.remove(index);
+    public void removeExample(String name) {
+        examples.remove(name);
     }
 
     // ContentMediaType

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/SchemaImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/SchemaImpl.java
@@ -13,9 +13,11 @@ import com.reprezen.kaizen.oasparser.jsonoverlay.std.BooleanOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.std.IntegerOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.std.NumberOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.std.StringOverlay;
+import com.reprezen.kaizen.oasparser.model3.Example;
 import com.reprezen.kaizen.oasparser.model3.ExternalDocs;
 import com.reprezen.kaizen.oasparser.model3.Schema;
 import com.reprezen.kaizen.oasparser.model3.Xml;
+import com.reprezen.kaizen.oasparser.ovl3.ExampleImpl;
 import com.reprezen.kaizen.oasparser.ovl3.ExternalDocsImpl;
 import com.reprezen.kaizen.oasparser.ovl3.OpenApiObjectImpl;
 import com.reprezen.kaizen.oasparser.ovl3.SchemaImpl;
@@ -154,7 +156,7 @@ public class SchemaImpl extends OpenApiObjectImpl implements Schema {
     private ExternalDocsImpl externalDocs = registerField("externalDocs", "externalDocs", null, ExternalDocsImpl.factory.create("externalDocs", this));
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private ValListOverlay<Object, AnyObjectOverlay> examples = registerField("examples", "examples", null, new ValListOverlay<Object, AnyObjectOverlay>("examples", this, AnyObjectOverlay.factory));;
+    private MapOverlay<ExampleImpl> examples = registerField("examples", "examples", "[a-zA-Z0-9\\._-]+", new MapOverlay<ExampleImpl>("examples", this, ExampleImpl.factory, "[a-zA-Z0-9\\._-]+"));
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     private AnyObjectOverlay example = registerField("example", "example", null, new AnyObjectOverlay("example", this));
@@ -834,44 +836,40 @@ public class SchemaImpl extends OpenApiObjectImpl implements Schema {
     // Example
     @Override
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public Collection<Object> getExamples() {
+    public Map<String, ? extends Example> getExamples() {
         return examples.get();
     }
 
     @Override
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public boolean hasExamples() {
-        return !examples.isMissing();
+    public boolean hasExample(String name) {
+        return examples.containsKey(name);
     }
 
     @Override
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public Object getExample(int index) {
-        return examples.get(index);
+    public Example getExample(String name) {
+        return examples.get(name);
     }
 
     @Override
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void setExamples(Collection<Object> examples) {
-        this.examples.set((Collection<Object>) examples);
+    public void setExamples(Map<String, ? extends Example> examples) {
+        @SuppressWarnings("unchecked")
+            Map<String,ExampleImpl> implExamples = (Map<String, ExampleImpl>) examples;
+            this.examples.set(implExamples);
     }
 
     @Override
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void setExample(int index, Object example) {
-        examples.set(index, example);
+    public void setExample(String name, Example example) {
+        examples.set(name, (ExampleImpl) example);
     }
 
     @Override
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void addExample(Object example) {
-        examples.add(example);
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void removeExample(int index) {
-        examples.remove(index);
+    public void removeExample(String name) {
+        examples.remove(name);
     }
 
     // Example

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/types3.yaml
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/types3.yaml
@@ -54,7 +54,7 @@ types:
         keyPattern: *namePat
       components/examples:
         name: Example
-        type: Object
+        type: Example
         structure: map
         keyPattern: *namePat
       components/requestBodies:
@@ -438,8 +438,9 @@ types:
         name: Schema
       examples:
         name: Example
-        type: Object
-        structure: collection
+        type: Example
+        structure: map
+        keyPattern: *namePat
       example:
         name: Example
         type: Object
@@ -513,8 +514,9 @@ types:
         type: Object
       examples:
         name: Example
-        type: Object
-        structure: collection
+        type: Example
+        structure: map
+        keyPattern: *namePat
       content:
         name: ContentMediaType
         type: MediaType
@@ -637,8 +639,9 @@ types:
         name: ExternalDocs
       examples:
         name: Example
-        type: Object
-        structure: collection
+        type: Example
+        structure: map
+        keyPattern: *namePat
       example:
         name: Example
         type: Object
@@ -664,4 +667,20 @@ types:
       wrapped:
         name: Wrapped
         type: Boolean        
+      *extName: *extDef
+  
+  - name: Example
+    fields:
+      summary:
+        name: Summary
+        type: String
+      description:
+        name: Description
+        type: String
+      value:
+        name: Value
+        type: Object        
+      externalValue:
+        name: ExternalValue
+        type: String
       *extName: *extDef

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/ExampleValidator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/ExampleValidator.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ *  Copyright (c) 2017 ModelSolv, Inc. and others.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  Contributors:
+ *     ModelSolv, Inc. - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package com.reprezen.kaizen.oasparser.val3;
+
+import com.reprezen.kaizen.oasparser.model3.Example;
+import com.reprezen.kaizen.oasparser.val.ObjectValidatorBase;
+import com.reprezen.kaizen.oasparser.val.ValidationResults;
+
+public class ExampleValidator extends ObjectValidatorBase<Example> {
+
+    @Override
+    public void validateObject(Example object, ValidationResults results) {
+        // TODO Auto-generated method stub
+    }
+
+}

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/MediaTypeValidator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/MediaTypeValidator.java
@@ -16,6 +16,7 @@ import java.util.Set;
 
 import com.google.inject.Inject;
 import com.reprezen.kaizen.oasparser.model3.EncodingProperty;
+import com.reprezen.kaizen.oasparser.model3.Example;
 import com.reprezen.kaizen.oasparser.model3.MediaType;
 import com.reprezen.kaizen.oasparser.model3.Schema;
 import com.reprezen.kaizen.oasparser.val.ObjectValidatorBase;
@@ -28,6 +29,8 @@ public class MediaTypeValidator extends ObjectValidatorBase<MediaType> {
     private Validator<Schema> schemaValidator;
     @Inject
     private Validator<EncodingProperty> encodingPropertyValidator;
+    @Inject
+    private Validator<Example> exampleValidator;
 
     @Override
     public void validateObject(MediaType mediaType, ValidationResults results) {
@@ -38,6 +41,7 @@ public class MediaTypeValidator extends ObjectValidatorBase<MediaType> {
                 encodingPropertyValidator);
         checkEncodingPropsAreProps(mediaType, results);
         validateExtensions(mediaType.getExtensions(), results);
+        validateMap(mediaType.getExamples(), results, false, "examples", Regexes.NOEXT_NAME_REGEX, exampleValidator);
     }
 
     void checkEncodingPropsAreProps(MediaType mediaType, ValidationResults results) {

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/OpenApi3Validator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/OpenApi3Validator.java
@@ -80,7 +80,7 @@ public class OpenApi3Validator extends ObjectValidatorBase<OpenApi3> {
                         responseValidator);
                 validateMap(swagger.getParameters(), results, false, "collections/parameters", NAME_REGEX,
                         parameterValidator);
-                // validateMap(swagger.getExamples(), results, false, "collections/examples", NAME_REGEX, null);
+                validateMap(swagger.getExamples(), results, false, "collections/examples", NAME_REGEX, null);
                 validateMap(swagger.getRequestBodies(), results, false, "collection/requestBodies", NAME_REGEX,
                         requestBodyValidator);
                 validateMap(swagger.getHeaders(), results, false, "collections/headers", NAME_REGEX, headerValidator);

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/OpenApi3Validator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/OpenApi3Validator.java
@@ -20,6 +20,7 @@ import com.reprezen.kaizen.oasparser.model3.ExternalDocs;
 import com.reprezen.kaizen.oasparser.model3.Header;
 import com.reprezen.kaizen.oasparser.model3.Info;
 import com.reprezen.kaizen.oasparser.model3.Link;
+import com.reprezen.kaizen.oasparser.model3.OpenApi3;
 import com.reprezen.kaizen.oasparser.model3.Parameter;
 import com.reprezen.kaizen.oasparser.model3.Path;
 import com.reprezen.kaizen.oasparser.model3.RequestBody;
@@ -28,7 +29,6 @@ import com.reprezen.kaizen.oasparser.model3.Schema;
 import com.reprezen.kaizen.oasparser.model3.SecurityRequirement;
 import com.reprezen.kaizen.oasparser.model3.SecurityScheme;
 import com.reprezen.kaizen.oasparser.model3.Server;
-import com.reprezen.kaizen.oasparser.model3.OpenApi3;
 import com.reprezen.kaizen.oasparser.model3.Tag;
 import com.reprezen.kaizen.oasparser.val.ObjectValidatorBase;
 import com.reprezen.kaizen.oasparser.val.ValidationResults;
@@ -80,7 +80,7 @@ public class OpenApi3Validator extends ObjectValidatorBase<OpenApi3> {
                         responseValidator);
                 validateMap(swagger.getParameters(), results, false, "collections/parameters", NAME_REGEX,
                         parameterValidator);
-                validateMap(swagger.getExamples(), results, false, "collections/examples", NAME_REGEX, null);
+                // validateMap(swagger.getExamples(), results, false, "collections/examples", NAME_REGEX, null);
                 validateMap(swagger.getRequestBodies(), results, false, "collection/requestBodies", NAME_REGEX,
                         requestBodyValidator);
                 validateMap(swagger.getHeaders(), results, false, "collections/headers", NAME_REGEX, headerValidator);

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/SchemaValidator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/SchemaValidator.java
@@ -60,7 +60,7 @@ public class SchemaValidator extends ObjectValidatorBase<Schema> {
         checkReadWrite(schema, results);
         validateField(schema.getXml(), results, false, "xml", xmlValidator);
         validateField(schema.getExternalDocs(), results, false, "externalDocs", externalDocsValidator);
-        validateList(schema.getExamples(), schema.hasExamples(), results, false, "examples", null);
+        // validateList(schema.getExamples(), schema.hasExamples(), results, false, "examples", null);
         validateExtensions(schema.getExtensions(), results);
     }
 

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/SchemaValidator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/SchemaValidator.java
@@ -13,6 +13,7 @@ package com.reprezen.kaizen.oasparser.val3;
 import static com.reprezen.kaizen.oasparser.val.Messages.m;
 
 import com.google.inject.Inject;
+import com.reprezen.kaizen.oasparser.model3.Example;
 import com.reprezen.kaizen.oasparser.model3.ExternalDocs;
 import com.reprezen.kaizen.oasparser.model3.Schema;
 import com.reprezen.kaizen.oasparser.model3.Xml;
@@ -26,6 +27,8 @@ public class SchemaValidator extends ObjectValidatorBase<Schema> {
     private Validator<Xml> xmlValidator;
     @Inject
     private Validator<ExternalDocs> externalDocsValidator;
+    @Inject
+    private Validator<Example> exampleValidator;
 
     @Override
     public void validateObject(Schema schema, ValidationResults results) {
@@ -60,7 +63,7 @@ public class SchemaValidator extends ObjectValidatorBase<Schema> {
         checkReadWrite(schema, results);
         validateField(schema.getXml(), results, false, "xml", xmlValidator);
         validateField(schema.getExternalDocs(), results, false, "externalDocs", externalDocsValidator);
-        // validateList(schema.getExamples(), schema.hasExamples(), results, false, "examples", null);
+        validateMap(schema.getExamples(), results, false, "examples", Regexes.NOEXT_NAME_REGEX, exampleValidator);
         validateExtensions(schema.getExtensions(), results);
     }
 

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/ValidationConfigurator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/ValidationConfigurator.java
@@ -15,6 +15,7 @@ import com.google.inject.TypeLiteral;
 import com.reprezen.kaizen.oasparser.model3.Callback;
 import com.reprezen.kaizen.oasparser.model3.Contact;
 import com.reprezen.kaizen.oasparser.model3.EncodingProperty;
+import com.reprezen.kaizen.oasparser.model3.Example;
 import com.reprezen.kaizen.oasparser.model3.ExternalDocs;
 import com.reprezen.kaizen.oasparser.model3.Header;
 import com.reprezen.kaizen.oasparser.model3.Info;
@@ -22,6 +23,7 @@ import com.reprezen.kaizen.oasparser.model3.License;
 import com.reprezen.kaizen.oasparser.model3.Link;
 import com.reprezen.kaizen.oasparser.model3.MediaType;
 import com.reprezen.kaizen.oasparser.model3.OAuthFlow;
+import com.reprezen.kaizen.oasparser.model3.OpenApi3;
 import com.reprezen.kaizen.oasparser.model3.Operation;
 import com.reprezen.kaizen.oasparser.model3.Parameter;
 import com.reprezen.kaizen.oasparser.model3.Path;
@@ -32,7 +34,6 @@ import com.reprezen.kaizen.oasparser.model3.SecurityRequirement;
 import com.reprezen.kaizen.oasparser.model3.SecurityScheme;
 import com.reprezen.kaizen.oasparser.model3.Server;
 import com.reprezen.kaizen.oasparser.model3.ServerVariable;
-import com.reprezen.kaizen.oasparser.model3.OpenApi3;
 import com.reprezen.kaizen.oasparser.model3.Tag;
 import com.reprezen.kaizen.oasparser.model3.Xml;
 import com.reprezen.kaizen.oasparser.val.Validator;
@@ -47,6 +48,8 @@ public abstract class ValidationConfigurator extends AbstractModule {
         }).to(ContactValidator.class);
         bind(new TypeLiteral<Validator<EncodingProperty>>() {
         }).to(EncodingPropertyValidator.class);
+        bind(new TypeLiteral<Validator<Example>>() {
+        }).to(ExampleValidator.class);
         bind(new TypeLiteral<Validator<ExternalDocs>>() {
         }).to(ExternalDocsValidator.class);
         bind(new TypeLiteral<Validator<Header>>() {

--- a/kaizen-openapi-parser/src/test/java/com/reprezen/swaggerparser/test/ExampleTest.java
+++ b/kaizen-openapi-parser/src/test/java/com/reprezen/swaggerparser/test/ExampleTest.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ *  Copyright (c) 2017 ModelSolv, Inc. and others.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  Contributors:
+ *     ModelSolv, Inc. - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package com.reprezen.swaggerparser.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Map;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.io.Resources;
+import com.reprezen.kaizen.oasparser.OpenApiParser;
+import com.reprezen.kaizen.oasparser.model3.Example;
+import com.reprezen.kaizen.oasparser.model3.OpenApi3;
+
+public class ExampleTest {
+
+    private static OpenApi3 model;
+    private Map<String, Object> exampleFixture = ImmutableMap.<String, Object> of( //
+            "foo", "bar", //
+            "person", ImmutableMap.<String, Object> of( //
+                    "name", "Paul"));
+
+    @BeforeClass
+    public static void beforeClass() {
+        model = (OpenApi3) new OpenApiParser().parse(Resources.getResource("models/examplesTest.yaml"), false);
+    }
+
+    @Test
+    public void testExample() {
+        Object example = model.getPath("/v2") //
+                .getOperation("get") //
+                .getResponse("203") //
+                .getContentMediaType("application/json") //
+                .getExample();
+
+        assertEquals(exampleFixture, example);
+    }
+
+    @Test
+    public void testExamples() {
+        Map<String, ? extends Example> examples = model.getPath("/v2") //
+                .getOperation("get") //
+                .getResponse("200") //
+                .getContentMediaType("application/json") //
+                .getExamples();
+
+        assertEquals(1, examples.size());
+        assertTrue(examples.containsKey("foo"));
+
+        Example example = examples.get("foo");
+
+        assertEquals(exampleFixture, example.getValue());
+        assertEquals("First Example", example.getSummary());
+        assertEquals("An Example", example.getDescription());
+    }
+}

--- a/kaizen-openapi-parser/src/test/java/com/reprezen/swaggerparser/test/ExampleTest.java
+++ b/kaizen-openapi-parser/src/test/java/com/reprezen/swaggerparser/test/ExampleTest.java
@@ -34,7 +34,7 @@ public class ExampleTest {
 
     @BeforeClass
     public static void beforeClass() {
-        model = (OpenApi3) new OpenApiParser().parse(Resources.getResource("models/examplesTest.yaml"), false);
+        model = (OpenApi3) new OpenApiParser().parse(Resources.getResource("models/examplesTest.yaml"), true);
     }
 
     @Test
@@ -65,4 +65,10 @@ public class ExampleTest {
         assertEquals("First Example", example.getSummary());
         assertEquals("An Example", example.getDescription());
     }
+
+    @Test
+    public void testValidate() {
+        assertTrue(model.isValid());
+    }
+
 }

--- a/kaizen-openapi-parser/src/test/resources/models/examplesTest.yaml
+++ b/kaizen-openapi-parser/src/test/resources/models/examplesTest.yaml
@@ -1,0 +1,36 @@
+openapi: "3.0.0"
+info:
+  title: Simple API overview
+  version: v2
+paths:  
+  /v2:
+    get:
+      operationId: getVersionDetailsv2
+      summary: Show API version details
+      responses:
+        200:
+          description: |-
+            200 response
+          content:
+            application/json: 
+              examples:
+                foo:
+                  summary: First Example
+                  description: An Example
+                  value: {
+                    "foo": "bar",
+                    "person": {
+                      "name": "Paul"                      
+                    }
+                  }
+        203:
+          description: |-
+            203 response
+          content:
+            application/json: 
+              example: {
+                "foo": "bar",
+                "person": {
+                  "name": "Paul"                      
+                }
+              }

--- a/kaizen-openapi-parser/src/test/resources/models/parseTest.yaml
+++ b/kaizen-openapi-parser/src/test/resources/models/parseTest.yaml
@@ -63,18 +63,24 @@ paths:
         explode: true
         allowReserved: true
         examples:
-        - example
-        - 10
-        - 5.5
+          first: 
+            value: example
+          second:
+            value: 10
+          third: 
+            value: 5.5
         example: example
         content:
           application/json:
             schema:
               title: title
             examples:
-            - x
-            - y
-            - z
+              x:
+                value: x
+              y:
+                value: y
+              z:
+                value: z
             example: 10
             encoding:
               fooEncoding:
@@ -223,10 +229,14 @@ components:
         url: url
       example: xxx
       examples:
-        - 1.0
-        - true
-        - null
-        - xyzzy
+        first:
+          value: 1.0
+        second:
+          value: true
+        third:
+          value: null
+        fourth:
+          value: xyzzy
       deprecated: true
       x-foo: foo
     schema2:
@@ -246,8 +256,10 @@ components:
       name: name
       in: in
   examples:
-    example1: null
-    example2: xyzzy
+    example1: 
+      value: null
+    example2: 
+      value: xyzzy
   requestBodies: 
     reqBody1:
       description: description


### PR DESCRIPTION
See #59 

This PR adds support for the latest specification of Example Object. I mark it as do not merge because some code has still to be validated in the validator.

Example externalValues are currently modeled as simple Strings, maybe they should be handle differently, maybe being resolvable Maps but I haven't find yet how to implement that.