### PR TITLE
task/44 type attr in schemas is not required

### DIFF
--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val/ValidatorBase.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val/ValidatorBase.java
@@ -34,8 +34,6 @@ import com.reprezen.kaizen.oasparser.val.oasparser.fake.scheme.Handler;
 
 public abstract class ValidatorBase<T> implements Validator<T> {
 
-    private static boolean laxRequired = System.getenv("OAS_PARSER_LAX_REQUIRED") != null;
-
     @Override
     public ValidationResults validate(T object) {
         ValidationResults results = new ValidationResults();
@@ -162,7 +160,7 @@ public abstract class ValidatorBase<T> implements Validator<T> {
 
     public <V> void validateList(final Collection<? extends V> value, final boolean isPresent,
             final ValidationResults results, final boolean required, final String crumb, final Validator<V> validator) {
-        if (required && !laxRequired && !isPresent) {
+        if (required && !isPresent) {
             results.addError(m.msg("MissingField|Required field is missing", crumb), crumb);
         }
         if (isPresent && validator != null) {
@@ -258,7 +256,7 @@ public abstract class ValidatorBase<T> implements Validator<T> {
 
     private void checkMissing(boolean required, final Object value, final ValidationResults results,
             final String crumb) {
-        if (required && !laxRequired && isMissing(value)) {
+        if (required && isMissing(value)) {
             results.addError(m.msg("MissingField|Required field is missing", crumb), crumb);
         }
     }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/SchemaValidator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/SchemaValidator.java
@@ -46,7 +46,7 @@ public class SchemaValidator extends ObjectValidatorBase<Schema> {
         validateList(schema.getEnums(), schema.hasEnums(), results, false, "enum", null);
         validateNonEmpty(schema.getEnums(), schema.hasEnums(), results, "enum");
         validateUnique(schema.getEnums(), results, "enum");
-        validateString(schema.getType(), results, true, "boolean|object|array|number|integer|string", "type");
+        validateString(schema.getType(), results, false, "boolean|object|array|number|integer|string", "type");
         validateList(schema.getAllOfSchemas(), schema.hasAllOfSchemas(), results, false, "allOf", this);
         validateList(schema.getOneOfSchemas(), schema.hasOneOfSchemas(), results, false, "oneOf", this);
         validateList(schema.getAnyOfSchemas(), schema.hasAnyOfSchemas(), results, false, "anyOf", this);


### PR DESCRIPTION
Also removed lax checking capability, which was a temporary hack primarily to deal with this case, while I intended to seek clarification from OAS authors.

Fixing this causes some previously failing example tests to succeed (formerly succeeded only with lax checking enabled.