### PR TITLE
#55 OpenApi3 validation should allow root paths (/)

### DIFF
--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/Regexes.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/Regexes.java
@@ -14,7 +14,7 @@ import java.util.regex.Pattern;
 
 public class Regexes {
 
-    public static final Pattern PATH_REGEX = Pattern.compile("/.+");
+    public static final Pattern PATH_REGEX = Pattern.compile("/.*");
     public static final Pattern EXT_REGEX = Pattern.compile("x-.+");
     public static final Pattern NOEXT_REGEX = Pattern.compile("(?!x-).*");
     public static final Pattern NAME_REGEX = Pattern.compile("[a-zA-Z0-9\\._-]+");


### PR DESCRIPTION
PR #56 fixed the parser, but the validation was still creating an error for the `/` path items. This PR fixes the validator.