### PR TITLE
ZEN-3606: Eliminate static reference caches

### DIFF
--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/OpenApiParser.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/OpenApiParser.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.reprezen.kaizen.oasparser.jsonoverlay.JsonLoader;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ReferenceRegistry;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ResolutionBase;
 import com.reprezen.kaizen.oasparser.jsonoverlay.Resolver;
 import com.reprezen.kaizen.oasparser.ovl3.OpenApi3Impl;
@@ -83,10 +84,11 @@ public class OpenApiParser {
 
     public OpenApi parse(URL resolutionBase, boolean validate) {
         try {
-            Resolver.preresolve(resolutionBase);
+            final ReferenceRegistry referenceRegistry = new ReferenceRegistry();
+            new Resolver(referenceRegistry).preresolve(resolutionBase);
             JsonNode tree = ResolutionBase.get(resolutionBase.toString()).getJson();
             if (isVersion3(tree)) {
-                OpenApi3Impl model = new OpenApi3Impl(null, tree, null);
+                OpenApi3Impl model = new OpenApi3Impl(null, tree, null, referenceRegistry);
                 injector.injectMembers(model);
                 if (validate) {
                     model.validate();

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/OpenApiParser.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/OpenApiParser.java
@@ -21,7 +21,7 @@ import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.reprezen.kaizen.oasparser.jsonoverlay.JsonLoader;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ReferenceRegistry;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ResolutionBase;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ResolutionBaseRegistry;
 import com.reprezen.kaizen.oasparser.jsonoverlay.Resolver;
 import com.reprezen.kaizen.oasparser.ovl3.OpenApi3Impl;
 import com.reprezen.kaizen.oasparser.val3.ValidationConfigurator;
@@ -46,8 +46,10 @@ public class OpenApiParser {
 
     public OpenApi parse(String spec, URL resolutionBase, boolean validate) {
         try {
-            JsonNode tree = JsonLoader.loadString(resolutionBase, spec);
-            ResolutionBase.register(resolutionBase.toString(), tree);
+            JsonLoader jsonLoader = new JsonLoader();
+            JsonNode tree = jsonLoader.loadString(resolutionBase, spec);
+            ResolutionBaseRegistry resolutionBaseRegistry = new ResolutionBaseRegistry(jsonLoader);
+            resolutionBaseRegistry.register(resolutionBase.toString(), tree);
             return parse(resolutionBase, validate);
         } catch (IOException e) {
             throw new SwaggerParserException("Failed to parse spec as JSON or YAML", e);
@@ -85,8 +87,10 @@ public class OpenApiParser {
     public OpenApi parse(URL resolutionBase, boolean validate) {
         try {
             final ReferenceRegistry referenceRegistry = new ReferenceRegistry();
-            new Resolver(referenceRegistry).preresolve(resolutionBase);
-            JsonNode tree = ResolutionBase.get(resolutionBase.toString()).getJson();
+            JsonLoader jsonLoader = new JsonLoader();
+            ResolutionBaseRegistry resolutionBaseRegistry = new ResolutionBaseRegistry(jsonLoader);
+            new Resolver(referenceRegistry, resolutionBaseRegistry).preresolve(resolutionBase);
+            JsonNode tree = resolutionBaseRegistry.get(resolutionBase.toString()).getJson();
             if (isVersion3(tree)) {
                 OpenApi3Impl model = new OpenApi3Impl(null, tree, null, referenceRegistry);
                 injector.injectMembers(model);

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/OpenApiParser.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/OpenApiParser.java
@@ -50,7 +50,7 @@ public class OpenApiParser {
             JsonNode tree = jsonLoader.loadString(resolutionBase, spec);
             ResolutionBaseRegistry resolutionBaseRegistry = new ResolutionBaseRegistry(jsonLoader);
             resolutionBaseRegistry.register(resolutionBase.toString(), tree);
-            return parse(resolutionBase, validate);
+            return parse(resolutionBase, validate, resolutionBaseRegistry);
         } catch (IOException e) {
             throw new SwaggerParserException("Failed to parse spec as JSON or YAML", e);
         }
@@ -85,10 +85,12 @@ public class OpenApiParser {
     }
 
     public OpenApi parse(URL resolutionBase, boolean validate) {
+        return parse(resolutionBase, validate, new ResolutionBaseRegistry(new JsonLoader()));
+    }
+    
+    protected OpenApi parse(URL resolutionBase, boolean validate, ResolutionBaseRegistry resolutionBaseRegistry) {
         try {
-            final ReferenceRegistry referenceRegistry = new ReferenceRegistry();
-            JsonLoader jsonLoader = new JsonLoader();
-            ResolutionBaseRegistry resolutionBaseRegistry = new ResolutionBaseRegistry(jsonLoader);
+            ReferenceRegistry referenceRegistry = new ReferenceRegistry();
             new Resolver(referenceRegistry, resolutionBaseRegistry).preresolve(resolutionBase);
             JsonNode tree = resolutionBaseRegistry.get(resolutionBase.toString()).getJson();
             if (isVersion3(tree)) {

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/JsonLoader.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/JsonLoader.java
@@ -28,14 +28,14 @@ public class JsonLoader {
 
     private static ObjectMapper jsonMapper = new ObjectMapper();
     private static YAMLMapper yamlMapper = new YAMLMapper();
-    private static Yaml yaml = new Yaml();
+    private Yaml yaml = new Yaml();
 
-    private static Map<String, JsonNode> cache = Maps.newHashMap();
+    private Map<String, JsonNode> cache = Maps.newHashMap();
 
-    private JsonLoader() {
+    public JsonLoader() {
     }
 
-    public static JsonNode load(URL url) throws IOException {
+    public JsonNode load(URL url) throws IOException {
         String urlString = url.toString();
         if (cache.containsKey(urlString)) {
             return cache.get(urlString);
@@ -44,7 +44,7 @@ public class JsonLoader {
         return loadString(url, json);
     }
 
-    public static JsonNode loadString(URL url, String json) throws IOException, JsonProcessingException {
+    public JsonNode loadString(URL url, String json) throws IOException, JsonProcessingException {
         String trimmed = json.trim();
         JsonNode tree;
         if (trimmed.startsWith("{")) {

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/Reference.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/Reference.java
@@ -12,16 +12,12 @@ package com.reprezen.kaizen.oasparser.jsonoverlay;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
-import java.util.Map;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.MissingNode;
 import com.google.common.base.Charsets;
-import com.google.common.collect.Maps;
 
 public class Reference {
-
-    private Map<String, Reference> references = Maps.newHashMap();
 
     private String refString;
     private ResolutionBase base;
@@ -31,8 +27,11 @@ public class Reference {
     private ResolutionException error;
     private String key;
 
+    private final ResolutionBaseRegistry resolutionBaseRegistry;
+
     /*package*/ Reference(String refString, ResolutionBase base) {
         this.refString = refString;
+        resolutionBaseRegistry = base.getResolutionBaseRegistry();
         int pos = refString.indexOf('#');
         String relUrl = pos < 0 ? refString : refString.substring(0, pos);
         if (relUrl.isEmpty()) {
@@ -40,7 +39,7 @@ public class Reference {
         } else {
             // note re false: if creating a ref with resolution requested, the base will be resolved as a side-effect
             // during ref resolution, so no need to do it now.
-            this.base = ResolutionBase.of(base.comprehend(relUrl), false);
+            this.base = resolutionBaseRegistry.of(base.comprehend(relUrl), false);
         }
         if (pos >= 0) {
             this.fragment = refString.substring(pos);
@@ -58,6 +57,7 @@ public class Reference {
 
     /*package*/ Reference(String refString, ResolutionBase base, ResolutionException e) {
         this.refString = refString;
+        resolutionBaseRegistry = base.getResolutionBaseRegistry();
         this.fragment = null;
         this.base = base;
         this.isValid = false;

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/ReferenceRegistry.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/ReferenceRegistry.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ *  Copyright (c) 2017 ModelSolv, Inc. and others.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  Contributors:
+ *     ModelSolv, Inc. - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package com.reprezen.kaizen.oasparser.jsonoverlay;
+
+import java.util.Collection;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.Maps;
+
+public class ReferenceRegistry {
+
+    private Map<String, Reference> references = Maps.newHashMap();
+
+    public Collection<Reference> getAllReferences() {
+        return references.values();
+    }
+
+    public String register(JsonNode refStringNode, ResolutionBase base, boolean resolve) {
+        return get(refStringNode, base, resolve).getKey();
+    }
+
+    public String register(String refString, ResolutionBase base, boolean resolve) {
+        return get(refString, base, resolve).getKey();
+    }
+
+    public Reference get(String key) {
+        return references.get(key);
+    }
+
+    public Reference get(JsonNode refNode) {
+        if (refNode.isObject() && refNode.has("$ref") && refNode.has("key")) {
+            return get(refNode.get("key").textValue());
+        } else {
+            return null;
+        }
+    }
+
+    public Reference get(JsonNode refStringNode, ResolutionBase base, boolean resolve) {
+        if (refStringNode.isTextual()) {
+            return get(refStringNode.textValue(), base, resolve);
+        } else {
+            String badRefString = refStringNode.toString();
+            Reference ref = new Reference(badRefString, base,
+                    new ResolutionException("Non-text $ref property value in JSON reference node"));
+            String key = ref.getKey();
+            if (!references.containsKey(key)) {
+                references.put(key, ref);
+            }
+            return references.get(key);
+        }
+    }
+
+    public Reference get(String refString, ResolutionBase base, boolean resolve) {
+        try {
+            if (base.isInvalid()) {
+                throw new ResolutionException("Invalid base for reference resolution", base.getError());
+            }
+            String comprehendedRef = base.comprehend(refString);
+            if (!references.containsKey(comprehendedRef)) {
+                references.put(comprehendedRef, new Reference(comprehendedRef, base));
+            }
+            Reference ref = references.get(comprehendedRef);
+            if (resolve) {
+                ref.resolve();
+            }
+            return ref;
+        } catch (ResolutionException e) {
+            Reference ref = new Reference(refString, base, e);
+            references.put(refString, ref);
+            return ref;
+        }
+    }
+
+}

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/ResolutionBase.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/ResolutionBase.java
@@ -12,111 +12,36 @@ package com.reprezen.kaizen.oasparser.jsonoverlay;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.net.URL;
-import java.util.Collection;
-import java.util.Map;
-import java.util.Set;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 
 public class ResolutionBase {
-
-    private static Map<String, ResolutionBase> instances = Maps.newConcurrentMap();
 
     private String urlString;
     private Boolean isValid = null;
     private ResolutionException error = null;
     private JsonNode json = null;
-
-    private ResolutionBase(String urlString) {
+    private final ResolutionBaseRegistry resolutionBaseRegistry;
+    
+    /*package*/ ResolutionBase(String urlString, ResolutionBaseRegistry resolutionBaseRegistry) {
         this.urlString = urlString;
         this.isValid = null;
+        this.resolutionBaseRegistry = resolutionBaseRegistry;
     }
 
-    private ResolutionBase(String urlString, ResolutionException e) {
+    /*package*/ ResolutionBase(String urlString, ResolutionException e, ResolutionBaseRegistry resolutionBaseRegistry) {
         this.urlString = urlString;
         this.isValid = false;
         this.error = e;
+        this.resolutionBaseRegistry = resolutionBaseRegistry;
     }
 
-    private ResolutionBase(String urlString, JsonNode json) {
+    /*package*/ ResolutionBase(String urlString, JsonNode json, ResolutionBaseRegistry resolutionBaseRegistry) {
         this.urlString = urlString;
         this.json = json;
         this.isValid = true;
-    }
-
-    public static ResolutionBase of(URL baseUrl, boolean resolve) {
-        return of(baseUrl, baseUrl.toString(), resolve);
-    }
-
-    public static Collection<ResolutionBase> getAllBases() {
-        Set<ResolutionBase> allBases = Sets.newHashSet(); // cull duplicates caused by aliased entries
-        allBases.addAll(instances.values());
-        return allBases;
-    }
-
-    public static ResolutionBase get(String urlString) {
-        return instances.get(urlString);
-    }
-
-    public static ResolutionBase of(String rawUrlString, boolean resolve) {
-        URL url;
-        try {
-            url = new URL(rawUrlString);
-            return of(url, rawUrlString, resolve);
-        } catch (MalformedURLException e) {
-            return new ResolutionBase(rawUrlString, new ResolutionException("Invalid URL: " + rawUrlString, e));
-        }
-    }
-
-    public static ResolutionBase register(String urlString, JsonNode json) {
-        ResolutionBase base = new ResolutionBase(urlString, json);
-        instances.put(urlString, base);
-        return base;
-    }
-
-    private static ResolutionBase of(URL baseUrl, String rawUrlString, boolean resolve) {
-        if (instances.containsKey(rawUrlString)) {
-            return instances.get(rawUrlString);
-        }
-        try {
-            String urlString = normalizeUrlString(baseUrl);
-            ResolutionBase base;
-            if (instances.containsKey(urlString)) {
-                base = instances.get(urlString);
-                instances.put(rawUrlString, base);
-            } else {
-                base = new ResolutionBase(urlString);
-                instances.put(urlString, base);
-                instances.put(baseUrl.toString(), base);
-            }
-            if (resolve && !base.isResolved()) {
-                base.resolve();
-            }
-            return base;
-        } catch (ResolutionException e) {
-            if (!instances.containsKey(rawUrlString)) {
-                instances.put(rawUrlString, new ResolutionBase(rawUrlString, e));
-            }
-            return instances.get(rawUrlString);
-        }
-    }
-
-    private static String normalizeUrlString(URL url) {
-        String urlString = url.toString();
-        if (urlString.contains("#")) {
-            urlString = urlString.substring(0, urlString.indexOf('#'));
-        }
-        try {
-            URI uri = new URI(urlString).normalize();
-            return uri.toString();
-        } catch (URISyntaxException e) {
-            throw new ResolutionException("Invalid document URI", e);
-        }
+        this.resolutionBaseRegistry = resolutionBaseRegistry;
     }
 
     public JsonNode getJson() {
@@ -150,7 +75,7 @@ public class ResolutionBase {
     public JsonNode resolve() {
         if (isValid == null) {
             try {
-                json = JsonLoader.load(new URL(urlString));
+                json = resolutionBaseRegistry.getJsonLoader().load(new URL(urlString));
                 isValid = true;
             } catch (IOException e) {
                 isValid = false;
@@ -179,5 +104,9 @@ public class ResolutionBase {
                             basedUrlString + fragment, urlString),
                     e);
         }
+    }
+    
+    public ResolutionBaseRegistry getResolutionBaseRegistry() {
+        return resolutionBaseRegistry;
     }
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/ResolutionBaseRegistry.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/ResolutionBaseRegistry.java
@@ -1,0 +1,109 @@
+/*******************************************************************************
+ *  Copyright (c) 2017 ModelSolv, Inc. and others.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  Contributors:
+ *     ModelSolv, Inc. - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package com.reprezen.kaizen.oasparser.jsonoverlay;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+
+public class ResolutionBaseRegistry {
+
+    private Map<String, ResolutionBase> instances = Maps.newConcurrentMap();
+    private final JsonLoader jsonLoader;
+    
+    public ResolutionBaseRegistry(JsonLoader jsonLoader) {
+        this.jsonLoader = jsonLoader;
+    }
+    
+    public ResolutionBase of(URL baseUrl, boolean resolve) {
+        return of(baseUrl, baseUrl.toString(), resolve);
+    }
+
+    public Collection<ResolutionBase> getAllBases() {
+        Set<ResolutionBase> allBases = Sets.newHashSet(); // cull duplicates caused by aliased entries
+        allBases.addAll(instances.values());
+        return allBases;
+    }
+
+    public ResolutionBase get(String urlString) {
+        return instances.get(urlString);
+    }
+
+    public ResolutionBase of(String rawUrlString, boolean resolve) {
+        URL url;
+        try {
+            url = new URL(rawUrlString);
+            return of(url, rawUrlString, resolve);
+        } catch (MalformedURLException e) {
+            return new ResolutionBase(rawUrlString, new ResolutionException("Invalid URL: " + rawUrlString, e), this);
+        }
+    }
+
+    public ResolutionBase register(String urlString, JsonNode json) {
+        ResolutionBase base = new ResolutionBase(urlString, json, this);
+        instances.put(urlString, base);
+        return base;
+    }
+    
+    public JsonLoader getJsonLoader() {
+        return jsonLoader;
+    }
+
+    private ResolutionBase of(URL baseUrl, String rawUrlString, boolean resolve) {
+        if (instances.containsKey(rawUrlString)) {
+            return instances.get(rawUrlString);
+        }
+        try {
+            String urlString = normalizeUrlString(baseUrl);
+            ResolutionBase base;
+            if (instances.containsKey(urlString)) {
+                base = instances.get(urlString);
+                instances.put(rawUrlString, base);
+            } else {
+                base = new ResolutionBase(urlString, this);
+                instances.put(urlString, base);
+                instances.put(baseUrl.toString(), base);
+            }
+            if (resolve && !base.isResolved()) {
+                base.resolve();
+            }
+            return base;
+        } catch (ResolutionException e) {
+            if (!instances.containsKey(rawUrlString)) {
+                instances.put(rawUrlString, new ResolutionBase(rawUrlString, e, this));
+            }
+            return instances.get(rawUrlString);
+        }
+    }
+
+    private static String normalizeUrlString(URL url) {
+        String urlString = url.toString();
+        if (urlString.contains("#")) {
+            urlString = urlString.substring(0, urlString.indexOf('#'));
+        }
+        try {
+            URI uri = new URI(urlString).normalize();
+            return uri.toString();
+        } catch (URISyntaxException e) {
+            throw new ResolutionException("Invalid document URI", e);
+        }
+    }
+
+
+}

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/Resolver.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/Resolver.java
@@ -32,20 +32,22 @@ public class Resolver {
 
     private Set<ResolutionBase> resolvedBases = Sets.newHashSet();
     private final ReferenceRegistry referenceRegistry;
+    private final ResolutionBaseRegistry resolutionBaseRegistry;
     
-    public Resolver(ReferenceRegistry referenceRegistry) {
+    public Resolver(ReferenceRegistry referenceRegistry, ResolutionBaseRegistry resolutionBaseRegistry) {
        this.referenceRegistry = referenceRegistry;
+       this.resolutionBaseRegistry = resolutionBaseRegistry;
     }
 
     public void preresolve(String... baseUrls) {
         for (String url : baseUrls) {
-            preresolve(ResolutionBase.of(url, true));
+            preresolve(resolutionBaseRegistry.of(url, true));
         }
     }
 
     public void preresolve(URL... baseUrls) {
         for (URL url : baseUrls) {
-            preresolve(ResolutionBase.of(url, true));
+            preresolve(resolutionBaseRegistry.of(url, true));
         }
     }
 

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/coll/ObjectOverlay.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/coll/ObjectOverlay.java
@@ -20,9 +20,14 @@ import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ReferenceRegistry;
 
 public class ObjectOverlay<OO extends ObjectOverlay<OO>> extends JsonOverlay<OO> {
 
+    protected ObjectOverlay(String key, JsonNode json, JsonOverlay<?> parent, ReferenceRegistry referenceRegistry) {
+        super(key, json, parent, referenceRegistry);
+    }
+    
     public ObjectOverlay(String key, JsonNode json, JsonOverlay<?> parent) {
         super(key, json, parent);
     }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/gen/TypeGenerator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/gen/TypeGenerator.java
@@ -29,7 +29,9 @@ import com.github.javaparser.JavaParser;
 import com.github.javaparser.ParseException;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.body.BodyDeclaration;
+import com.github.javaparser.ast.body.ConstructorDeclaration;
 import com.github.javaparser.ast.body.FieldDeclaration;
+import com.github.javaparser.ast.body.InitializerDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.body.TypeDeclaration;
 import com.github.javaparser.ast.comments.Comment;
@@ -45,6 +47,7 @@ import com.google.inject.Inject;
 import com.reprezen.kaizen.oasparser.OpenApi;
 import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlayFactory;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ReferenceRegistry;
 import com.reprezen.kaizen.oasparser.jsonoverlay.coll.ListOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.coll.MapOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.coll.ValListOverlay;
@@ -167,6 +170,7 @@ public abstract class TypeGenerator {
                 JsonNode.class, //
                 JsonOverlay.class, //
                 JsonOverlayFactory.class, //
+                ReferenceRegistry.class, //
                 Inject.class, //
                 StringOverlay.class, //
                 IntegerOverlay.class, //
@@ -258,7 +262,7 @@ public abstract class TypeGenerator {
     private void addManualMethods(SimpleJavaGenerator gen, CompilationUnit existing) {
         for (TypeDeclaration type : existing.getTypes()) {
             for (BodyDeclaration member : type.getMembers()) {
-                if (member instanceof MethodDeclaration || member instanceof FieldDeclaration) {
+                if (member instanceof MethodDeclaration || member instanceof FieldDeclaration || member instanceof ConstructorDeclaration) {
                     if (!isGenerated(member)) {
                         gen.addMember(new Member(member.toString(), null).complete(true));
                     }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/OpenApi3Impl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/OpenApi3Impl.java
@@ -84,7 +84,7 @@ public class OpenApi3Impl extends OpenApiObjectImpl implements OpenApi3 {
     public OpenApi3Impl(String key, JsonNode json, JsonOverlay<?> parent, ReferenceRegistry referenceRegistry) {
         super(key, json, parent, referenceRegistry);
     }
-    
+
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public OpenApi3Impl(String key, JsonNode json, JsonOverlay<?> parent) {
         super(key, json, parent);

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/OpenApi3Impl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/OpenApi3Impl.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.google.inject.Inject;
 import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlayFactory;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ReferenceRegistry;
 import com.reprezen.kaizen.oasparser.jsonoverlay.coll.ListOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.coll.MapOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.coll.ValMapOverlay;
@@ -80,6 +81,10 @@ public class OpenApi3Impl extends OpenApiObjectImpl implements OpenApi3 {
         return getValidationResults().getItems();
     }
 
+    public OpenApi3Impl(String key, JsonNode json, JsonOverlay<?> parent, ReferenceRegistry referenceRegistry) {
+        super(key, json, parent, referenceRegistry);
+    }
+    
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public OpenApi3Impl(String key, JsonNode json, JsonOverlay<?> parent) {
         super(key, json, parent);

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/OpenApiObjectImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/OpenApiObjectImpl.java
@@ -12,6 +12,7 @@ package com.reprezen.kaizen.oasparser.ovl3;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ReferenceRegistry;
 import com.reprezen.kaizen.oasparser.jsonoverlay.coll.ObjectOverlay;
 import com.reprezen.kaizen.oasparser.model3.OpenApi3;
 import com.reprezen.kaizen.oasparser.model3.OpenApiObject;
@@ -19,6 +20,10 @@ import com.reprezen.kaizen.oasparser.model3.OpenApiObject;
 
 public class OpenApiObjectImpl extends ObjectOverlay<OpenApiObjectImpl> implements OpenApiObject {
 
+    protected OpenApiObjectImpl(String key, JsonNode json, JsonOverlay<?> parent, ReferenceRegistry referenceRegistry) {
+        super(key, json, parent, referenceRegistry);
+    }
+    
     public OpenApiObjectImpl(String key, JsonNode json, JsonOverlay<?> parent) {
         super(key, json, parent);
     }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/types3.yaml
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/types3.yaml
@@ -21,7 +21,7 @@ types:
   - name: OpenApi3
     imports: 
       intf:  [ ValidationResults ]
-      impl: [ OpenApi3Validator, Validator, ValidationResults, Severity, Inject ]
+      impl: [ OpenApi3Validator, Validator, ValidationResults, Severity, Inject, ReferenceRegistry ]
     extendInterfaces: [OpenApi]
     fields:
       openapi:


### PR DESCRIPTION
Static reference caches make KaiZen parser impossible to use for the live views. Current version caches not only external references but also local ones. 
This PR addresses it by 
* Splitting `ResolutionBase` to `ResolutionBase` + `ResolutionBaseRegistry`
* Splitting `Reference` to `Reference` and `ReferenceRegistry`
* Making methods inside `JsonLoader` non-static (instance)

To use the new instance-level methods, I added a new custom constructor to `OpenApi3Impl`, but it did not survive code re-generation. So, `TypeGenerator` and related files were updated to preserve constructors and new class imports.

