### PR TITLE
Fix ExamplesTest

### DIFF
--- a/kaizen-openapi-parser/src/test/java/com/reprezen/swaggerparser/test/ExamplesTest.java
+++ b/kaizen-openapi-parser/src/test/java/com/reprezen/swaggerparser/test/ExamplesTest.java
@@ -36,15 +36,15 @@ import com.reprezen.kaizen.oasparser.val.ValidationResults.ValidationItem;
 @RunWith(Parameterized.class)
 public class ExamplesTest extends Assert {
 
-    private static final String SPEC_REPO = "OAI/OpenAPI-Specification";
-    private static final String EXAMPLES_BRANCH = "OpenAPI.next";
-    private static final String EXAMPLES_ROOT = "examples/v3.0";
+    private static final String SPEC_REPO = "RepreZen/KaiZen-OpenAPI-Editor";
+    private static final String EXAMPLES_BRANCH = "master";
+    private static final String EXAMPLES_ROOT = "com.reprezen.swagedit.openapi3.tests/resources/spec_examples/v3.0";
 
     private static ObjectMapper mapper = new ObjectMapper();
 
-    @Parameters
-    public static Collection<URL> findExamples() throws IOException {
-        Collection<URL> examples = Lists.newArrayList();
+    @Parameters(name = "{index}: {1}")
+    public static Collection<Object[]> findExamples() throws IOException {
+        Collection<Object[]> examples = Lists.newArrayList();
         Deque<URL> dirs = Queues.newArrayDeque();
         String auth = System.getenv("GITHUB_AUTH") != null ? System.getenv("GITHUB_AUTH") + "@" : "";
         String request = String.format("https://%sapi.github.com/repos/%s/contents/%s?ref=%s", auth, SPEC_REPO,
@@ -62,7 +62,7 @@ public class ExamplesTest extends Assert {
                     dirs.add(new URL(resultUrl));
                 } else if (type.equals("file") && (path.endsWith(".yaml") || path.endsWith(".json"))) {
                     String downloadUrl = result.get("download_url").asText();
-                    examples.add(new URL(downloadUrl));
+                    examples.add(new Object[]{new URL(downloadUrl), result.get("name").asText()});
                 }
             }
         }
@@ -71,6 +71,9 @@ public class ExamplesTest extends Assert {
 
     @Parameter
     public URL exampleUrl;
+    
+    @Parameter(1)
+    public String fileName;
 
     @Test
     public void exampleCanBeParsed() throws IOException {


### PR DESCRIPTION
1. Use our _prêt à utiliser_ examples instead of the OAS3 examples. The official examples aren't always valid and some of them will be intentionally "omitted for brevity" (== invalid from the parser's perspective), see https://github.com/OAI/OpenAPI-Specification/pull/1228#issuecomment-312316783
2. Fix test names. Now file names are shown in test case names instead of just index:
<img width="433" alt="screen shot 2017-07-25 at 4 06 10 pm" src="https://user-images.githubusercontent.com/644582/28591544-1f484ed2-7154-11e7-981f-620ff2ddbc34.png">
