### PR TITLE
Task/4 Implement simple serialization capability

### DIFF
--- a/kaizen-openapi-parser/.classpath
+++ b/kaizen-openapi-parser/.classpath
@@ -28,5 +28,10 @@
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">
+		<attributes>
+			<attribute name="maven.pomderived" value="true"/>
+		</attributes>
+	</classpathentry>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/kaizen-openapi-parser/.project
+++ b/kaizen-openapi-parser/.project
@@ -11,17 +11,17 @@
 			</arguments>
 		</buildCommand>
 		<buildCommand>
-			<name>org.eclipse.m2e.core.maven2Builder</name>
-			<arguments>
-			</arguments>
-		</buildCommand>
-		<buildCommand>
 			<name>org.eclipse.pde.ManifestBuilder</name>
 			<arguments>
 			</arguments>
 		</buildCommand>
 		<buildCommand>
 			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
 			<arguments>
 			</arguments>
 		</buildCommand>

--- a/kaizen-openapi-parser/.settings/org.eclipse.core.resources.prefs
+++ b/kaizen-openapi-parser/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,6 @@
+eclipse.preferences.version=1
+encoding//src/main/java=UTF-8
+encoding//src/main/resources=UTF-8
+encoding//src/test/java=UTF-8
+encoding//src/test/resources=UTF-8
+encoding/<project>=UTF-8

--- a/kaizen-openapi-parser/pom.xml
+++ b/kaizen-openapi-parser/pom.xml
@@ -129,6 +129,23 @@
 		</plugins>
 	    </build>
 	</profile>
+	<profile>
+	    <id>compile-for-gen</id>
+	    <build>
+		<plugins>
+		    <plugin>
+			<groupId>org.apache.maven.plugins</groupId>
+			<artifactId>maven-compiler-plugin</artifactId>
+			<configuration>
+			    <includes>
+				<include>**/jsonoverlay/**/*</include>
+				<include>**/oasparser/GenOpenApi3.java</include>
+			    </includes>
+			</configuration>
+		    </plugin>
+		</plugins>
+	    </build>
+	</profile>
     </profiles>
     <build>
 	<plugins>

--- a/kaizen-openapi-parser/pom.xml
+++ b/kaizen-openapi-parser/pom.xml
@@ -103,6 +103,12 @@
 	    <artifactId>javax.mail</artifactId>
 	    <version>1.5.6</version>
 	</dependency>
+	<dependency>
+		<groupId>org.skyscreamer</groupId>
+		<artifactId>jsonassert</artifactId>
+		<version>1.5.0</version>
+		<scope>test</scope>
+	</dependency>
     </dependencies>
     <profiles>
 	<profile>

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/JsonLoader.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/JsonLoader.java
@@ -45,12 +45,11 @@ public class JsonLoader {
     }
 
     public JsonNode loadString(URL url, String json) throws IOException, JsonProcessingException {
-        String trimmed = json.trim();
         JsonNode tree;
-        if (trimmed.startsWith("{")) {
-            tree = jsonMapper.readTree(trimmed);
+        if (json.trim().startsWith("{")) {
+            tree = jsonMapper.readTree(json);
         } else {
-            Object parsedYaml = yaml.load(trimmed); // this handles aliases - YAMLMapper doesn't
+            Object parsedYaml = yaml.load(json); // this handles aliases - YAMLMapper doesn't
             tree = yamlMapper.convertValue(parsedYaml, JsonNode.class);
         }
         if (url != null) {

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/JsonOverlay.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/JsonOverlay.java
@@ -117,7 +117,7 @@ public abstract class JsonOverlay<V> {
 		}
 	}
 
-	public JsonNode getJson() {
+	protected JsonNode getJson() {
 		if (ref != null) {
 			return resolvedJson;
 		} else {

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/JsonOverlay.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/JsonOverlay.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package com.reprezen.kaizen.oasparser.jsonoverlay;
 
-import java.util.Collections;
 import java.util.Iterator;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -22,171 +21,198 @@ import com.google.common.base.Optional;
 
 public abstract class JsonOverlay<V> {
 
-    protected final static JsonNodeFactory jsonFactory = JsonNodeFactory.instance;
-    protected final static ObjectMapper mapper = new ObjectMapper();
+	protected final static JsonNodeFactory jsonFactory = JsonNodeFactory.instance;
+	protected final static ObjectMapper mapper = new ObjectMapper();
 
-    private final ReferenceRegistry referenceRegistry;
+	private final ReferenceRegistry referenceRegistry;
 
-    protected String key;
-    private JsonNode json; // need to prevent subclasses from direct access due to reference management
-    private JsonNode resolvedJson = null;
-    protected JsonOverlay<?> parent;
-    protected JsonOverlay<?> root;
-    protected Reference ref = null;
-    protected V value;
+	protected String key;
+	private JsonNode json; // need to prevent subclasses from direct access due to reference management
+	private JsonNode resolvedJson = null;
+	protected JsonOverlay<?> parent;
+	protected JsonOverlay<?> root;
+	protected Reference ref = null;
+	protected V value;
+	protected boolean jsonIsCurrent;
 
-    public JsonOverlay(String key, V value, JsonOverlay<?> parent) {
-        this(key, Optional.fromNullable(value), Optional.<JsonNode> absent(), parent);
-    }
+	public JsonOverlay(String key, V value, JsonOverlay<?> parent) {
+		this(key, Optional.fromNullable(value), Optional.<JsonNode>absent(), parent);
+	}
 
-    public JsonOverlay(String key, JsonNode json, JsonOverlay<?> parent, ReferenceRegistry referenceRegistry) {
-        this(key, Optional.<V> absent(), Optional.fromNullable(json), parent, referenceRegistry);
-    }
-    
-    public JsonOverlay(String key, JsonNode json, JsonOverlay<?> parent) {
-        this(key, Optional.<V> absent(), Optional.fromNullable(json), parent);
-    }
+	public JsonOverlay(String key, JsonNode json, JsonOverlay<?> parent, ReferenceRegistry referenceRegistry) {
+		this(key, Optional.<V>absent(), Optional.fromNullable(json), parent, referenceRegistry);
+	}
 
-    public JsonOverlay(String key, JsonOverlay<?> parent) {
-        this(key, Optional.<V> absent(), Optional.<JsonNode> absent(), parent);
-    }
+	public JsonOverlay(String key, JsonNode json, JsonOverlay<?> parent) {
+		this(key, Optional.<V>absent(), Optional.fromNullable(json), parent);
+	}
 
-    private JsonOverlay(String key, Optional<V> value, Optional<JsonNode> json, JsonOverlay<?> parent) {
-        this(key, value, json, parent, parent == null?new ReferenceRegistry() : parent.referenceRegistry);
-    }
-    
-    private JsonOverlay(String key, Optional<V> value, Optional<JsonNode> json, JsonOverlay<?> parent, ReferenceRegistry referenceRegistry) {
-        this.key = key;
-        this.parent = parent;
-        this.referenceRegistry = referenceRegistry;
-        if (parent == null) {
-            root = this;
-        } else {
-            root = parent.getRoot();
-        }
-        if (json.isPresent()) {
-            this.json = json.get();
-            processReference();
-            this.value = fromJson();
-        } else if (value.isPresent()) {
-            this.value = value.get();
-            this.json = toJson();
-        } else if (parent != null) {
-            this.json = parent.getJson(key);
-            processReference();
-            this.value = fromJson();
-        } else {
-            this.json = MissingNode.getInstance();
-            this.value = null;
-        }
-    }
+	public JsonOverlay(String key, JsonOverlay<?> parent) {
+		this(key, Optional.<V>absent(), Optional.<JsonNode>absent(), parent);
+	}
 
-    public V get() {
-        return value;
-    }
+	private JsonOverlay(String key, Optional<V> value, Optional<JsonNode> json, JsonOverlay<?> parent) {
+		this(key, value, json, parent, parent == null ? new ReferenceRegistry() : parent.referenceRegistry);
+	}
 
-    public void set(V value) {
-        this.value = value;
-    }
+	private JsonOverlay(String key, Optional<V> value, Optional<JsonNode> json, JsonOverlay<?> parent,
+			ReferenceRegistry referenceRegistry) {
+		this.key = key;
+		this.parent = parent;
+		this.referenceRegistry = referenceRegistry;
+		if (parent == null) {
+			root = this;
+		} else {
+			root = parent.getRoot();
+		}
+		if (json.isPresent()) {
+			this.json = json.get();
+			processReference();
+			this.value = fromJson();
+			this.jsonIsCurrent = true;
+		} else if (value.isPresent()) {
+			this.value = value.get();
+			this.jsonIsCurrent = false;
+			this.json = toJson();
+		} else if (parent != null) {
+			this.json = parent.getJson(key);
+			this.jsonIsCurrent = true;
+			processReference();
+			this.value = fromJson();
+		} else {
+			this.json = MissingNode.getInstance();
+			this.jsonIsCurrent = true;
+			this.value = null;
+		}
+	}
 
-    public JsonNode getJson() {
-        if (ref != null) {
-            return resolvedJson;
-        } else {
-            return json;
-        }
-    }
+	public V get() {
+		return value;
+	}
 
-    public JsonNode getJson(String key) {
-        JsonNode json = getJson();
-        if (key.isEmpty()) {
-            return json;
-        } else if (key.indexOf('/') < 0) {
-            return json.path(key);
-        } else {
-            return json.at("/" + key);
-        }
-    }
+	public void set(V value) {
+		this.value = value;
+		invalidate();
+		if (parent != null) {
+			parent.addToSerialization(key);
+		}
+	}
 
-    public JsonNode getResolvedJson(String key) {
-        JsonNode json = getJson(key);
-        if (isReferenceNode(json)) {
-            return referenceRegistry.get(json.get("key").asText()).getJson();
-        } else {
-            return json;
-        }
-    }
+	protected void invalidate() {
+		this.jsonIsCurrent = false;
+		if (parent != null) {
+			parent.invalidate();
+		}
+	}
 
-    public JsonNode getOriginalJson() {
-        return json;
-    }
+	public JsonNode getJson() {
+		if (ref != null) {
+			return resolvedJson;
+		} else {
+			return json;
+		}
+	}
 
-    public abstract V fromJson();
+	public JsonNode getJson(String key) {
+		JsonNode json = getJson();
+		if (key.isEmpty()) {
+			return json;
+		} else if (key.indexOf('/') < 0) {
+			return json.path(key);
+		} else {
+			return json.at("/" + key);
+		}
+	}
 
-    public abstract JsonNode toJson();
+	public JsonNode getResolvedJson(String key) {
+		JsonNode json = getJson(key);
+		if (isReferenceNode(json)) {
+			return referenceRegistry.get(json.get("key").asText()).getJson();
+		} else {
+			return json;
+		}
+	}
 
-    protected Iterable<? extends JsonOverlay<?>> getChildren() {
-        return Collections.emptyList();
-    }
+	public JsonNode getOriginalJson() {
+		return json;
+	}
 
-    protected void processReference() {
-        if (isReferenceNode()) {
-            ref = referenceRegistry.get(json.get("key").asText());
-            resolvedJson = ref.getJson();
-        }
-    }
+	public abstract V fromJson();
 
-    protected boolean isReferenceNode() {
-        return isReferenceNode(json);
-    }
+	public JsonNode toJson() {
+		if (jsonIsCurrent) {
+			return getJson();
+		} else {
+			this.json = createJson();
+			this.jsonIsCurrent = true;
+			return json;
+		}
+	}
 
-    protected boolean isReferenceNode(JsonNode json) {
-        // If the $ref property isn't a string, that's an issue for validation.
-        return json instanceof ObjectNode && json.has("$ref");
-    }
+	public abstract JsonNode createJson();
 
-    public boolean isReference() {
-        return ref != null;
-    }
+	protected void addToSerialization(String key) {
+		// no-op except for ObjectOverlay
+	}
 
-    public Reference getReference() {
-        return ref;
-    }
+	protected void processReference() {
+		if (isReferenceNode()) {
+			ref = referenceRegistry.get(json.get("key").asText());
+			resolvedJson = ref.getJson();
+		}
+	}
 
-    public JsonOverlay<?> getParentOverlay() {
-        return parent;
-    }
+	protected boolean isReferenceNode() {
+		return isReferenceNode(json);
+	}
 
-    public JsonOverlay<?> getRoot() {
-        return root != null ? root : this;
-    }
+	protected boolean isReferenceNode(JsonNode json) {
+		// If the $ref property isn't a string, that's an issue for validation.
+		return json instanceof ObjectNode && json.has("$ref");
+	}
 
-    public String getKey() {
-        return key;
-    }
+	public boolean isReference() {
+		return ref != null;
+	}
 
-    public void reparent(JsonOverlay<?> parent, String key) {
-        this.parent = parent;
-        this.root = parent.root;
-        this.key = key;
-    }
+	public Reference getReference() {
+		return ref;
+	}
 
-    public void deparent() {
-        this.parent = null;
-        this.root = null;
-        this.key = null;
-    }
+	public JsonOverlay<?> getParentOverlay() {
+		return parent;
+	}
 
-    public boolean isMissing() {
-        return json.isMissingNode();
-    }
+	public JsonOverlay<?> getRoot() {
+		return root != null ? root : this;
+	}
 
-    public static <T> Iterable<T> iterable(final Iterator<T> iterator) {
-        return new Iterable<T>() {
-            @Override
-            public Iterator<T> iterator() {
-                return iterator;
-            }
-        };
-    }
+	public String getKey() {
+		return key;
+	}
+
+	public void reparent(JsonOverlay<?> parent, String key) {
+		this.parent = parent;
+		this.root = parent.root;
+		this.key = key;
+	}
+
+	public void deparent() {
+		this.parent = null;
+		this.root = null;
+		this.key = null;
+	}
+
+	public boolean isMissing() {
+		return json.isMissingNode();
+	}
+
+	public static <T> Iterable<T> iterable(final Iterator<T> iterator) {
+		return new Iterable<T>() {
+			@Override
+			public Iterator<T> iterator() {
+				return iterator;
+			}
+		};
+	}
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/JsonOverlay.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/JsonOverlay.java
@@ -152,26 +152,37 @@ public abstract class JsonOverlay<V> {
 	public abstract V fromJson();
 
 	public JsonNode toJson() {
-		if (jsonIsCurrent) {
+		return toJson(false);
+	}
+	
+	public JsonNode toJson(boolean followRefs) {
+		if (jsonIsCurrent && !followRefs) {
 			return getJson();
 		} else {
-			this.json = createJson();
-			this.jsonIsCurrent = true;
-			return json;
+			JsonNode result = createJson(followRefs);
+			if (!followRefs) {
+				this.json = result;
+				this.jsonIsCurrent = true;
+			}
+			return result;
 		}
 	}
 
 	public JsonNode createJson() {
-		if (isReference()) {
+		return createJson(false);
+	}
+	
+	public JsonNode createJson(boolean followRefs) {
+		if (isReference() && !followRefs) {
 			ObjectNode obj = JsonNodeFactory.instance.objectNode();
 			obj.put("$ref", json.get("$ref").asText());
 			return obj; 
 		} else {
-			return _createJson();
+			return _createJson(followRefs);
 		}
 	}
 	
-	protected abstract JsonNode _createJson();
+	protected abstract JsonNode _createJson(boolean followRefs);
 
 	protected void addToSerialization(String key) {
 		// no-op except for ObjectOverlay

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/JsonOverlay.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/JsonOverlay.java
@@ -161,7 +161,17 @@ public abstract class JsonOverlay<V> {
 		}
 	}
 
-	public abstract JsonNode createJson();
+	public JsonNode createJson() {
+		if (isReference()) {
+			ObjectNode obj = JsonNodeFactory.instance.objectNode();
+			obj.put("$ref", json.get("$ref").asText());
+			return obj; 
+		} else {
+			return _createJson();
+		}
+	}
+	
+	protected abstract JsonNode _createJson();
 
 	protected void addToSerialization(String key) {
 		// no-op except for ObjectOverlay

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/JsonOverlay.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/JsonOverlay.java
@@ -12,6 +12,7 @@ package com.reprezen.kaizen.oasparser.jsonoverlay;
 
 import java.util.Iterator;
 
+import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
@@ -88,6 +89,17 @@ public abstract class JsonOverlay<V> {
 
 	public V get() {
 		return value;
+	}
+
+	public JsonOverlay<?> find(JsonPointer path) {
+		// this implementation suffices for primitive types, but must be overriden in
+		// overlays designed for JSON arrays or objects
+		return isMissing() ? null//
+				: path.matches() ? this : null;
+	}
+
+	public JsonOverlay<?> find(String path) {
+		return find(JsonPointer.compile(path));
 	}
 
 	public void set(V value) {

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/Reference.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/Reference.java
@@ -131,8 +131,4 @@ public class Reference {
         }
         return json;
     }
-
-    public String getFragnent() {
-        return fragment;
-    }
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/coll/CollectionStore.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/coll/CollectionStore.java
@@ -111,22 +111,22 @@ public class CollectionStore<OV extends JsonOverlay<?>> {
         }
     }
 
-    public JsonNode createJson() {
-        return isList ? createJsonList() : createJsonMap();
+    public JsonNode createJson(boolean followRefs) {
+        return isList ? createJsonList(followRefs) : createJsonMap(followRefs);
     }
 
-    private JsonNode createJsonList() {
+    private JsonNode createJsonList(boolean followRefs) {
         ArrayNode list = jsonFactory.arrayNode();
         for (OV overlay : overlays.values()) {
-            list.add(overlay.createJson());
+            list.add(overlay.createJson(followRefs));
         }
         return list;
     }
 
-    private JsonNode createJsonMap() {
+    private JsonNode createJsonMap(boolean followRefs) {
         ObjectNode map = jsonFactory.objectNode();
         for (OV overlay : overlays.values()) {
-            map.set(overlay.getKey(), overlay.createJson());
+            map.set(overlay.getKey(), overlay.createJson(followRefs));
         }
         return map;
     }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/coll/CollectionStore.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/coll/CollectionStore.java
@@ -111,22 +111,22 @@ public class CollectionStore<OV extends JsonOverlay<?>> {
         }
     }
 
-    public JsonNode toJson() {
-        return isList ? toJsonList() : toJsonMap();
+    public JsonNode createJson() {
+        return isList ? createJsonList() : createJsonMap();
     }
 
-    private JsonNode toJsonList() {
+    private JsonNode createJsonList() {
         ArrayNode list = jsonFactory.arrayNode();
         for (OV overlay : overlays.values()) {
-            list.add(overlay.toJson());
+            list.add(overlay.createJson());
         }
         return list;
     }
 
-    private JsonNode toJsonMap() {
+    private JsonNode createJsonMap() {
         ObjectNode map = jsonFactory.objectNode();
         for (OV overlay : overlays.values()) {
-            map.set(overlay.getKey(), overlay.toJson());
+            map.set(overlay.getKey(), overlay.createJson());
         }
         return map;
     }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/coll/JsonPointerTrie.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/coll/JsonPointerTrie.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ *  Copyright (c) 2017 ModelSolv, Inc. and others.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  Contributors:
+ *     ModelSolv, Inc. - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package com.reprezen.kaizen.oasparser.jsonoverlay.coll;
+
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import org.apache.commons.lang3.tuple.Pair;
+
+import com.fasterxml.jackson.core.JsonPointer;
+import com.google.common.collect.Maps;
+
+public class JsonPointerTrie<T> {
+
+	private Map<Pattern, T> patternMap = Maps.newHashMap();
+
+	private Map<String, JsonPointerTrie<T>> children = Maps.newHashMap();
+
+	public void add(JsonPointer path, Pattern pattern, T value) {
+		if (path.matches()) {
+			// note: pattern = null works with HashMap and is how a path that terminates in
+			// this object will be handled. When pattern is not null, a nonempty path will
+			// have its head segment matched against non-null patterns to choose the value.
+			patternMap.put(pattern, value);
+		} else {
+			String childKey = path.getMatchingProperty();
+			if (!children.containsKey(childKey)) {
+				children.put(childKey, new JsonPointerTrie<T>());
+			}
+			children.get(childKey).add(path.tail(), pattern, value);
+		}
+	}
+
+	public Pair<T, JsonPointer> find(JsonPointer path) {
+		if (path.matches()) {
+			return Pair.of(patternMap.get(null), null);
+		} else {
+			String key = path.getMatchingProperty();
+			if (children.containsKey(key)) {
+				return children.get(key).find(path.tail());
+			}
+			// see if any non-null pattern matches key, return our T value with the same
+			// JsonPointer. This case addresses objects that implenent maps with
+			// pattern-constrained keys. We resolve to that map-like object, and the
+			// remaining path starts with a key into that map.
+			for (Pattern pat : patternMap.keySet()) {
+				if (pat.matcher(key).matches()) {
+					return Pair.of(patternMap.get(pat), path);
+				}
+			}
+			// no non-null patterns matched - return our null-pattern value, with the
+			// remaining path to be applied to it.
+			return Pair.of(patternMap.get(null), path);
+		}
+	}
+}

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/coll/JsonPointerTrie.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/coll/JsonPointerTrie.java
@@ -41,7 +41,7 @@ public class JsonPointerTrie<T> {
 
 	public Pair<T, JsonPointer> find(JsonPointer path) {
 		if (path.matches()) {
-			return Pair.of(patternMap.get(null), null);
+			return Pair.of(patternMap.get(null), path);
 		} else {
 			String key = path.getMatchingProperty();
 			if (children.containsKey(key)) {
@@ -52,7 +52,7 @@ public class JsonPointerTrie<T> {
 			// pattern-constrained keys. We resolve to that map-like object, and the
 			// remaining path starts with a key into that map.
 			for (Pattern pat : patternMap.keySet()) {
-				if (pat.matcher(key).matches()) {
+				if (pat != null && pat.matcher(key).matches()) {
 					return Pair.of(patternMap.get(pat), path);
 				}
 			}

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/coll/ListOverlay.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/coll/ListOverlay.java
@@ -98,7 +98,7 @@ public class ListOverlay<OV extends JsonOverlay<?>> extends JsonOverlay<Collecti
 	}
 
 	@Override
-	public JsonNode createJson() {
+	public JsonNode _createJson() {
 		return store.createJson();
 	}
 

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/coll/ListOverlay.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/coll/ListOverlay.java
@@ -99,7 +99,7 @@ public class ListOverlay<OV extends JsonOverlay<?>> extends JsonOverlay<Collecti
 
 	@Override
 	public JsonNode createJson() {
-		return store.toJson();
+		return store.createJson();
 	}
 
 	public void add(OV overlay) {

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/coll/ListOverlay.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/coll/ListOverlay.java
@@ -13,6 +13,7 @@ package com.reprezen.kaizen.oasparser.jsonoverlay.coll;
 import java.util.Collection;
 import java.util.Collections;
 
+import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlayFactory;
@@ -67,6 +68,18 @@ public class ListOverlay<OV extends JsonOverlay<?>> extends JsonOverlay<Collecti
 		store.set(overlays);
 		reset();
 		invalidate();
+	}
+
+	@Override
+	public JsonOverlay<?> find(JsonPointer path) {
+		if (path.matches()) {
+			return this;
+		} else if (path.mayMatchElement()) {
+			int index = path.getMatchingIndex();
+			return size() > index ? store.get(index).find(path.tail()) : null;
+		} else {
+			return null;
+		}
 	}
 
 	public void clear() {

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/coll/ListOverlay.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/coll/ListOverlay.java
@@ -18,112 +18,115 @@ import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlayFactory;
 
 public class ListOverlay<OV extends JsonOverlay<?>> extends JsonOverlay<Collection<OV>>
-        implements CollectionOverlay<OV> {
+		implements CollectionOverlay<OV> {
 
-    private final CollectionStore<OV> store = new CollectionStore<OV>(this);
+	private final CollectionStore<OV> store = new CollectionStore<OV>(this);
 
-    private ListOverlay(String key, JsonOverlayFactory<OV> factory, JsonOverlay<?> parent) {
-        super(key, (Collection<OV>) null, parent);
-    }
+	private ListOverlay(String key, JsonOverlayFactory<OV> factory, JsonOverlay<?> parent) {
+		super(key, (Collection<OV>) null, parent);
+	}
 
-    public ListOverlay(String key, Collection<OV> overlays, JsonOverlay<?> parent, JsonOverlayFactory<OV> factory) {
-        this(key, factory, parent);
-        store.init(true, null).load(CollectionData.of(overlays));
-        reset();
-    }
+	public ListOverlay(String key, Collection<OV> overlays, JsonOverlay<?> parent, JsonOverlayFactory<OV> factory) {
+		this(key, factory, parent);
+		store.init(true, null).load(CollectionData.of(overlays));
+		reset();
+	}
 
-    public ListOverlay(String key, JsonNode json, JsonOverlay<?> parent, JsonOverlayFactory<OV> factory) {
-        this(key, factory, parent);
-        store.init(true, null).load(CollectionData.of(json, parent, factory));
-        reset();
-    }
+	public ListOverlay(String key, JsonNode json, JsonOverlay<?> parent, JsonOverlayFactory<OV> factory) {
+		this(key, factory, parent);
+		store.init(true, null).load(CollectionData.of(json, parent, factory));
+		reset();
+	}
 
-    public ListOverlay(String key, JsonOverlay<?> parent, JsonOverlayFactory<OV> factory) {
-        this(key, factory, parent);
-        store.init(true, null).load(CollectionData.of(parent.getResolvedJson(key), parent, factory));
-        reset();
-    }
+	public ListOverlay(String key, JsonOverlay<?> parent, JsonOverlayFactory<OV> factory) {
+		this(key, factory, parent);
+		store.init(true, null).load(CollectionData.of(parent.getResolvedJson(key), parent, factory));
+		reset();
+	}
 
-    @Override
-    public boolean isMissing() {
-        return super.isMissing() || !getJson().isArray();
-    }
+	@Override
+	public boolean isMissing() {
+		return super.isMissing() || !getJson().isArray();
+	}
 
-    private void reset() {
-        super.set(store.getOverlays());
-    }
+	private void reset() {
+		super.set(store.getOverlays());
+	}
 
-    @Override
-    protected Collection<? extends JsonOverlay<?>> getChildren() {
-        return store != null ? store.getOverlays() : Collections.<OV> emptyList();
-    }
+	@Override
+	public Collection<OV> get() {
+		return value;
+	}
 
-    @Override
-    public Collection<OV> get() {
-        return value;
-    }
+	public OV get(int index) {
+		return store.get(index);
+	}
 
-    public OV get(int index) {
-        return store.get(index);
-    }
+	@Override
+	public void set(Collection<OV> overlays) {
+		store.set(overlays);
+		reset();
+		invalidate();
+	}
 
-    @Override
-    public void set(Collection<OV> overlays) {
-        store.set(overlays);
-        reset();
-    }
+	public void clear() {
+		store.clear();
+		reset();
+		invalidate();
+	}
 
-    public void clear() {
-        store.clear();
-        reset();
-    }
+	public int size() {
+		return store.size();
+	}
 
-    public int size() {
-        return store.size();
-    }
+	@Override
+	public Collection<OV> fromJson() {
+		return store != null ? store.getOverlays() : Collections.<OV>emptyList();
+	}
 
-    @Override
-    public Collection<OV> fromJson() {
-        return store != null ? store.getOverlays() : Collections.<OV> emptyList();
-    }
+	@Override
+	public JsonNode createJson() {
+		return store.toJson();
+	}
 
-    @Override
-    public JsonNode toJson() {
-        return store.toJson();
-    }
+	public void add(OV overlay) {
+		store.add(overlay);
+		reset();
+		invalidate();
+	}
 
-    public void add(OV overlay) {
-        store.add(overlay);
-        reset();
-    }
+	public void add(String key, OV overlay) {
+		store.add(key, overlay);
+		reset();
+		invalidate();
+	}
 
-    public void add(String key, OV overlay) {
-        store.add(key, overlay);
-        reset();
-    }
+	public void remove(String key) {
+		store.remove(key);
+		reset();
+		invalidate();
+	}
 
-    public void remove(String key) {
-        store.remove(key);
-        reset();
-    }
+	public void remove(int index) {
+		store.remove(index);
+		reset();
+		invalidate();
+	}
 
-    public void remove(int index) {
-        store.remove(index);
-        reset();
-    }
+	public void replace(String key, OV overlay) {
+		store.replace(key, overlay);
+		reset();
+		invalidate();
+	}
 
-    public void replace(String key, OV overlay) {
-        store.replace(key, overlay);
-        reset();
-    }
+	public void set(int index, OV overlay) {
+		store.replace(index, overlay);
+		reset();
+		invalidate();
+	}
 
-    public void set(int index, OV overlay) {
-        store.replace(index, overlay);
-        reset();
-    }
-
-    @Override
-    public CollectionStore<OV> getStore() {
-        return store;
-    }
+	@Override
+	public CollectionStore<OV> getStore() {
+		return store;
+	}
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/coll/ListOverlay.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/coll/ListOverlay.java
@@ -98,8 +98,8 @@ public class ListOverlay<OV extends JsonOverlay<?>> extends JsonOverlay<Collecti
 	}
 
 	@Override
-	public JsonNode _createJson() {
-		return store.createJson();
+	public JsonNode _createJson(boolean followRefs) {
+		return store.createJson(followRefs);
 	}
 
 	public void add(OV overlay) {

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/coll/MapOverlay.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/coll/MapOverlay.java
@@ -19,135 +19,140 @@ import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlayFactory;
 
 public class MapOverlay<OV extends JsonOverlay<?>> extends JsonOverlay<Map<String, OV>>
-        implements CollectionOverlay<OV> {
+		implements CollectionOverlay<OV> {
 
-    private final CollectionStore<OV> store = new CollectionStore<OV>(this);
+	private final CollectionStore<OV> store = new CollectionStore<OV>(this);
 
-    private MapOverlay(String key, JsonOverlay<?> parent) {
-        super(key, (Map<String, OV>) null, parent);
-    }
+	private MapOverlay(String key, JsonOverlay<?> parent) {
+		super(key, (Map<String, OV>) null, parent);
+	}
 
-    public MapOverlay(String key, Collection<OV> overlays, JsonOverlay<?> parent, String keyPat) {
-        this(key, parent);
-        store.init(false, keyPat).load(CollectionData.of(overlays));
-        reset();
-    }
+	public MapOverlay(String key, Collection<OV> overlays, JsonOverlay<?> parent, String keyPat) {
+		this(key, parent);
+		store.init(false, keyPat).load(CollectionData.of(overlays));
+		reset();
+	}
 
-    public MapOverlay(String key, Map<String, OV> overlayMap, JsonOverlay<?> parent, String keyPat) {
-        this(key, parent);
-        store.init(false, keyPat).load(CollectionData.of(overlayMap));
-        reset();
-    }
+	public MapOverlay(String key, Map<String, OV> overlayMap, JsonOverlay<?> parent, String keyPat) {
+		this(key, parent);
+		store.init(false, keyPat).load(CollectionData.of(overlayMap));
+		reset();
+	}
 
-    public MapOverlay(String key, JsonNode json, JsonOverlay<?> parent, JsonOverlayFactory<OV> factory, String keyPat) {
-        this(key, parent);
-        store.init(false, keyPat).load(CollectionData.of(json, parent, factory));
-        reset();
-    }
+	public MapOverlay(String key, JsonNode json, JsonOverlay<?> parent, JsonOverlayFactory<OV> factory, String keyPat) {
+		this(key, parent);
+		store.init(false, keyPat).load(CollectionData.of(json, parent, factory));
+		reset();
+	}
 
-    public MapOverlay(String key, JsonOverlay<?> parent, JsonOverlayFactory<OV> factory, String keyPat) {
-        this(key, parent);
-        store.init(false, keyPat).load(CollectionData.of(parent.getResolvedJson(key), parent, factory));
-        reset();
-    }
+	public MapOverlay(String key, JsonOverlay<?> parent, JsonOverlayFactory<OV> factory, String keyPat) {
+		this(key, parent);
+		store.init(false, keyPat).load(CollectionData.of(parent.getResolvedJson(key), parent, factory));
+		reset();
+	}
 
-    @Override
-    public boolean isMissing() {
-        return super.isMissing() || !getJson().isObject();
-    }
+	@Override
+	public boolean isMissing() {
+		return super.isMissing() || !getJson().isObject();
+	}
 
-    private void reset() {
-        super.set(store.getOverlayMap());
-    }
+	private void reset() {
+		super.set(store.getOverlayMap());
+	}
 
-    @Override
-    protected Collection<? extends JsonOverlay<?>> getChildren() {
-        return store != null ? store.getOverlays() : Collections.<OV> emptyList();
-    }
+	public OV get(String key) {
+		return value.get(key);
+	}
 
-    public OV get(String key) {
-        return value.get(key);
-    }
+	public boolean containsKey(String key) {
+		return value.containsKey(key);
+	}
 
-    public boolean containsKey(String key) {
-        return value.containsKey(key);
-    }
+	public Collection<OV> getValues() {
+		return value.values();
+	}
 
-    public Collection<OV> getValues() {
-        return value.values();
-    }
+	@Override
+	public void set(Map<String, OV> overlayMap) {
+		store.set(overlayMap);
+		reset();
+		invalidate();
+	}
 
-    @Override
-    public void set(Map<String, OV> overlayMap) {
-        store.set(overlayMap);
-        reset();
-    }
+	public void set(Collection<OV> overlays) {
+		store.set(overlays);
+		reset();
+		invalidate();
+	}
 
-    public void set(Collection<OV> overlays) {
-        store.set(overlays);
-        reset();
-    }
+	public void clear() {
+		store.clear();
+		reset();
+		invalidate();
+	}
 
-    public void clear() {
-        store.clear();
-        reset();
-    }
+	public int size() {
+		return value.size();
+	}
 
-    public int size() {
-        return value.size();
-    }
+	@Override
+	public Map<String, OV> fromJson() {
+		return store != null ? store.getOverlayMap() : Collections.<String, OV>emptyMap();
+	}
 
-    @Override
-    public Map<String, OV> fromJson() {
-        return store != null ? store.getOverlayMap() : Collections.<String, OV> emptyMap();
-    }
+	@Override
+	public JsonNode createJson() {
+		return store.toJson();
+	}
 
-    @Override
-    public JsonNode toJson() {
-        return store.toJson();
-    }
+	public void set(String key, OV overlay) {
+		if (value.containsKey(key)) {
+			store.replace(key, overlay);
+		} else {
+			store.add(key, overlay);
+		}
+		reset();
+		invalidate();
+	}
 
-    public void set(String key, OV overlay) {
-        if (value.containsKey(key)) {
-            store.replace(key, overlay);
-        } else {
-            store.add(key, overlay);
-        }
-        reset();
-    }
+	public void add(OV overlay) {
+		store.add(overlay);
+		reset();
+		invalidate();
+	}
 
-    public void add(OV overlay) {
-        store.add(overlay);
-        reset();
-    }
+	public void add(String key, OV overlay) {
+		store.add(key, overlay);
+		reset();
+		invalidate();
+	}
 
-    public void add(String key, OV overlay) {
-        store.add(key, overlay);
-        reset();
-    }
+	public void remove(String key) {
+		store.remove(key);
+		reset();
+		invalidate();
+	}
 
-    public void remove(String key) {
-        store.remove(key);
-        reset();
-    }
+	public void remove(int index) {
+		store.remove(index);
+		reset();
+		invalidate();
+	}
 
-    public void remove(int index) {
-        store.remove(index);
-        reset();
-    }
+	public void replace(String key, OV overlay) {
+		store.replace(key, overlay);
+		reset();
+		invalidate();
+	}
 
-    public void replace(String key, OV overlay) {
-        store.replace(key, overlay);
-        reset();
-    }
+	public void replace(int index, OV overlay) {
+		store.replace(index, overlay);
+		reset();
+		invalidate();
+	}
 
-    public void replace(int index, OV overlay) {
-        store.replace(index, overlay);
-        reset();
-    }
-
-    @Override
-    public CollectionStore<OV> getStore() {
-        return store;
-    }
+	@Override
+	public CollectionStore<OV> getStore() {
+		return store;
+	}
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/coll/MapOverlay.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/coll/MapOverlay.java
@@ -114,8 +114,8 @@ public class MapOverlay<OV extends JsonOverlay<?>> extends JsonOverlay<Map<Strin
 	}
 
 	@Override
-	public JsonNode _createJson() {
-		return store.createJson();
+	public JsonNode _createJson(boolean followRefs) {
+		return store.createJson(followRefs);
 	}
 
 	public void set(String key, OV overlay) {

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/coll/MapOverlay.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/coll/MapOverlay.java
@@ -115,7 +115,7 @@ public class MapOverlay<OV extends JsonOverlay<?>> extends JsonOverlay<Map<Strin
 
 	@Override
 	public JsonNode createJson() {
-		return store.toJson();
+		return store.createJson();
 	}
 
 	public void set(String key, OV overlay) {

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/coll/MapOverlay.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/coll/MapOverlay.java
@@ -14,6 +14,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 
+import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlayFactory;
@@ -85,6 +86,18 @@ public class MapOverlay<OV extends JsonOverlay<?>> extends JsonOverlay<Map<Strin
 		invalidate();
 	}
 
+	@Override
+	public JsonOverlay<?> find(JsonPointer path) {
+		if (path.matches()) {
+			return this;
+		} else if (path.mayMatchProperty()) {
+			String key = path.getMatchingProperty();
+			return containsKey(key) ? store.getOverlay(key).find(path.tail()) : null;
+		} else {
+			return null;
+		}
+	}
+	
 	public void clear() {
 		store.clear();
 		reset();

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/coll/MapOverlay.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/coll/MapOverlay.java
@@ -114,7 +114,7 @@ public class MapOverlay<OV extends JsonOverlay<?>> extends JsonOverlay<Map<Strin
 	}
 
 	@Override
-	public JsonNode createJson() {
+	public JsonNode _createJson() {
 		return store.createJson();
 	}
 

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/coll/ObjectOverlay.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/coll/ObjectOverlay.java
@@ -95,7 +95,8 @@ public abstract class ObjectOverlay<OO extends ObjectOverlay<OO>> extends JsonOv
 		private JsonPointerTrie<OverlayGetter> accessorsTrie = new JsonPointerTrie<>();
 
 		public void add(String path, String keyPattern, OverlayGetter getter) {
-			accessorsTrie.add(JsonPointer.compile("/" + path), Pattern.compile("^" + keyPattern + "$"), getter);
+			Pattern pattern = keyPattern != null ? Pattern.compile("^" + keyPattern + "$") : null;
+			accessorsTrie.add(JsonPointer.compile(path.isEmpty() ? "" : "/" + path), pattern, getter);
 		}
 		
 		public Pair<OverlayGetter, JsonPointer> find(JsonPointer path) {

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/coll/ObjectOverlay.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/coll/ObjectOverlay.java
@@ -11,7 +11,6 @@
 package com.reprezen.kaizen.oasparser.jsonoverlay.coll;
 
 import java.lang.reflect.Field;
-import java.util.Collections;
 import java.util.Map;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -24,177 +23,178 @@ import com.reprezen.kaizen.oasparser.jsonoverlay.ReferenceRegistry;
 
 public class ObjectOverlay<OO extends ObjectOverlay<OO>> extends JsonOverlay<OO> {
 
-    protected ObjectOverlay(String key, JsonNode json, JsonOverlay<?> parent, ReferenceRegistry referenceRegistry) {
-        super(key, json, parent, referenceRegistry);
-    }
-    
-    public ObjectOverlay(String key, JsonNode json, JsonOverlay<?> parent) {
-        super(key, json, parent);
-    }
+	protected ObjectOverlay(String key, JsonNode json, JsonOverlay<?> parent, ReferenceRegistry referenceRegistry) {
+		super(key, json, parent, referenceRegistry);
+	}
 
-    public ObjectOverlay(String key, JsonOverlay<?> parent) {
-        this(key, parent.getJson(key), parent);
-    }
+	public ObjectOverlay(String key, JsonNode json, JsonOverlay<?> parent) {
+		super(key, json, parent);
+	}
 
-    @Override
-    protected Iterable<? extends JsonOverlay<?>> getChildren() {
-        // TODO fix this
-        return Collections.emptyList();
-    }
+	public ObjectOverlay(String key, JsonOverlay<?> parent) {
+		this(key, parent.getJson(key), parent);
+	}
 
-    @Override
-    public boolean isMissing() {
-        return super.isMissing() || !getJson().isObject();
-    }
+	@Override
+	public boolean isMissing() {
+		return super.isMissing() || !getJson().isObject();
+	}
 
-    @Override
-    public JsonNode toJson() {
-        return getJson(); // TODO fix this
-    }
+	public JsonNode createJson() {
+		return getJson(); // TODO Fix this
+	}
 
-    @Override
-    public OO fromJson() {
-        return (OO) this; // TODO fix this
-    }
+	@Override
+	public OO fromJson() {
+		// this is never needed - the constructor of any class derived from
+		// ObjectOverlay is expected to consume its JSON object explicitly, so by the
+		// time this is called, this overlay already houses any JSON provided at time fo
+		// instantiation
+		@SuppressWarnings("unchecked")
+		OO result = (OO) this;
+		return result;
+	}
 
-    @Override
-    public void set(OO value) {
-        super.set(value);
-    }
+	@Override
+	public void set(OO value) {
+		super.set(value);
+		invalidate();
+	}
 
-    protected static <T extends ObjectOverlay<?>> boolean isEmptyRecursive(JsonOverlay<?> obj, Class<T> cls) {
-        while (obj != null) {
-            if (!obj.isMissing()) {
-                return false;
-            } else if (obj.getClass().equals(cls)) {
-                return true;
-            }
-            obj = obj.getParentOverlay();
-        }
-        return false;
-    }
+	protected static <T extends ObjectOverlay<?>> boolean isEmptyRecursive(JsonOverlay<?> obj, Class<T> cls) {
+		while (obj != null) {
+			if (!obj.isMissing()) {
+				return false;
+			} else if (obj.getClass().equals(cls)) {
+				return true;
+			}
+			obj = obj.getParentOverlay();
+		}
+		return false;
+	}
 
-    private static Map<Class<? extends ObjectOverlay<?>>, FieldData> fieldData = Maps.newHashMap();
+	private static Map<Class<? extends ObjectOverlay<?>>, FieldData> fieldData = Maps.newHashMap();
 
-    protected <T extends JsonOverlay<?>> T registerField(String path, String fieldName, String pattern, T instance) {
-        @SuppressWarnings("unchecked")
-        Class<? extends ObjectOverlay<?>> cls = (Class<? extends ObjectOverlay<?>>) getClass();
-        path = path != null ? path.replaceAll("/", ":") : null;
-        if (!fieldData.containsKey(cls)) {
-            fieldData.put(cls, new FieldData());
-        }
-        try {
-            fieldData.get(cls).add(path, fieldName, pattern, this);
-        } catch (SecurityException e) {
-            // we don't normally need this functionality except in testing, so if security manager blocks us we'll just
-            // proceed normally, and fail later if anyone tries to use the feature
-        } catch (NoSuchFieldException e) {
-            // this one we do care about - it means that the generated code is bogus
-            throw new IllegalStateException(
-                    String.format("Internal error: expected field '%s' in generated class '%s' does not exist",
-                            fieldName, getClass()),
-                    e);
-        }
-        return instance;
-    }
+	protected <T extends JsonOverlay<?>> T registerField(String path, String fieldName, String pattern, T instance) {
+		@SuppressWarnings("unchecked")
+		Class<? extends ObjectOverlay<?>> cls = (Class<? extends ObjectOverlay<?>>) getClass();
+		path = path != null ? path.replaceAll("/", ":") : null;
+		if (!fieldData.containsKey(cls)) {
+			fieldData.put(cls, new FieldData());
+		}
+		try {
+			fieldData.get(cls).add(path, fieldName, pattern, this);
+		} catch (SecurityException e) {
+			// we don't normally need this functionality except in testing, so if security
+			// manager blocks us we'll just
+			// proceed normally, and fail later if anyone tries to use the feature
+		} catch (NoSuchFieldException e) {
+			// this one we do care about - it means that the generated code is bogus
+			throw new IllegalStateException(
+					String.format("Internal error: expected field '%s' in generated class '%s' does not exist",
+							fieldName, getClass()),
+					e);
+		}
+		return instance;
+	}
 
-    public Optional<JsonOverlay<?>> getFieldValue(String path) throws IllegalArgumentException, IllegalAccessException {
-        @SuppressWarnings("unchecked")
-        Class<? extends ObjectOverlay<?>> cls = (Class<? extends ObjectOverlay<?>>) getClass();
-        if (fieldData.containsKey(cls)) {
-            return fieldData.get(cls).getFieldValue(path, this);
-        } else {
-            return Optional.absent();
-        }
-    }
+	public Optional<JsonOverlay<?>> getFieldValue(String path) throws IllegalArgumentException, IllegalAccessException {
+		@SuppressWarnings("unchecked")
+		Class<? extends ObjectOverlay<?>> cls = (Class<? extends ObjectOverlay<?>>) getClass();
+		if (fieldData.containsKey(cls)) {
+			return fieldData.get(cls).getFieldValue(path, this);
+		} else {
+			return Optional.absent();
+		}
+	}
 
-    private static class FieldData {
-        Multimap<String, FieldDataItem> itemsByPath = HashMultimap.create();
+	private static class FieldData {
+		Multimap<String, FieldDataItem> itemsByPath = HashMultimap.create();
 
-        public void add(String path, String fieldName, String pattern, ObjectOverlay<?> overlay)
-                throws NoSuchFieldException, SecurityException {
-            itemsByPath.put(path, new FieldDataItem(fieldName, overlay));
-        }
+		public void add(String path, String fieldName, String pattern, ObjectOverlay<?> overlay)
+				throws NoSuchFieldException, SecurityException {
+			itemsByPath.put(path, new FieldDataItem(fieldName, overlay));
+		}
 
-        public Optional<JsonOverlay<?>> getFieldValue(String path, ObjectOverlay<?> overlay)
-                throws IllegalArgumentException, IllegalAccessException {
-            if (itemsByPath.containsKey(path)) {
-                for (FieldDataItem item : itemsByPath.get(path)) {
-                    Optional<JsonOverlay<?>> value = item.getFieldValue(path, overlay);
-                    if (value.isPresent()) {
-                        return value;
-                    }
-                }
-            } else {
-                for (FieldDataItem item : itemsByPath.get(removeKey(path))) {
-                    Optional<JsonOverlay<?>> value = item.getFieldValue(path, overlay);
-                    if (value.isPresent()) {
-                        return value;
-                    }
-                }
-            }
-            return Optional.absent();
-        }
+		public Optional<JsonOverlay<?>> getFieldValue(String path, ObjectOverlay<?> overlay)
+				throws IllegalArgumentException, IllegalAccessException {
+			if (itemsByPath.containsKey(path)) {
+				for (FieldDataItem item : itemsByPath.get(path)) {
+					Optional<JsonOverlay<?>> value = item.getFieldValue(path, overlay);
+					if (value.isPresent()) {
+						return value;
+					}
+				}
+			} else {
+				for (FieldDataItem item : itemsByPath.get(removeKey(path))) {
+					Optional<JsonOverlay<?>> value = item.getFieldValue(path, overlay);
+					if (value.isPresent()) {
+						return value;
+					}
+				}
+			}
+			return Optional.absent();
+		}
 
-        private String removeKey(String path) {
-            int lastColon = path.lastIndexOf(':');
-            if (lastColon >= 0) {
-                return path.substring(0, lastColon);
-            } else {
-                return "";
-            }
-        }
-    }
+		private String removeKey(String path) {
+			int lastColon = path.lastIndexOf(':');
+			if (lastColon >= 0) {
+				return path.substring(0, lastColon);
+			} else {
+				return "";
+			}
+		}
+	}
 
-    private static class FieldDataItem {
-        private Field field;
+	private static class FieldDataItem {
+		private Field field;
 
-        public FieldDataItem(String fieldName, ObjectOverlay<?> overlay)
-                throws NoSuchFieldException, SecurityException {
-            super();
-            this.field = findField(overlay, fieldName);
-            this.field.setAccessible(true);
-        }
+		public FieldDataItem(String fieldName, ObjectOverlay<?> overlay)
+				throws NoSuchFieldException, SecurityException {
+			super();
+			this.field = findField(overlay, fieldName);
+			this.field.setAccessible(true);
+		}
 
-        private Field findField(ObjectOverlay<?> overlay, String fieldName) throws NoSuchFieldException {
-            Class<?> cls = overlay.getClass();
-            NoSuchFieldException nsf = null;
-            while (ObjectOverlay.class.isAssignableFrom(cls)) {
-                try {
-                    return cls.getDeclaredField(fieldName);
-                } catch (NoSuchFieldException e) {
-                    if (nsf == null) {
-                        nsf = e;
-                    }
-                    cls = cls.getSuperclass();
-                }
-            }
-            throw nsf;
-        }
+		private Field findField(ObjectOverlay<?> overlay, String fieldName) throws NoSuchFieldException {
+			Class<?> cls = overlay.getClass();
+			NoSuchFieldException nsf = null;
+			while (ObjectOverlay.class.isAssignableFrom(cls)) {
+				try {
+					return cls.getDeclaredField(fieldName);
+				} catch (NoSuchFieldException e) {
+					if (nsf == null) {
+						nsf = e;
+					}
+					cls = cls.getSuperclass();
+				}
+			}
+			throw nsf;
+		}
 
-        public Optional<JsonOverlay<?>> getFieldValue(String path, ObjectOverlay<?> overlay)
-                throws IllegalArgumentException, IllegalAccessException {
-            JsonOverlay<?> fieldValue = (JsonOverlay<?>) field.get(overlay);
-            if (fieldValue != null) {
-                if (fieldValue instanceof MapOverlay || fieldValue instanceof ValMapOverlay) {
-                    String key = getKey(path);
-                    if (key != null) {
-                        CollectionStore<?> store = ((CollectionOverlay<?>) fieldValue).getStore();
-                        JsonOverlay<?> keyedValue = store.getOverlay(key);
-                        if (keyedValue != null) {
-                            return Optional.<JsonOverlay<?>> of(keyedValue);
-                        }
-                    }
-                } else {
-                    return Optional.<JsonOverlay<?>> of(fieldValue);
-                }
-            }
-            return Optional.absent();
-        }
+		public Optional<JsonOverlay<?>> getFieldValue(String path, ObjectOverlay<?> overlay)
+				throws IllegalArgumentException, IllegalAccessException {
+			JsonOverlay<?> fieldValue = (JsonOverlay<?>) field.get(overlay);
+			if (fieldValue != null) {
+				if (fieldValue instanceof MapOverlay || fieldValue instanceof ValMapOverlay) {
+					String key = getKey(path);
+					if (key != null) {
+						CollectionStore<?> store = ((CollectionOverlay<?>) fieldValue).getStore();
+						JsonOverlay<?> keyedValue = store.getOverlay(key);
+						if (keyedValue != null) {
+							return Optional.<JsonOverlay<?>>of(keyedValue);
+						}
+					}
+				} else {
+					return Optional.<JsonOverlay<?>>of(fieldValue);
+				}
+			}
+			return Optional.absent();
+		}
 
-        private String getKey(String path) {
-            int lastColon = path.lastIndexOf(':');
-            return lastColon >= 0 ? path.substring(lastColon + 1) : path;
-        }
-    }
+		private String getKey(String path) {
+			int lastColon = path.lastIndexOf(':');
+			return lastColon >= 0 ? path.substring(lastColon + 1) : path;
+		}
+	}
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/coll/ObjectOverlay.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/coll/ObjectOverlay.java
@@ -197,4 +197,22 @@ public class ObjectOverlay<OO extends ObjectOverlay<OO>> extends JsonOverlay<OO>
 			return lastColon >= 0 ? path.substring(lastColon + 1) : path;
 		}
 	}
+
+	protected static class PropertyAccessors {
+		public PropertyAccessors() {
+		}
+
+		public void add(String path, Getter getter) {
+		}
+	}
+
+	protected static class PropertyAccessor {
+		public PropertyAccessor(String path, Getter getter) {
+
+		}
+	}
+
+	protected interface Getter {
+		public JsonOverlay<?> get();
+	}
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/coll/ObjectOverlay.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/coll/ObjectOverlay.java
@@ -47,7 +47,7 @@ public abstract class ObjectOverlay<OO extends ObjectOverlay<OO>> extends JsonOv
 		return super.isMissing() || !getJson().isObject();
 	}
 
-	public JsonNode createJson() {
+	public JsonNode _createJson() {
 		ObjectNode obj = JsonNodeFactory.instance.objectNode();
 		List<PropertyAccessor> accessorList = this.accessors.getPropertyAccessors();
 		for (PropertyAccessor accessor : accessorList) {

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/coll/ObjectOverlay.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/coll/ObjectOverlay.java
@@ -47,21 +47,21 @@ public abstract class ObjectOverlay<OO extends ObjectOverlay<OO>> extends JsonOv
 		return super.isMissing() || !getJson().isObject();
 	}
 
-	public JsonNode _createJson() {
+	public JsonNode _createJson(boolean followRefs) {
 		ObjectNode obj = JsonNodeFactory.instance.objectNode();
 		List<PropertyAccessor> accessorList = this.accessors.getPropertyAccessors();
 		for (PropertyAccessor accessor : accessorList) {
 			JsonOverlay<?> value = accessor.get();
 			if (value != null && !value.isMissing()) {
 				JsonPointer path = accessor.getPath();
-				JsonNode json = value.createJson();
+				JsonNode json = value.createJson(followRefs);
 				boolean merge = accessor.getKeyPattern() != null;
 				// how to handle property accessors with empty parent path:
-				// - an object property that has a key pattern has its values merged into an
+				// * an object property that has a key pattern has its values merged into an
 				//// accumulating object; typically there will be other such accessors, and/or
 				//// other accessors with a non-empty parent path, and the accumulation is the
 				//// final created JSON value
-				// - any other value (not an object, or an object without a key pattern) is
+				// * any other value (not an object, or an object without a key pattern) is
 				//// returned as the overall created JSON value, all by itself. It is an error
 				//// for there to be ANY other accessor in this case
 				if (path.matches()) {
@@ -69,7 +69,8 @@ public abstract class ObjectOverlay<OO extends ObjectOverlay<OO>> extends JsonOv
 						obj.setAll((ObjectNode) json);
 					} else {
 						if (accessorList.size() > 1) {
-							throw new IllegalStateException("Whole-value property accessor may not coexist with other accessors");
+							throw new IllegalStateException(
+									"Whole-value property accessor may not coexist with other accessors");
 						}
 						return json;
 					}

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/coll/ObjectOverlay.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/coll/ObjectOverlay.java
@@ -10,25 +10,27 @@
  *******************************************************************************/
 package com.reprezen.kaizen.oasparser.jsonoverlay.coll;
 
-import java.lang.reflect.Field;
-import java.util.Map;
+import java.util.regex.Pattern;
 
+import org.apache.commons.lang3.tuple.Pair;
+
+import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.google.common.base.Optional;
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Multimap;
 import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ReferenceRegistry;
 
-public class ObjectOverlay<OO extends ObjectOverlay<OO>> extends JsonOverlay<OO> {
+public abstract class ObjectOverlay<OO extends ObjectOverlay<OO>> extends JsonOverlay<OO> {
+
+	private PropertyAccessors accessors = new PropertyAccessors();
 
 	protected ObjectOverlay(String key, JsonNode json, JsonOverlay<?> parent, ReferenceRegistry referenceRegistry) {
 		super(key, json, parent, referenceRegistry);
+		installPropertyAccessors(this.accessors);
 	}
 
 	public ObjectOverlay(String key, JsonNode json, JsonOverlay<?> parent) {
 		super(key, json, parent);
+		installPropertyAccessors(this.accessors);
 	}
 
 	public ObjectOverlay(String key, JsonOverlay<?> parent) {
@@ -73,146 +75,35 @@ public class ObjectOverlay<OO extends ObjectOverlay<OO>> extends JsonOverlay<OO>
 		return false;
 	}
 
-	private static Map<Class<? extends ObjectOverlay<?>>, FieldData> fieldData = Maps.newHashMap();
-
-	protected <T extends JsonOverlay<?>> T registerField(String path, String fieldName, String pattern, T instance) {
-		@SuppressWarnings("unchecked")
-		Class<? extends ObjectOverlay<?>> cls = (Class<? extends ObjectOverlay<?>>) getClass();
-		path = path != null ? path.replaceAll("/", ":") : null;
-		if (!fieldData.containsKey(cls)) {
-			fieldData.put(cls, new FieldData());
-		}
-		try {
-			fieldData.get(cls).add(path, fieldName, pattern, this);
-		} catch (SecurityException e) {
-			// we don't normally need this functionality except in testing, so if security
-			// manager blocks us we'll just
-			// proceed normally, and fail later if anyone tries to use the feature
-		} catch (NoSuchFieldException e) {
-			// this one we do care about - it means that the generated code is bogus
-			throw new IllegalStateException(
-					String.format("Internal error: expected field '%s' in generated class '%s' does not exist",
-							fieldName, getClass()),
-					e);
-		}
-		return instance;
-	}
-
-	public Optional<JsonOverlay<?>> getFieldValue(String path) throws IllegalArgumentException, IllegalAccessException {
-		@SuppressWarnings("unchecked")
-		Class<? extends ObjectOverlay<?>> cls = (Class<? extends ObjectOverlay<?>>) getClass();
-		if (fieldData.containsKey(cls)) {
-			return fieldData.get(cls).getFieldValue(path, this);
+	protected abstract void installPropertyAccessors(PropertyAccessors accessors);
+	
+	@Override
+	public JsonOverlay<?> find(JsonPointer path) {
+		if (path.matches()) {
+			return this;
 		} else {
-			return Optional.absent();
-		}
-	}
-
-	private static class FieldData {
-		Multimap<String, FieldDataItem> itemsByPath = HashMultimap.create();
-
-		public void add(String path, String fieldName, String pattern, ObjectOverlay<?> overlay)
-				throws NoSuchFieldException, SecurityException {
-			itemsByPath.put(path, new FieldDataItem(fieldName, overlay));
-		}
-
-		public Optional<JsonOverlay<?>> getFieldValue(String path, ObjectOverlay<?> overlay)
-				throws IllegalArgumentException, IllegalAccessException {
-			if (itemsByPath.containsKey(path)) {
-				for (FieldDataItem item : itemsByPath.get(path)) {
-					Optional<JsonOverlay<?>> value = item.getFieldValue(path, overlay);
-					if (value.isPresent()) {
-						return value;
-					}
-				}
+			Pair<OverlayGetter, JsonPointer> result = accessors.find(path);
+			if (result.getLeft() != null) {
+				return result.getLeft().get().find(result.getRight());
 			} else {
-				for (FieldDataItem item : itemsByPath.get(removeKey(path))) {
-					Optional<JsonOverlay<?>> value = item.getFieldValue(path, overlay);
-					if (value.isPresent()) {
-						return value;
-					}
-				}
+				return null;
 			}
-			return Optional.absent();
-		}
-
-		private String removeKey(String path) {
-			int lastColon = path.lastIndexOf(':');
-			if (lastColon >= 0) {
-				return path.substring(0, lastColon);
-			} else {
-				return "";
-			}
-		}
-	}
-
-	private static class FieldDataItem {
-		private Field field;
-
-		public FieldDataItem(String fieldName, ObjectOverlay<?> overlay)
-				throws NoSuchFieldException, SecurityException {
-			super();
-			this.field = findField(overlay, fieldName);
-			this.field.setAccessible(true);
-		}
-
-		private Field findField(ObjectOverlay<?> overlay, String fieldName) throws NoSuchFieldException {
-			Class<?> cls = overlay.getClass();
-			NoSuchFieldException nsf = null;
-			while (ObjectOverlay.class.isAssignableFrom(cls)) {
-				try {
-					return cls.getDeclaredField(fieldName);
-				} catch (NoSuchFieldException e) {
-					if (nsf == null) {
-						nsf = e;
-					}
-					cls = cls.getSuperclass();
-				}
-			}
-			throw nsf;
-		}
-
-		public Optional<JsonOverlay<?>> getFieldValue(String path, ObjectOverlay<?> overlay)
-				throws IllegalArgumentException, IllegalAccessException {
-			JsonOverlay<?> fieldValue = (JsonOverlay<?>) field.get(overlay);
-			if (fieldValue != null) {
-				if (fieldValue instanceof MapOverlay || fieldValue instanceof ValMapOverlay) {
-					String key = getKey(path);
-					if (key != null) {
-						CollectionStore<?> store = ((CollectionOverlay<?>) fieldValue).getStore();
-						JsonOverlay<?> keyedValue = store.getOverlay(key);
-						if (keyedValue != null) {
-							return Optional.<JsonOverlay<?>>of(keyedValue);
-						}
-					}
-				} else {
-					return Optional.<JsonOverlay<?>>of(fieldValue);
-				}
-			}
-			return Optional.absent();
-		}
-
-		private String getKey(String path) {
-			int lastColon = path.lastIndexOf(':');
-			return lastColon >= 0 ? path.substring(lastColon + 1) : path;
 		}
 	}
 
 	protected static class PropertyAccessors {
-		public PropertyAccessors() {
+		private JsonPointerTrie<OverlayGetter> accessorsTrie = new JsonPointerTrie<>();
+
+		public void add(String path, String keyPattern, OverlayGetter getter) {
+			accessorsTrie.add(JsonPointer.compile("/" + path), Pattern.compile("^" + keyPattern + "$"), getter);
 		}
-
-		public void add(String path, Getter getter) {
-		}
-	}
-
-	protected static class PropertyAccessor {
-		public PropertyAccessor(String path, Getter getter) {
-
+		
+		public Pair<OverlayGetter, JsonPointer> find(JsonPointer path) {
+			return accessorsTrie.find(path);
 		}
 	}
-
-	protected interface Getter {
+	
+	protected interface OverlayGetter {
 		public JsonOverlay<?> get();
 	}
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/coll/ValListOverlay.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/coll/ValListOverlay.java
@@ -20,127 +20,131 @@ import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlayFactory;
 
 public class ValListOverlay<V, OV extends JsonOverlay<V>> extends JsonOverlay<Collection<V>>
-        implements CollectionOverlay<OV> {
+		implements CollectionOverlay<OV> {
 
-    private JsonOverlayFactory<OV> factory;
-    private final CollectionStore<OV> store = new CollectionStore<OV>(this);
+	private JsonOverlayFactory<OV> factory;
+	private final CollectionStore<OV> store = new CollectionStore<OV>(this);
 
-    private Map<String, V> values = Maps.newLinkedHashMap();
+	private Map<String, V> values = Maps.newLinkedHashMap();
 
-    private ValListOverlay(String key, JsonOverlayFactory<OV> factory, JsonOverlay<?> parent) {
-        // we'd normally put factory at the end for this constructor, but then it'd clash with another
-        super(key, (Collection<V>) null, parent);
-        this.factory = factory;
-    }
+	private ValListOverlay(String key, JsonOverlayFactory<OV> factory, JsonOverlay<?> parent) {
+		// we'd normally put factory at the end for this constructor, but then it'd
+		// clash with another
+		super(key, (Collection<V>) null, parent);
+		this.factory = factory;
+	}
 
-    public ValListOverlay(String key, Collection<V> values, JsonOverlay<?> parent, JsonOverlayFactory<OV> factory) {
-        this(key, factory, parent);
-        store.init(true, null).load(CollectionData.<V, OV> of(values, factory));
-        reset();
-    }
+	public ValListOverlay(String key, Collection<V> values, JsonOverlay<?> parent, JsonOverlayFactory<OV> factory) {
+		this(key, factory, parent);
+		store.init(true, null).load(CollectionData.<V, OV>of(values, factory));
+		reset();
+	}
 
-    public ValListOverlay(String key, JsonNode json, JsonOverlay<?> parent, JsonOverlayFactory<OV> factory) {
-        this(key, factory, parent);
-        store.init(true, null).load(CollectionData.of(json, parent, factory));
-        reset();
-    }
+	public ValListOverlay(String key, JsonNode json, JsonOverlay<?> parent, JsonOverlayFactory<OV> factory) {
+		this(key, factory, parent);
+		store.init(true, null).load(CollectionData.of(json, parent, factory));
+		reset();
+	}
 
-    public ValListOverlay(String key, JsonOverlay<?> parent, JsonOverlayFactory<OV> factory) {
-        this(key, factory, parent);
-        store.init(true, null).load(CollectionData.of(parent.getResolvedJson(key), parent, factory));
-        reset();
-    }
+	public ValListOverlay(String key, JsonOverlay<?> parent, JsonOverlayFactory<OV> factory) {
+		this(key, factory, parent);
+		store.init(true, null).load(CollectionData.of(parent.getResolvedJson(key), parent, factory));
+		reset();
+	}
 
-    @Override
-    public boolean isMissing() {
-        return super.isMissing() || !getJson().isArray();
-    }
+	@Override
+	public boolean isMissing() {
+		return super.isMissing() || !getJson().isArray();
+	}
 
-    private void reset() {
-        values.clear();
-        for (OV overlay : store.getOverlays()) {
-            values.put(overlay.getKey(), overlay.get());
-        }
-        super.set(values.values());
-    }
+	private void reset() {
+		values.clear();
+		for (OV overlay : store.getOverlays()) {
+			values.put(overlay.getKey(), overlay.get());
+		}
+		super.set(values.values());
+	}
 
-    @Override
-    protected Collection<? extends JsonOverlay<?>> getChildren() {
-        return store != null ? store.getOverlays() : Collections.<OV> emptyList();
-    }
+	public V get(int index) {
+		return store.get(index).get();
+	}
 
-    public V get(int index) {
-        return store.get(index).get();
-    }
+	public Collection<OV> getOverlays() {
+		return store.getOverlays();
+	}
 
-    public Collection<OV> getOverlays() {
-        return store.getOverlays();
-    }
+	@Override
+	public void set(Collection<V> values) {
+		store.clear();
+		for (V value : values) {
+			store.add(createOverlay(value));
+		}
+		reset();
+		invalidate();
+	}
 
-    @Override
-    public void set(Collection<V> values) {
-        store.clear();
-        for (V value : values) {
-            store.add(createOverlay(value));
-        }
-        reset();
-    }
+	public void set(int index, V value) {
+		store.replace(index, createOverlay(value));
+		reset();
+		invalidate();
+	}
 
-    public void set(int index, V value) {
-        store.replace(index, createOverlay(value));
-        reset();
-    }
+	public void clear() {
+		store.clear();
+		reset();
+		invalidate();
+	}
 
-    public void clear() {
-        store.clear();
-        reset();
-    }
+	public int size() {
+		return store.size();
+	}
 
-    public int size() {
-        return store.size();
-    }
+	@Override
+	public Collection<V> fromJson() {
+		return values != null ? values.values() : Collections.<V>emptyList();
+	}
 
-    @Override
-    public Collection<V> fromJson() {
-        return values != null ? values.values() : Collections.<V> emptyList();
-    }
+	@Override
+	public JsonNode createJson() {
+		return store.toJson();
+	}
 
-    @Override
-    public JsonNode toJson() {
-        return store.toJson();
-    }
+	public void add(V value) {
+		store.add(createOverlay(value));
+		reset();
+		invalidate();
+	}
 
-    public void add(V value) {
-        store.add(createOverlay(value));
-        reset();
-    }
+	public void add(String key, V value) {
+		store.add(key, createOverlay(value));
+		reset();
+		invalidate();
+	}
 
-    public void add(String key, V value) {
-        store.add(key, createOverlay(value));
-        reset();
-    }
+	public void remove(String key) {
+		store.remove(key);
+		reset();
+		invalidate();
+	}
 
-    public void remove(String key) {
-        store.remove(key);
-        reset();
-    }
+	public void remove(int index) {
+		store.remove(index);
+		reset();
+		invalidate();
+	}
 
-    public void remove(int index) {
-        store.remove(index);
-        reset();
-    }
+	public void replace(String key, V value) {
+		store.replace(key, createOverlay(value));
+		reset();
+		invalidate();
+	}
 
-    public void replace(String key, V value) {
-        store.replace(key, createOverlay(value));
-        reset();
-    }
+	private OV createOverlay(V value) {
+		return factory.create(null, value, this);
+	}
 
-    private OV createOverlay(V value) {
-        return factory.create(null, value, this);
-    }
-
-    @Override
-    public CollectionStore<OV> getStore() {
-        return store;
-    }
+	@Override
+	public CollectionStore<OV> getStore() {
+		return store;
+	}
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/coll/ValListOverlay.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/coll/ValListOverlay.java
@@ -118,7 +118,7 @@ public class ValListOverlay<V, OV extends JsonOverlay<V>> extends JsonOverlay<Co
 	}
 
 	@Override
-	public JsonNode createJson() {
+	public JsonNode _createJson() {
 		return store.createJson();
 	}
 

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/coll/ValListOverlay.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/coll/ValListOverlay.java
@@ -119,7 +119,7 @@ public class ValListOverlay<V, OV extends JsonOverlay<V>> extends JsonOverlay<Co
 
 	@Override
 	public JsonNode createJson() {
-		return store.toJson();
+		return store.createJson();
 	}
 
 	public void add(V value) {

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/coll/ValListOverlay.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/coll/ValListOverlay.java
@@ -14,6 +14,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 
+import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.Maps;
 import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
@@ -87,6 +88,18 @@ public class ValListOverlay<V, OV extends JsonOverlay<V>> extends JsonOverlay<Co
 		store.replace(index, createOverlay(value));
 		reset();
 		invalidate();
+	}
+
+	@Override
+	public JsonOverlay<?> find(JsonPointer path) {
+		if (path.matches()) {
+			return this;
+		} else if (path.mayMatchElement()) {
+			int index = path.getMatchingIndex();
+			return size() > index ? store.get(index).find(path.tail()) : null;
+		} else {
+			return null;
+		}
 	}
 
 	public void clear() {

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/coll/ValListOverlay.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/coll/ValListOverlay.java
@@ -118,8 +118,8 @@ public class ValListOverlay<V, OV extends JsonOverlay<V>> extends JsonOverlay<Co
 	}
 
 	@Override
-	public JsonNode _createJson() {
-		return store.createJson();
+	public JsonNode _createJson(boolean followRefs) {
+		return store.createJson(followRefs);
 	}
 
 	public void add(V value) {

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/coll/ValMapOverlay.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/coll/ValMapOverlay.java
@@ -21,151 +21,155 @@ import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlayFactory;
 
 public class ValMapOverlay<V, OV extends JsonOverlay<V>> extends JsonOverlay<Map<String, V>>
-        implements CollectionOverlay<OV> {
-    private JsonOverlayFactory<OV> factory;
-    private final CollectionStore<OV> store = new CollectionStore<OV>(this);
-    private Map<String, V> values = Maps.newLinkedHashMap();
+		implements CollectionOverlay<OV> {
+	private JsonOverlayFactory<OV> factory;
+	private final CollectionStore<OV> store = new CollectionStore<OV>(this);
+	private Map<String, V> values = Maps.newLinkedHashMap();
 
-    private ValMapOverlay(String key, JsonOverlayFactory<OV> factory, JsonOverlay<?> parent) {
-        super(key, (Map<String, V>) null, parent);
-        this.factory = factory;
-    }
+	private ValMapOverlay(String key, JsonOverlayFactory<OV> factory, JsonOverlay<?> parent) {
+		super(key, (Map<String, V>) null, parent);
+		this.factory = factory;
+	}
 
-    public ValMapOverlay(String key, Map<String, V> valueMap, JsonOverlay<?> parent, JsonOverlayFactory<OV> factory,
-            String keyPat) {
-        this(key, factory, parent);
-        store.init(false, keyPat).load(CollectionData.of(valueMap, factory));
-        reset();
-    }
+	public ValMapOverlay(String key, Map<String, V> valueMap, JsonOverlay<?> parent, JsonOverlayFactory<OV> factory,
+			String keyPat) {
+		this(key, factory, parent);
+		store.init(false, keyPat).load(CollectionData.of(valueMap, factory));
+		reset();
+	}
 
-    public ValMapOverlay(String key, JsonNode json, JsonOverlay<?> parent, JsonOverlayFactory<OV> factory,
-            String keyPat) {
-        this(key, factory, parent);
-        store.init(false, keyPat).load(CollectionData.of(json, parent, factory));
-        reset();
-    }
+	public ValMapOverlay(String key, JsonNode json, JsonOverlay<?> parent, JsonOverlayFactory<OV> factory,
+			String keyPat) {
+		this(key, factory, parent);
+		store.init(false, keyPat).load(CollectionData.of(json, parent, factory));
+		reset();
+	}
 
-    public ValMapOverlay(String key, JsonOverlay<?> parent, JsonOverlayFactory<OV> factory, String keyPat) {
-        this(key, factory, parent);
-        store.init(false, keyPat).load(CollectionData.of(parent.getResolvedJson(key), parent, factory));
-        reset();
-    }
+	public ValMapOverlay(String key, JsonOverlay<?> parent, JsonOverlayFactory<OV> factory, String keyPat) {
+		this(key, factory, parent);
+		store.init(false, keyPat).load(CollectionData.of(parent.getResolvedJson(key), parent, factory));
+		reset();
+	}
 
-    private void reset() {
-        super.set(getFromStore());
-    }
+	private void reset() {
+		super.set(getFromStore());
+	}
 
-    @Override
-    public boolean isMissing() {
-        return super.isMissing() || !getJson().isObject();
-    }
+	@Override
+	public boolean isMissing() {
+		return super.isMissing() || !getJson().isObject();
+	}
 
-    private Map<String, V> getFromStore() {
-        values.clear();
-        for (Entry<String, OV> entry : store.getOverlayMap().entrySet()) {
-            values.put(entry.getKey(), entry.getValue().get());
-        }
-        return values;
-    }
+	private Map<String, V> getFromStore() {
+		values.clear();
+		for (Entry<String, OV> entry : store.getOverlayMap().entrySet()) {
+			values.put(entry.getKey(), entry.getValue().get());
+		}
+		return values;
+	}
 
-    @Override
-    protected Collection<? extends JsonOverlay<?>> getChildren() {
-        return store != null ? store.getOverlays() : Collections.<OV> emptyList();
-    }
+	public Map<String, OV> getOverlayMap() {
+		return store.getOverlayMap();
+	}
 
-    public Map<String, OV> getOverlayMap() {
-        return store.getOverlayMap();
-    }
+	public Collection<OV> getOverlays() {
+		return store.getOverlays();
+	}
 
-    public Collection<OV> getOverlays() {
-        return store.getOverlays();
-    }
+	public Collection<V> getValues() {
+		return values.values();
+	}
 
-    public Collection<V> getValues() {
-        return values.values();
-    }
+	public V get(String key) {
+		return values.get(key);
+	}
 
-    public V get(String key) {
-        return values.get(key);
-    }
+	public boolean containsKey(String key) {
+		return values.containsKey(key);
+	}
 
-    public boolean containsKey(String key) {
-        return values.containsKey(key);
-    }
+	@Override
+	public void set(Map<String, V> valueMap) {
+		store.clear();
+		for (Entry<String, V> entry : valueMap.entrySet()) {
+			store.add(entry.getKey(), createOverlay(entry.getValue()));
+		}
+		reset();
+		invalidate();
+	}
 
-    @Override
-    public void set(Map<String, V> valueMap) {
-        store.clear();
-        for (Entry<String, V> entry : valueMap.entrySet()) {
-            store.add(entry.getKey(), createOverlay(entry.getValue()));
-        }
-        reset();
-    }
+	public void set(String key, V value) {
+		OV overlay = createOverlay(value);
+		if (containsKey(key)) {
+			store.replace(key, overlay);
+		} else {
+			store.add(key, overlay);
+		}
+		invalidate();
+	}
 
-    public void set(String key, V value) {
-        OV overlay = createOverlay(value);
-        if (containsKey(key)) {
-            store.replace(key, overlay);
-        } else {
-            store.add(key, overlay);
-        }
-    }
+	public void set(Collection<OV> overlays) {
+		store.set(overlays);
+		reset();
+		invalidate();
+	}
 
-    public void set(Collection<OV> overlays) {
-        store.set(overlays);
-        reset();
-    }
+	public void clear() {
+		store.clear();
+		reset();
+		invalidate();
+	}
 
-    public void clear() {
-        store.clear();
-        reset();
-    }
+	public int size() {
+		return store.size();
+	}
 
-    public int size() {
-        return store.size();
-    }
+	@Override
+	public Map<String, V> fromJson() {
+		return values != null ? values : Collections.<String, V>emptyMap();
+	}
 
-    @Override
-    public Map<String, V> fromJson() {
-        return values != null ? values : Collections.<String, V> emptyMap();
-    }
+	@Override
+	public JsonNode createJson() {
+		return store.toJson();
+	}
 
-    @Override
-    public JsonNode toJson() {
-        return store.toJson();
-    }
+	public void add(String key, V value) {
+		store.add(key, createOverlay(value));
+		reset();
+		invalidate();
+	}
 
-    public void add(String key, V value) {
-        store.add(key, createOverlay(value));
-        reset();
-    }
+	public void remove(String key) {
+		store.remove(key);
+		reset();
+		invalidate();
+	}
 
-    public void remove(String key) {
-        store.remove(key);
-        reset();
-    }
+	public void remove(int index) {
+		store.remove(index);
+		reset();
+		invalidate();
+	}
 
-    public void remove(int index) {
-        store.remove(index);
-        reset();
-    }
+	public void replace(String key, V value) {
+		store.replace(key, createOverlay(value));
+		reset();
+		invalidate();
+	}
 
-    public void replace(String key, V value) {
-        store.replace(key, createOverlay(value));
-        reset();
-    }
+	public void replace(int index, V value) {
+		store.replace(index, factory.create(null, value, parent));
+		reset();
+		invalidate();
+	}
 
-    public void replace(int index, V value) {
-        store.replace(index, factory.create(null, value, parent));
-        reset();
-    }
+	private OV createOverlay(V value) {
+		return factory.create(null, value, this);
+	}
 
-    private OV createOverlay(V value) {
-        return factory.create(null, value, this);
-    }
-
-    @Override
-    public CollectionStore<OV> getStore() {
-        return store;
-    }
+	@Override
+	public CollectionStore<OV> getStore() {
+		return store;
+	}
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/coll/ValMapOverlay.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/coll/ValMapOverlay.java
@@ -144,7 +144,7 @@ public class ValMapOverlay<V, OV extends JsonOverlay<V>> extends JsonOverlay<Map
 
 	@Override
 	public JsonNode createJson() {
-		return store.toJson();
+		return store.createJson();
 	}
 
 	public void add(String key, V value) {

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/coll/ValMapOverlay.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/coll/ValMapOverlay.java
@@ -15,6 +15,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.Maps;
 import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
@@ -112,6 +113,18 @@ public class ValMapOverlay<V, OV extends JsonOverlay<V>> extends JsonOverlay<Map
 		store.set(overlays);
 		reset();
 		invalidate();
+	}
+
+	@Override
+	public JsonOverlay<?> find(JsonPointer path) {
+		if (path.matches()) {
+			return this;
+		} else if (path.mayMatchProperty()) {
+			String key = path.getMatchingProperty();
+			return containsKey(key) ? store.getOverlay(key).find(path.tail()) : null;
+		} else {
+			return null;
+		}
 	}
 
 	public void clear() {

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/coll/ValMapOverlay.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/coll/ValMapOverlay.java
@@ -143,8 +143,8 @@ public class ValMapOverlay<V, OV extends JsonOverlay<V>> extends JsonOverlay<Map
 	}
 
 	@Override
-	public JsonNode _createJson() {
-		return store.createJson();
+	public JsonNode _createJson(boolean followRefs) {
+		return store.createJson(followRefs);
 	}
 
 	public void add(String key, V value) {

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/coll/ValMapOverlay.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/coll/ValMapOverlay.java
@@ -143,7 +143,7 @@ public class ValMapOverlay<V, OV extends JsonOverlay<V>> extends JsonOverlay<Map
 	}
 
 	@Override
-	public JsonNode createJson() {
+	public JsonNode _createJson() {
 		return store.createJson();
 	}
 

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/gen/ImplGenerator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/gen/ImplGenerator.java
@@ -14,6 +14,7 @@ import static com.reprezen.kaizen.oasparser.jsonoverlay.gen.Template.t;
 
 import java.io.File;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.lang3.StringUtils;
@@ -34,260 +35,246 @@ import com.reprezen.kaizen.oasparser.ovl3.OpenApiObjectImpl;
 
 public class ImplGenerator extends TypeGenerator {
 
-    public ImplGenerator(File dir, String intfPackage, String implPackage, String suffix, boolean preserve) {
-        super(dir, intfPackage, implPackage, suffix, preserve);
-    }
+	public ImplGenerator(File dir, String intfPackage, String implPackage, String suffix, boolean preserve) {
+		super(dir, intfPackage, implPackage, suffix, preserve);
+	}
 
-    @Override
-    protected String getPackage() {
-        return implPackage;
-    }
+	@Override
+	protected String getPackage() {
+		return implPackage;
+	}
 
-    @Override
-    protected Collection<String> getImports(Type type) {
-        return type.getRequiredImports("impl");
-    }
+	@Override
+	protected Collection<String> getImports(Type type) {
+		return type.getRequiredImports("impl");
+	}
 
-    @Override
-    public void addGeneratedMembers(Type type, SimpleJavaGenerator gen) {
-        super.addGeneratedMembers(type, gen);
-        gen.addMember(getFactoryMethod(type));
-    }
+	@Override
+	public Members getOtherMembers(Type type) {
+		Members members = new Members();
+		members.add(getFactoryMethod(type));
+		members.addAll(getPropertyAccessorMembers(type));
+		return members;
+	}
 
-    @Override
-    public String getTypeDeclaration(Type type, String suffix) {
-        requireTypes(OpenApiObjectImpl.class);
-        requireTypes(type);
-        return t("public class ${name}${0} extends ${1} implements ${name}", type, suffix, getSuperType(type));
-    }
+	@Override
+	public String getTypeDeclaration(Type type, String suffix) {
+		requireTypes(OpenApiObjectImpl.class);
+		requireTypes(type);
+		return t("public class ${name}${0} extends ${1} implements ${name}", type, suffix, getSuperType(type));
+	}
 
-    private String getSuperType(Type type) {
-        String superType = type.getExtensionOf();
-        return superType != null ? getImplType(superType) : "OpenApiObjectImpl";
-    }
+	private String getSuperType(Type type) {
+		String superType = type.getExtensionOf();
+		return superType != null ? Type.getImplType(superType) : "OpenApiObjectImpl";
+	}
 
-    @Override
-    protected Members getConstructors(Type type) {
-        Members members = new Members();
-        members.add(t("public ${name}Impl(String key, JsonNode json, JsonOverlay<?> parent)", type),
-                code("super(key, json, parent);"));
-        requireTypes(JsonNode.class, JsonOverlay.class);
-        members.add(t("public ${name}Impl(String key, JsonOverlay<?> parent)", type), code("super(key, parent);"));
-        return members;
-    }
+	@Override
+	protected Members getConstructors(Type type) {
+		Members members = new Members();
+		members.add(t("public ${name}Impl(String key, JsonNode json, JsonOverlay<?> parent)", type), //
+				code("super(key, json, parent);", //
+						"installPropertyAccessors();"));
+		requireTypes(JsonNode.class, JsonOverlay.class);
+		members.add(t("public ${name}Impl(String key, JsonOverlay<?> parent)", type), //
+				code("super(key, parent);", //
+						"installPropertyAccessors();"));
+		return members;
+	}
 
-    @Override
-    protected boolean skipField(Field field) {
-        return field.isNoImpl();
-    }
+	@Override
+	protected boolean skipField(Field field) {
+		return field.isNoImpl();
+	}
 
-    @Override
-    protected Members getFieldMembers(Field field) {
-        requireTypes(field.getType(), getImplType(field));
-        Members members = new Members();
-        switch (field.getStructure()) {
-        case scalar:
-            String reg = t("registerField(${qpath}, \"${lcName}\", ${qkeyPat}", field);
-            if (isScalarType(field)) {
-                // T foo = register(..., new TImpl(path, this))
-                members.add(t("private ${implType} ${lcName} = ${0}, new ${implType}(${qpath}, this))", field, reg));
-            } else {
-                // T foo = register(..., TImpl.factory.create(path, this)) - protects against infinite recursion
-                members.add(t("private ${implType} ${lcName} = ${0}, ${implType}.factory.create(${qpath}, this))",
-                        field, reg));
-            }
-            break;
-        case collection:
-            requireTypes(Collection.class);
-            reg = t("registerField(${qpath}, \"${lcPlural}\", ${qkeyPat}", field);
-            if (isScalarType(field)) {
-                requireTypes(ValListOverlay.class);
-                // ValListOverlay<T, TImpl> foos = new ValListOverlay<T, TImpl>(id, this, TImpl.factory)
-                members.add(
-                        t("private ValListOverlay<${type}, ${implType}> ${lcPlural} = ${0}, new ValListOverlay<${type}, ${implType}>(${qpath}, this, ${implType}.factory));",
-                                field, reg));
-            } else {
-                requireTypes(ListOverlay.class);
-                // ListOverlay<TImpl> foos = new ListOverlay<TImpl>(id, this, TImpl.factory)
-                members.add(
-                        t("private ListOverlay<${implType}> ${lcPlural} = ${0}, new ListOverlay<${implType}>(${qpath}, this, ${implType}.factory))",
-                                field, reg));
-            }
-            break;
-        case map:
-            requireTypes(Map.class);
-            reg = t("registerField(${qpath}, \"${lcPlural}\", ${qkeyPat}", field);
-            if (isScalarType(field)) {
-                requireTypes(ValMapOverlay.class);
-                // ValMapOverlay<T, TImpl> foos = new ValMapOverlay<T, TImpl>(id, this, TImpl.factory)
-                members.add(
-                        t("private ValMapOverlay<${type},${implType}> ${lcPlural} = ${0}, new ValMapOverlay<${type}, ${implType}>(${qpath}, this, ${implType}.factory, ${qkeyPat}))",
-                                field, reg));
-            } else {
-                requireTypes(MapOverlay.class);
-                // MapOverlay<TImpl> foos = new MapOverlay<TImpl>(id, this, TImpl.factory)
-                members.add(
-                        t("private MapOverlay<${implType}> ${lcPlural} = ${0}, new MapOverlay<${implType}>(${qpath}, this, ${implType}.factory, ${qkeyPat}))",
-                                field, reg));
-            }
-            break;
-        }
+	@Override
+	protected Members getFieldMembers(Field field) {
+		requireTypes(field.getType(), field.getImplType());
+		Members members = new Members();
+		members.add(t("private ${propType} ${propName} = ${propCons}", field));
+		switch (field.getStructure()) {
+		case collection:
+			requireTypes(Collection.class, field.isScalarType() ? ValListOverlay.class : ListOverlay.class);
+			break;
+		case map:
+			requireTypes(Map.class, field.isScalarType() ? ValMapOverlay.class : MapOverlay.class);
+			break;
+		default:
+			break;
+		}
+		return members;
+	}
 
-        return members;
-    }
+	@Override
+	protected Members getFieldMethods(Field field) {
+		Members methods = new Members();
+		boolean first = true;
+		String typeComment = field.getName();
+		switch (field.getStructure()) {
+		case scalar:
+			for (Member method : getScalarMethods(field)) {
+				methods.addMember(method).override().comment(first ? typeComment : null);
+				first = false;
+			}
+			break;
+		case collection:
+			for (Member method : getCollectionMethods(field)) {
+				methods.addMember(method).override().comment(first ? typeComment : null);
+				first = false;
+			}
+			break;
+		case map:
+			for (Member method : getMapMethods(field)) {
+				methods.addMember(method).override().comment(first ? typeComment : null);
+				first = false;
+			}
+			break;
+		}
+		return methods;
+	}
 
-    @Override
-    protected Members getFieldMethods(Field field) {
-        Members methods = new Members();
-        boolean first = true;
-        String typeComment = field.getName();
-        switch (field.getStructure()) {
-        case scalar:
-            for (Member method : getScalarMethods(field)) {
-                methods.addMember(method).override().comment(first ? typeComment : null);
-                first = false;
-            }
-            break;
-        case collection:
-            for (Member method : getCollectionMethods(field)) {
-                methods.addMember(method).override().comment(first ? typeComment : null);
-                first = false;
-            }
-            break;
-        case map:
-            for (Member method : getMapMethods(field)) {
-                methods.addMember(method).override().comment(first ? typeComment : null);
-                first = false;
-            }
-            break;
-        }
-        return methods;
-    }
+	private Members getScalarMethods(Field field) {
+		Members methods = new Members();
+		String getDecl = t("public ${type} get${name}()", field);
+		String setDecl = t("public void set${name}(${type} ${lcName})", field);
+		if (field.isScalarType()) {
+			// T getFoo() => return foo.get()
+			methods.add(getDecl, code(field, "return ${lcName}.get();"));
+			if (field.isBoolean()) {
+				// boolean isFoo() => foo.get() != null ? foo.get() : boolDefault
+				methods.add(t("public boolean is${name}()", field),
+						code(field, "return ${lcName}.get() != null ? ${lcName}.get() : ${boolDefault};"));
+			}
+			// void setFoo(T foo) => foo = this.foo.set(foo)
+			methods.add(setDecl, code(field, "this.${lcName}.set(${lcName});"));
+		} else {
+			// T getFoo() => return foo
+			methods.add(getDecl, code(field, "return ${lcName};"));
+			// void setFoo(T foo) => this.foo.set((TImpl) foo)
+			methods.add(setDecl, code(field, "this.${lcName}.set((${implType}) ${lcName});"));
+		}
+		return methods;
+	}
 
-    private Members getScalarMethods(Field field) {
-        Members methods = new Members();
-        String getDecl = t("public ${type} get${name}()", field);
-        String setDecl = t("public void set${name}(${type} ${lcName})", field);
-        if (isScalarType(field)) {
-            // T getFoo() => return foo.get()
-            methods.add(getDecl, code(field, "return ${lcName}.get();"));
-            if (field.isBoolean()) {
-                // boolean isFoo() => foo.get() != null ? foo.get() : boolDefault
-                methods.add(t("public boolean is${name}()", field),
-                        code(field, "return ${lcName}.get() != null ? ${lcName}.get() : ${boolDefault};"));
-            }
-            // void setFoo(T foo) => foo = this.foo.set(foo)
-            methods.add(setDecl, code(field, "this.${lcName}.set(${lcName});"));
-        } else {
-            // T getFoo() => return foo
-            methods.add(getDecl, code(field, "return ${lcName};"));
-            // void setFoo(T foo) => this.foo.set((TImpl) foo)
-            methods.add(setDecl, code(field, "this.${lcName}.set((${implType}) ${lcName});"));
-        }
-        return methods;
-    }
+	private Members getCollectionMethods(Field field) {
+		Members methods = new Members();
+		String getDecl = t("public Collection<${collType}> get${plural}()", field);
+		String hasDecl = t("public boolean has${plural}()", field);
+		String iGetDecl = t("public ${type} get${name}(int index)", field);
+		String setDecl = t("public void set${plural}(Collection<${collType}> ${lcPlural})", field);
+		String iSetDecl = t("public void set${name}(int index, ${type} ${lcName})", field);
+		String addDecl = t("public void add${name}(${type} ${lcName})", field);
+		// String insDecl = t("public void insert${name}(int index, ${type} ${lcName})",
+		// field);
+		String remDecl = t("public void remove${name}(int index)", field);
 
-    private Members getCollectionMethods(Field field) {
-        Members methods = new Members();
-        String getDecl = t("public Collection<${collType}> get${plural}()", field);
-        String hasDecl = t("public boolean has${plural}()", field);
-        String iGetDecl = t("public ${type} get${name}(int index)", field);
-        String setDecl = t("public void set${plural}(Collection<${collType}> ${lcPlural})", field);
-        String iSetDecl = t("public void set${name}(int index, ${type} ${lcName})", field);
-        String addDecl = t("public void add${name}(${type} ${lcName})", field);
-        // String insDecl = t("public void insert${name}(int index, ${type} ${lcName})", field);
-        String remDecl = t("public void remove${name}(int index)", field);
+		// Collection<T> getFoos() => foos.get()
+		methods.add(getDecl, code(field, "return ${lcPlural}.get();"));
+		// boolean hasFoos() => !foos.isMissing()
+		methods.add(hasDecl, code(field, "return !${lcPlural}.isMissing();"));
+		// T getFoo(int index) => foos.get(index)
+		methods.add(iGetDecl, code(field, "return ${lcPlural}.get(index);"));
+		if (field.isScalarType()) {
+			// void setFoos(Collection<T> foos) => this.foos.set((TImpl) foos)
+			methods.add(setDecl, code(field, "this.${lcPlural}.set((Collection<${collType}>) ${lcPlural});"));
+			// void setFoo(int index, T foo) => foos.set(index, foo)
+			methods.add(iSetDecl, code(field, "${lcPlural}.set(index, ${lcName});"));
+			// void addFoo(Foo foo) => foos.add(foo)
+			methods.add(addDecl, code(field, "${lcPlural}.add(${lcName});"));
+		} else {
+			// void setFoos(Collection<? extends T> foos) => this.foos.set(foos) (requires
+			// unchecked cast)
+			methods.add(setDecl, code(field, //
+					"@SuppressWarnings(\"unchecked\")", //
+					"Collection<${implType}> impl${plural} = (Collection<${implType}>) ${lcPlural};",
+					"this.${lcPlural}.set(impl${plural});"));
+			// void setFoo(int index, Foo foo) => foos.set(index, (TImpl) foo)
+			methods.add(iSetDecl, code(field, "${lcPlural}.set(index, (${implType}) ${lcName});"));
+			// void addFoo(Foo foo) => foos.add((TImpl) foo)
+			methods.add(addDecl, code(field, "${lcPlural}.add((${implType}) ${lcName});"));
+		}
+		// void insertFoo(int index, Foo foo) => foos.insertOveraly(index, foo)
+		// methods.add(insDecl, code(field, "${lcPlural}.insert(index, ${lcName});"));
+		// void removeFoo(int index) => foos.remove(index)
+		methods.add(remDecl, code(field, "${lcPlural}.remove(index);"));
+		// methods.addAll(getKeyedCollectionMethods(field));
+		return methods;
+	}
 
-        // Collection<T> getFoos() => foos.get()
-        methods.add(getDecl, code(field, "return ${lcPlural}.get();"));
-        // boolean hasFoos() => !foos.isMissing()
-        methods.add(hasDecl, code(field, "return !${lcPlural}.isMissing();"));
-        // T getFoo(int index) => foos.get(index)
-        methods.add(iGetDecl, code(field, "return ${lcPlural}.get(index);"));
-        if (isScalarType(field)) {
-            // void setFoos(Collection<T> foos) => this.foos.set((TImpl) foos)
-            methods.add(setDecl, code(field, "this.${lcPlural}.set((Collection<${collType}>) ${lcPlural});"));
-            // void setFoo(int index, T foo) => foos.set(index, foo)
-            methods.add(iSetDecl, code(field, "${lcPlural}.set(index, ${lcName});"));
-            // void addFoo(Foo foo) => foos.add(foo)
-            methods.add(addDecl, code(field, "${lcPlural}.add(${lcName});"));
-        } else {
-            // void setFoos(Collection<? extends T> foos) => this.foos.set(foos) (requires unchecked cast)
-            methods.add(setDecl,
-                    code(field, //
-                            "@SuppressWarnings(\"unchecked\")", //
-                            "Collection<${implType}> impl${plural} = (Collection<${implType}>) ${lcPlural};",
-                            "this.${lcPlural}.set(impl${plural});"));
-            // void setFoo(int index, Foo foo) => foos.set(index, (TImpl) foo)
-            methods.add(iSetDecl, code(field, "${lcPlural}.set(index, (${implType}) ${lcName});"));
-            // void addFoo(Foo foo) => foos.add((TImpl) foo)
-            methods.add(addDecl, code(field, "${lcPlural}.add((${implType}) ${lcName});"));
-        }
-        // void insertFoo(int index, Foo foo) => foos.insertOveraly(index, foo)
-        // methods.add(insDecl, code(field, "${lcPlural}.insert(index, ${lcName});"));
-        // void removeFoo(int index) => foos.remove(index)
-        methods.add(remDecl, code(field, "${lcPlural}.remove(index);"));
-        // methods.addAll(getKeyedCollectionMethods(field));
-        return methods;
-    }
+	private Member getFactoryMethod(Type type) {
+		requireTypes(JsonOverlayFactory.class, JsonNode.class);
+		Collection<String> decl = t(type,
+				"public static JsonOverlayFactory<${implName}> factory = new JsonOverlayFactory<${implName}>() {", //
+				"    @Override", //
+				"    public ${implName} create(String key, JsonNode json, JsonOverlay<?> parent) {", //
+				"        return isEmptyRecursive(parent, ${implName}.class) ? null : new ${implName}(key, json, parent);", //
+				"    }", //
+				"}");
+		return new Member(StringUtils.join(decl, "\n"), null);
+	}
 
-    private Member getFactoryMethod(Type type) {
-        requireTypes(JsonOverlayFactory.class, JsonNode.class);
-        Collection<String> decl = t(type,
-                "public static JsonOverlayFactory<${implName}> factory = new JsonOverlayFactory<${implName}>() {", //
-                "    @Override", //
-                "    public ${implName} create(String key, JsonNode json, JsonOverlay<?> parent) {", //
-                "        return isEmptyRecursive(parent, ${implName}.class) ? null : new ${implName}(key, json, parent);", //
-                "    }", //
-                "}");
-        return new Member(StringUtils.join(decl, "\n"), null).generated(true);
-    }
+	private Members getPropertyAccessorMembers(Type type) {
+		Members members = new Members();
+		members.add(new Member("PropertyAccessors accessors = new PropertyAccessors();", null));
+		String createDecl = "private void installPropertyAccessors()";
+		List<String> createCode = Lists.newArrayList();
+		createCode.add("Getter getter = null;");
+		for (Field field : type.getFields().values()) {
+			if (!field.isNoImpl()) {
+				createCode
+						.addAll(code(field, "getter = new Getter(){ public JsonOverlay<?> get(){return ${propName};}};",
+								"this.accessors.add(${qpath}, getter);"));
+			}
+		}
+		members.add(new Member(createDecl, createCode));
+		return members;
+	}
 
-    private Members getMapMethods(Field field) {
-        Members methods = new Members();
-        // Map<String, ? extends T> getFoos() => foos.get()
-        methods.add(t("public Map<String, ${collType}> get${plural}()", field),
-                code(field, "return ${lcPlural}.get();"));
-        // boolean hasFoo(String key) => foos.containsKey(key)
-        methods.add(t("public boolean has${name}(String ${keyName})", field),
-                code(field, "return ${lcPlural}.containsKey(${keyName});"));
-        // T getFoo(String key) => foos.get(key)
-        methods.add(t("public ${type} get${name}(String ${keyName})", field),
-                code(field, "return ${lcPlural}.get(${keyName});"));
-        if (isScalarType(field)) {
-            // void setFoos(Map<String, T> foos) => this.foos.set(foos)
-            methods.add(t("public void set${plural}(Map<String, ${type}> ${lcPlural})", field),
-                    code(field, "this.${lcPlural}.set(${lcPlural});"));
-            // void setFoo(String key, Foo foo) => foos.set(key, foo)
-            methods.add(t("public void set${name}(String ${keyName}, ${type} ${lcName})", field),
-                    code(field, "${lcPlural}.set(${keyName}, ${lcName});"));
-        } else {
-            // void setFoos(Map<String, ? extends Foo> foos) => this.foos.set(foo) (requires unchecked cast)
-            methods.add(t("public void set${plural}(Map<String, ${collType}> ${lcPlural})", field),
-                    code(field, //
-                            "@SuppressWarnings(\"unchecked\")",
-                            "Map<String,${implType}> impl${plural} = (Map<String, ${implType}>) ${lcPlural};",
-                            "this.${lcPlural}.set(impl${plural});"));
-            // void setFoo(String key, Foo foo) => foos.set(key, (TImpl) foo)
-            methods.add(t("public void set${name}(String ${keyName}, ${type} ${lcName})", field),
-                    code(field, "${lcPlural}.set(${keyName}, (${implType}) ${lcName});"));
-        }
-        // void removeFoo(String key) => foos.remove(key)
-        methods.add(t("public void remove${name}(String ${keyName})", field),
-                code(field, "${lcPlural}.remove(${keyName});"));
-        return methods;
-    }
+	private Members getMapMethods(Field field) {
+		Members methods = new Members();
+		// Map<String, ? extends T> getFoos() => foos.get()
+		methods.add(t("public Map<String, ${collType}> get${plural}()", field),
+				code(field, "return ${lcPlural}.get();"));
+		// boolean hasFoo(String key) => foos.containsKey(key)
+		methods.add(t("public boolean has${name}(String ${keyName})", field),
+				code(field, "return ${lcPlural}.containsKey(${keyName});"));
+		// T getFoo(String key) => foos.get(key)
+		methods.add(t("public ${type} get${name}(String ${keyName})", field),
+				code(field, "return ${lcPlural}.get(${keyName});"));
+		if (field.isScalarType()) {
+			// void setFoos(Map<String, T> foos) => this.foos.set(foos)
+			methods.add(t("public void set${plural}(Map<String, ${type}> ${lcPlural})", field),
+					code(field, "this.${lcPlural}.set(${lcPlural});"));
+			// void setFoo(String key, Foo foo) => foos.set(key, foo)
+			methods.add(t("public void set${name}(String ${keyName}, ${type} ${lcName})", field),
+					code(field, "${lcPlural}.set(${keyName}, ${lcName});"));
+		} else {
+			// void setFoos(Map<String, ? extends Foo> foos) => this.foos.set(foo) (requires
+			// unchecked cast)
+			methods.add(t("public void set${plural}(Map<String, ${collType}> ${lcPlural})", field), code(field, //
+					"@SuppressWarnings(\"unchecked\")",
+					"Map<String,${implType}> impl${plural} = (Map<String, ${implType}>) ${lcPlural};",
+					"this.${lcPlural}.set(impl${plural});"));
+			// void setFoo(String key, Foo foo) => foos.set(key, (TImpl) foo)
+			methods.add(t("public void set${name}(String ${keyName}, ${type} ${lcName})", field),
+					code(field, "${lcPlural}.set(${keyName}, (${implType}) ${lcName});"));
+		}
+		// void removeFoo(String key) => foos.remove(key)
+		methods.add(t("public void remove${name}(String ${keyName})", field),
+				code(field, "${lcPlural}.remove(${keyName});"));
+		return methods;
+	}
 
-    private Collection<String> code(String... lines) {
-        return Lists.newArrayList(lines);
-    }
+	private Collection<String> code(String... lines) {
+		return Lists.newArrayList(lines);
+	}
 
-    private Collection<String> code(final Field field, String... lines) {
-        return Lists.transform(Lists.newArrayList(lines), new Function<String, String>() {
-            @Override
-            public String apply(String template) {
-                return t(template, field);
-            }
-        });
-    }
+	private Collection<String> code(final Field field, String... lines) {
+		return Lists.transform(Lists.newArrayList(lines), new Function<String, String>() {
+			@Override
+			public String apply(String template) {
+				return t(template, field);
+			}
+		});
+	}
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/gen/ImplGenerator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/gen/ImplGenerator.java
@@ -213,6 +213,11 @@ public class ImplGenerator extends TypeGenerator {
 
 	private Members getPropertyAccessorMembers(Type type) {
 		Members members = new Members();
+		if (type.getExtensionOf() != null) {
+			// if this class is an extension of another, then we use that class's property accessors.
+			// N.B. That means that extension object types can't define their own additional properties.
+			return members;
+		}
 		String installDecl = "protected void installPropertyAccessors(PropertyAccessors accessors)";
 		List<String> createCode = Lists.newArrayList();
 		createCode.add("OverlayGetter getter = null;");

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/gen/ImplGenerator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/gen/ImplGenerator.java
@@ -73,12 +73,10 @@ public class ImplGenerator extends TypeGenerator {
 	protected Members getConstructors(Type type) {
 		Members members = new Members();
 		members.add(t("public ${name}Impl(String key, JsonNode json, JsonOverlay<?> parent)", type), //
-				code("super(key, json, parent);", //
-						"installPropertyAccessors();"));
+				code("super(key, json, parent);"));
 		requireTypes(JsonNode.class, JsonOverlay.class);
 		members.add(t("public ${name}Impl(String key, JsonOverlay<?> parent)", type), //
-				code("super(key, parent);", //
-						"installPropertyAccessors();"));
+				code("super(key, parent);"));
 		return members;
 	}
 
@@ -215,18 +213,17 @@ public class ImplGenerator extends TypeGenerator {
 
 	private Members getPropertyAccessorMembers(Type type) {
 		Members members = new Members();
-		members.add(new Member("PropertyAccessors accessors = new PropertyAccessors();", null));
-		String createDecl = "private void installPropertyAccessors()";
+		String installDecl = "protected void installPropertyAccessors(PropertyAccessors accessors)";
 		List<String> createCode = Lists.newArrayList();
-		createCode.add("Getter getter = null;");
+		createCode.add("OverlayGetter getter = null;");
 		for (Field field : type.getFields().values()) {
 			if (!field.isNoImpl()) {
 				createCode
-						.addAll(code(field, "getter = new Getter(){ public JsonOverlay<?> get(){return ${propName};}};",
-								"this.accessors.add(${qpath}, getter);"));
+						.addAll(code(field, "getter = new OverlayGetter(){ public JsonOverlay<?> get(){return ${propName};}};",
+								"accessors.add(${qpath}, ${qkeyPat}, getter);"));
 			}
 		}
-		members.add(new Member(createDecl, createCode));
+		members.add(new Member(installDecl, createCode).override());
 		return members;
 	}
 

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/gen/Template.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/gen/Template.java
@@ -19,95 +19,104 @@ import org.apache.commons.lang3.StringEscapeUtils;
 import com.google.common.base.Function;
 import com.google.common.collect.Lists;
 import com.reprezen.kaizen.oasparser.jsonoverlay.gen.TypeData.Field;
+import com.reprezen.kaizen.oasparser.jsonoverlay.gen.TypeData.Structure;
 import com.reprezen.kaizen.oasparser.jsonoverlay.gen.TypeData.Type;
 
 public class Template {
 
-    private static Pattern varPat = Pattern.compile("\\$\\{([a-zA-Z]+|\\d+)\\}");
+	private static Pattern varPat = Pattern.compile("\\$\\{([a-zA-Z]+|\\d+)\\}");
 
-    public static <T> String t(String template, T item, String... args) {
-        Matcher matcher = varPat.matcher(template);
-        StringBuffer result = new StringBuffer();
-        int start = 0;
-        while (matcher.find()) {
-            // would use matcher.appendReplace and matcher.appendTail, but it's way too hard to deal with all the
-            // escaping and quoting. Literal replacement is what I need here. Too bad they don't support that!
-            result.append(template.substring(start, matcher.start()));
-            result.append(replacement(matcher.group(1), item, args));
-            start = matcher.end();
-        }
-        result.append(template.substring(start));
-        return result.toString();
-    }
+	public static <T> String t(String template, T item, String... args) {
+		Matcher matcher = varPat.matcher(template);
+		StringBuffer result = new StringBuffer();
+		int start = 0;
+		while (matcher.find()) {
+			// would use matcher.appendReplace and matcher.appendTail, but it's way too hard
+			// to deal with all the
+			// escaping and quoting. Literal replacement is what I need here. Too bad they
+			// don't support that!
+			result.append(template.substring(start, matcher.start()));
+			result.append(replacement(matcher.group(1), item, args));
+			start = matcher.end();
+		}
+		result.append(template.substring(start));
+		return result.toString();
+	}
 
-    public static <T> List<String> t(final T item, String... templates) {
-        return Lists.transform(Lists.newArrayList(templates), new Function<String, String>() {
-            @Override
-            public String apply(String template) {
-                return t(template, item);
-            }
-        });
-    }
+	public static <T> List<String> t(final T item, String... templates) {
+		return Lists.transform(Lists.newArrayList(templates), new Function<String, String>() {
+			@Override
+			public String apply(String template) {
+				return t(template, item);
+			}
+		});
+	}
 
-    private static String replacement(String var, Field field, String[] args) {
-        switch (var) {
-        case "name":
-            return field.getName();
-        case "lcName":
-            return field.getLcName();
-        case "plural":
-            return field.getPlural();
-        case "lcPlural":
-            return field.getLcPlural();
-        case "type": {
-            String type = field.getType();
-            return "Primitive".equals(type) ? "Object" : type;
-        }
-        case "implType":
-            return TypeGenerator.getImplType(field);
-        case "collType": {
-            String type = TypeGenerator.getTypeInCollection(field);
-            return "Primitive".equals(type) ? "Object" : type;
-        }
-        case "keyName":
-            return field.getKeyName();
-        case "id":
-            return field.getId();
-        case "qid":
-            return quote(field.getId());
-        case "qpath":
-            return quote(field.getParentPath());
-        case "qkeyPat":
-            return quote(field.getKeyPattern());
-        case "boolDefault":
-            return String.valueOf(field.getBoolDefault());
-        default:
-            return args[Integer.valueOf(var)];
-        }
-    }
+	private static String replacement(String var, Field field, String[] args) {
+		switch (var) {
+		case "name":
+			return field.getName();
+		case "lcName":
+			return field.getLcName();
+		case "plural":
+			return field.getPlural();
+		case "lcPlural":
+			return field.getLcPlural();
+		case "type": {
+			String type = field.getType();
+			return "Primitive".equals(type) ? "Object" : type;
+		}
+		case "implType":
+			return field.getImplType();
+		case "collType": {
+			String type = field.getTypeInCollection();
+			return "Primitive".equals(type) ? "Object" : type;
+		}
+		case "keyName":
+			return field.getKeyName();
+		case "id":
+			return field.getId();
+		case "qid":
+			return quote(field.getId());
+		case "qpath":
+			return quote(field.getParentPath());
+		case "qkeyPat":
+			return quote(field.getKeyPattern());
+		case "boolDefault":
+			return String.valueOf(field.getBoolDefault());
+		case "propName":
+			return field.getPropertyName();
+		case "propType":
+			return field.getPropertyType();
+		case "propCons":
+			return field.getPropertyNew();
+		default:
+			return args[Integer.valueOf(var)];
+		}
+	}
 
-    private static String replacement(String var, Type type, String[] args) {
-        switch (var) {
-        case "name":
-            return type.getName();
-        case "implName":
-            return TypeGenerator.getImplType(type);
-        default:
-            return args[Integer.valueOf(var)];
-        }
-    }
+	private static String replacement(String var, Type type, String[] args) {
+		switch (var) {
+		case "name":
+			return type.getName();
+		case "implName":
+			return type.getImplType();
+		default:
+			return args[Integer.valueOf(var)];
+		}
+	}
 
-    private static String replacement(String var, Object item, String[] args) {
-        if (item instanceof Field) {
-            return replacement(var, (Field) item, args);
-        } else if (item instanceof Type) {
-            return replacement(var, (Type) item, args);
-        } else {
-            throw new UnsupportedOperationException();
-        }
-    }
+	private static String replacement(String var, Object item, String[] args) {
+		if (item instanceof Field) {
+			return replacement(var, (Field) item, args);
+		} else if (item instanceof Type) {
+			return replacement(var, (Type) item, args);
+		} else {
+			throw new UnsupportedOperationException();
+		}
+	}
 
-    private static String quote(String s) {
-        return s != null ? "\"" + StringEscapeUtils.escapeJava(s) + "\"" : "null";
-    }
+	private static String quote(String s) {
+		return s != null ? "\"" + StringEscapeUtils.escapeJava(s) + "\"" : "null";
+	}
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/gen/TypeData.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/gen/TypeData.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package com.reprezen.kaizen.oasparser.jsonoverlay.gen;
 
+import static com.reprezen.kaizen.oasparser.jsonoverlay.gen.Template.t;
+
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -26,248 +28,329 @@ import com.google.common.collect.Sets;
 
 public class TypeData {
 
-    private Collection<Type> types;
-    private Map<String, String> imports = Maps.newHashMap();
-    private List<String> defaultExtendInterfaces = null;
-    private Map<String, Type> typeMap = null;
+	private Collection<Type> types;
+	private Map<String, String> imports = Maps.newHashMap();
+	private List<String> defaultExtendInterfaces = null;
+	private Map<String, Type> typeMap = null;
 
-    // Container for "decls" section that is solely used to define reusable anchors
-    @JsonProperty
-    private Object decls;
+	// Container for "decls" section that is solely used to define reusable anchors
+	@JsonProperty
+	private Object decls;
 
-    public void init() {
-        typeMap = Maps.uniqueIndex(types, new Function<Type, String>() {
-            @Override
-            public String apply(Type type) {
-                return type.getName();
-            }
-        });
-        for (Type type : types) {
-            type.init(this);
-        }
-    }
+	public void init() {
+		typeMap = Maps.uniqueIndex(types, new Function<Type, String>() {
+			@Override
+			public String apply(Type type) {
+				return type.getName();
+			}
+		});
+		for (Type type : types) {
+			type.init(this);
+		}
+	}
 
-    public Collection<Type> getTypes() {
-        return types;
-    }
+	public Collection<Type> getTypes() {
+		return types;
+	}
 
-    public Map<String, Type> getTypeMap() {
-        return typeMap;
-    }
+	public Map<String, Type> getTypeMap() {
+		return typeMap;
+	}
 
-    public Type getType(String typeName) {
-        return typeMap.get(typeName);
-    }
+	public Type getType(String typeName) {
+		return typeMap.get(typeName);
+	}
 
-    public Map<String, String> getImports() {
-        return imports;
-    }
+	public Map<String, String> getImports() {
+		return imports;
+	}
 
-    public List<String> getDefaultExtendInterfaces() {
-        return defaultExtendInterfaces;
-    }
+	public List<String> getDefaultExtendInterfaces() {
+		return defaultExtendInterfaces;
+	}
 
-    public static class Type {
+	public static class Type {
 
-        private String name;
-        private Map<String, Field> fields = Maps.newLinkedHashMap();
-        private List<String> extendInterfaces = Lists.newArrayList();
-        private List<Method> extraMethods = Lists.newArrayList();
-        private Map<String, Collection<String>> imports = Maps.newHashMap();
-        private boolean noGen = false;
-        private String extensionOf;
+		private String name;
+		private Map<String, Field> fields = Maps.newLinkedHashMap();
+		private List<String> extendInterfaces = Lists.newArrayList();
+		private List<Method> extraMethods = Lists.newArrayList();
+		private Map<String, Collection<String>> imports = Maps.newHashMap();
+		private boolean noGen = false;
+		private String extensionOf;
 
-        private TypeData typeData;
+		private TypeData typeData;
 
-        public void init(TypeData typeData) {
-            this.typeData = typeData;
-            for (Entry<String, Field> field : fields.entrySet()) {
-                field.getValue().init(field.getKey(), this);
-            }
-        }
+		public void init(TypeData typeData) {
+			this.typeData = typeData;
+			for (Entry<String, Field> field : fields.entrySet()) {
+				field.getValue().init(field.getKey(), this);
+			}
+		}
 
-        public TypeData getTypeData() {
-            return typeData;
-        }
+		public TypeData getTypeData() {
+			return typeData;
+		}
 
-        public Collection<String> getRequiredImports(String moduleType) {
-            Set<String> results = Sets.newLinkedHashSet();
-            Collection<String> interfaces = extendInterfaces != null ? extendInterfaces
-                    : typeData.defaultExtendInterfaces;
-            if (interfaces != null) {
-                for (String intf : interfaces) {
-                    if (typeData.imports.containsKey(intf)) {
-                        results.add(typeData.imports.get(intf));
-                    }
-                }
-            }
-            if (imports.get(moduleType) != null) {
-                for (String imp : imports.get(moduleType)) {
-                    results.add(imp);
-                }
-            }
-            return results;
-        }
+		public Collection<String> getRequiredImports(String moduleType) {
+			Set<String> results = Sets.newLinkedHashSet();
+			Collection<String> interfaces = extendInterfaces != null ? extendInterfaces
+					: typeData.defaultExtendInterfaces;
+			if (interfaces != null) {
+				for (String intf : interfaces) {
+					if (typeData.imports.containsKey(intf)) {
+						results.add(typeData.imports.get(intf));
+					}
+				}
+			}
+			if (imports.get(moduleType) != null) {
+				for (String imp : imports.get(moduleType)) {
+					results.add(imp);
+				}
+			}
+			return results;
+		}
 
-        public String getIntfExtendsDecl() {
-            List<String> interfaces = extendInterfaces != null ? extendInterfaces : typeData.defaultExtendInterfaces;
-            return interfaces != null ? " extends " + StringUtils.join(interfaces, ", ") : "";
-        }
+		public String getIntfExtendsDecl() {
+			List<String> interfaces = extendInterfaces != null ? extendInterfaces : typeData.defaultExtendInterfaces;
+			return interfaces != null ? " extends " + StringUtils.join(interfaces, ", ") : "";
+		}
 
-        public String getName() {
-            return name;
-        }
+		public String getName() {
+			return name;
+		}
 
-        public Map<String, Field> getFields() {
-            return fields;
-        }
+		public Map<String, Field> getFields() {
+			return fields;
+		}
 
-        public List<String> getExtendInterfaces() {
-            return extendInterfaces;
-        }
+		public List<String> getExtendInterfaces() {
+			return extendInterfaces;
+		}
 
-        public List<Method> getExtraMethods() {
-            return extraMethods;
-        }
+		public List<Method> getExtraMethods() {
+			return extraMethods;
+		}
 
-        public Map<String, Collection<String>> getImports() {
-            return imports;
-        }
+		public Map<String, Collection<String>> getImports() {
+			return imports;
+		}
 
-        public boolean isNoGen() {
-            return noGen;
-        }
+		public boolean isNoGen() {
+			return noGen;
+		}
 
-        public String getExtensionOf() {
-            return extensionOf;
-        }
+		public String getExtensionOf() {
+			return extensionOf;
+		}
 
-    }
+		public String getImplType() {
+			return isNoGen() ? name : getImplType(name);
+		}
 
-    public static class Field {
-        private String name;
-        private String plural;
-        private Structure structure = Structure.scalar;
-        private String type;
-        private String keyName = "name";
-        private List<String> keyDecls;
-        private boolean selfKeyed = false;
-        private String keyPattern;
-        private boolean noImpl;
-        private String id;
-        private boolean boolDefault = false;
-        private String parentPath;
+		public static String getImplType(String typeName) {
+			switch (typeName) {
+			case "String":
+			case "Integer":
+			case "Number":
+			case "Boolean":
+			case "Primitive":
+				return typeName + "Overlay";
+			case "Object":
+				return "AnyObjectOverlay";
+			default:
+				return typeName + "Impl";
+			}
+		}
+	}
 
-        private Type container;
+	public static class Field {
+		private String name;
+		private String plural;
+		private Structure structure = Structure.scalar;
+		private String type;
+		private String keyName = "name";
+		private List<String> keyDecls;
+		private boolean selfKeyed = false;
+		private String keyPattern;
+		private boolean noImpl;
+		private String id;
+		private boolean boolDefault = false;
+		private String parentPath;
 
-        public void init(String id, Type container) {
-            this.id = id;
-            this.container = container;
-        }
+		private Type container;
 
-        public String getId() {
-            return id;
-        }
+		public void init(String id, Type container) {
+			this.id = id;
+			this.container = container;
+		}
 
-        public Type getContainer() {
-            return container;
-        }
+		public String getId() {
+			return id;
+		}
 
-        public TypeData getTypeData() {
-            return container.getTypeData();
-        }
+		public Type getContainer() {
+			return container;
+		}
 
-        public String getName() {
-            return name;
-        }
+		public TypeData getTypeData() {
+			return container.getTypeData();
+		}
 
-        public String getLcName() {
-            String lcName = lcFirst(name);
-            switch (lcName) {
-            case "default":
-            case "enum":
-                lcName = lcName + "Value";
-            }
-            return lcName;
-        }
+		public String getName() {
+			return name;
+		}
 
-        public String getPlural() {
-            return plural != null ? plural : name + "s";
-        }
+		public String getLcName() {
+			String lcName = lcFirst(name);
+			switch (lcName) {
+			case "default":
+			case "enum":
+				lcName = lcName + "Value";
+			}
+			return lcName;
+		}
 
-        public String getLcPlural() {
-            return lcFirst(getPlural());
-        }
+		public String getPlural() {
+			return plural != null ? plural : name + "s";
+		}
 
-        public Structure getStructure() {
-            return structure;
-        }
+		public String getLcPlural() {
+			return lcFirst(getPlural());
+		}
 
-        public String getType() {
-            return type != null ? type : name;
-        }
+		public Structure getStructure() {
+			return structure;
+		}
 
-        String lcFirst(String s) {
-            return s.substring(0, 1).toLowerCase() + s.substring(1);
-        }
+		public String getType() {
+			return type != null ? type : name;
+		}
 
-        public String getKeyName() {
-            return keyName;
-        }
+		String lcFirst(String s) {
+			return s.substring(0, 1).toLowerCase() + s.substring(1);
+		}
 
-        public Collection<String> getKeyDecls() {
-            return keyDecls;
-        }
+		public String getKeyName() {
+			return keyName;
+		}
 
-        public boolean isSelfKeyed() {
-            return selfKeyed;
-        }
+		public Collection<String> getKeyDecls() {
+			return keyDecls;
+		}
 
-        public String getKeyPattern() {
-            return keyPattern;
-        }
+		public boolean isSelfKeyed() {
+			return selfKeyed;
+		}
 
-        public boolean isNoImpl() {
-            return noImpl;
-        }
+		public String getKeyPattern() {
+			return keyPattern;
+		}
 
-        public boolean isBoolean() {
-            return type.equals("Boolean");
-        }
+		public boolean isNoImpl() {
+			return noImpl;
+		}
 
-        public boolean getBoolDefault() {
-            return boolDefault;
-        }
+		public boolean isBoolean() {
+			return type.equals("Boolean");
+		}
 
-        public String getParentPath() {
-            return parentPath != null ? parentPath : id;
-        }
-    }
+		public boolean getBoolDefault() {
+			return boolDefault;
+		}
 
-    public static class Method {
-        private String name;
-        private String type;
-        private List<String> argDecls;
-        private List<String> code;
+		public String getParentPath() {
+			return parentPath != null ? parentPath : id;
+		}
 
-        public String getName() {
-            return name;
-        }
+		public String getImplType() {
+			Type objectType = getContainer().getTypeData().getTypeMap().get(getType());
+			return Type.getImplType(objectType != null ? objectType.getName() : getType());
+		}
 
-        public String getType() {
-            return type;
-        }
+		public boolean isScalarType() {
+			switch (getType()) {
+			case "String":
+			case "Integer":
+			case "Number":
+			case "Boolean":
+			case "Primitive":
+			case "Object":
+				return true;
+			default:
+				return false;
+			}
+		}
 
-        public List<String> getArgDecls() {
-            return argDecls;
-        }
+		public String getPropertyName() {
+			return structure == Structure.scalar ? getLcName() : getLcPlural();
+		}
 
-        public List<String> getCode() {
-            return code;
-        }
-    }
+		public String getPropertyType() {
+			switch (structure) {
+			case scalar:
+				return getImplType();
+			case collection:
+				if (isScalarType()) {
+					return t("ValListOverlay<${type}, ${implType}>", this);
+				} else {
+					return t("ListOverlay<${implType}>", this);
+				}
+			case map:
+				if (isScalarType()) {
+					return t("ValMapOverlay<${type}, ${implType}>", this);
+				} else {
+					return t("MapOverlay<${implType}>", this);
+				}
+			}
+			return null;
+		}
 
-    public enum Structure {
-        scalar, collection, map
-    }
+		public String getPropertyNew() {
+			switch (structure) {
+			case scalar:
+				return t(isScalarType() ? "new ${implType}(${qpath}, this)"
+						: "${implType}.factory.create(${qpath}, this)", this);
+			case collection:
+				return t(isScalarType() ? "new ValListOverlay<${type}, ${implType}>(${qpath}, this, ${implType}.factory)"
+						: "new ListOverlay<${implType}>(${qpath}, this, ${implType}.factory)", this);
+			case map:
+				return t(isScalarType()
+						? "new ValMapOverlay<${type}, ${implType}>(${qpath}, this, ${implType}.factory, ${qkeyPat})"
+						: "new MapOverlay<${implType}>(${qpath}, this, ${implType}.factory, ${qkeyPat})", this);
+			}
+			return null;
+		}
+
+		public String getTypeInCollection() {
+			return isScalarType() ? type : t("? extends ${type}", this);
+		}
+	}
+
+	public static class Method {
+		private String name;
+		private String type;
+		private List<String> argDecls;
+		private List<String> code;
+
+		public String getName() {
+			return name;
+		}
+
+		public String getType() {
+			return type;
+		}
+
+		public List<String> getArgDecls() {
+			return argDecls;
+		}
+
+		public List<String> getCode() {
+			return code;
+		}
+	}
+
+	public enum Structure {
+		scalar, collection, map
+	}
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/gen/TypeGenerator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/gen/TypeGenerator.java
@@ -31,7 +31,6 @@ import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.body.BodyDeclaration;
 import com.github.javaparser.ast.body.ConstructorDeclaration;
 import com.github.javaparser.ast.body.FieldDeclaration;
-import com.github.javaparser.ast.body.InitializerDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.body.TypeDeclaration;
 import com.github.javaparser.ast.comments.Comment;
@@ -63,8 +62,8 @@ import com.reprezen.kaizen.oasparser.jsonoverlay.std.Primitive;
 import com.reprezen.kaizen.oasparser.jsonoverlay.std.PrimitiveOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.std.StringOverlay;
 import com.reprezen.kaizen.oasparser.val.ValidationResults;
-import com.reprezen.kaizen.oasparser.val.Validator;
 import com.reprezen.kaizen.oasparser.val.ValidationResults.Severity;
+import com.reprezen.kaizen.oasparser.val.Validator;
 import com.reprezen.kaizen.oasparser.val3.OpenApi3Validator;
 
 public abstract class TypeGenerator {
@@ -231,6 +230,7 @@ public abstract class TypeGenerator {
                 gen.addGeneratedMembers(getFieldMethods(field));
             }
         }
+        gen.addGeneratedMembers(getOtherMembers(type));
     }
 
     protected boolean skipField(Field field) {
@@ -292,6 +292,10 @@ public abstract class TypeGenerator {
     protected Members getFieldMethods(Field field) {
         return new Members();
     }
+    
+    protected Members getOtherMembers(Type type) {
+    	return new Members();
+    }
 
     protected Member addMember(String declaration, Collection<String> code) {
         Member member = new Member(declaration, code);
@@ -300,49 +304,6 @@ public abstract class TypeGenerator {
 
     protected final Member addMember(String declaration) {
         return addMember(declaration, null);
-    }
-
-    protected static String getImplType(Field field) {
-        Type fieldType = field.getContainer().getTypeData().getTypeMap().get(field.getType());
-        return fieldType == null ? getImplType(field.getType()) : getImplType(fieldType);
-    }
-
-    protected static String getImplType(Type type) {
-        return type.isNoGen() ? type.getName() : getImplType(type.getName());
-    }
-
-    protected static String getTypeInCollection(Field field) {
-        String type = field.getType();
-        return isScalarType(field) ? type : "? extends " + type;
-    }
-
-    protected static String getImplType(String type) {
-        switch (type) {
-        case "String":
-        case "Integer":
-        case "Number":
-        case "Boolean":
-        case "Primitive":
-            return type + "Overlay";
-        case "Object":
-            return "AnyObjectOverlay";
-        default:
-            return type + "Impl";
-        }
-    }
-
-    protected static boolean isScalarType(Field field) {
-        switch (field.getType()) {
-        case "String":
-        case "Integer":
-        case "Number":
-        case "Boolean":
-        case "Primitive":
-        case "Object":
-            return true;
-        default:
-            return false;
-        }
     }
 
     protected static class Members extends ArrayList<Member> {

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/gen/TypeGenerator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/gen/TypeGenerator.java
@@ -24,6 +24,7 @@ import javax.annotation.Generated;
 
 import org.apache.commons.io.FileUtils;
 
+import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.github.javaparser.JavaParser;
 import com.github.javaparser.ParseException;
@@ -167,6 +168,7 @@ public abstract class TypeGenerator {
                 Map.class, //
                 Optional.class, //
                 JsonNode.class, //
+                JsonPointer.class, //
                 JsonOverlay.class, //
                 JsonOverlayFactory.class, //
                 ReferenceRegistry.class, //

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/std/AnyObjectOverlay.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/std/AnyObjectOverlay.java
@@ -36,7 +36,7 @@ public class AnyObjectOverlay extends JsonOverlay<Object> {
     }
 
     @Override
-    public JsonNode _createJson() {
+    public JsonNode _createJson(boolean followRefs) {
         return value != null ? mapper.convertValue(value, JsonNode.class) : MissingNode.getInstance();
     }
 

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/std/AnyObjectOverlay.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/std/AnyObjectOverlay.java
@@ -36,7 +36,7 @@ public class AnyObjectOverlay extends JsonOverlay<Object> {
     }
 
     @Override
-    public JsonNode toJson() {
+    public JsonNode createJson() {
         return value != null ? mapper.convertValue(value, JsonNode.class) : MissingNode.getInstance();
     }
 

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/std/AnyObjectOverlay.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/std/AnyObjectOverlay.java
@@ -36,7 +36,7 @@ public class AnyObjectOverlay extends JsonOverlay<Object> {
     }
 
     @Override
-    public JsonNode createJson() {
+    public JsonNode _createJson() {
         return value != null ? mapper.convertValue(value, JsonNode.class) : MissingNode.getInstance();
     }
 

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/std/BooleanOverlay.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/std/BooleanOverlay.java
@@ -41,7 +41,7 @@ public class BooleanOverlay extends JsonOverlay<Boolean> {
     }
 
     @Override
-    public JsonNode _createJson() {
+    public JsonNode _createJson(boolean followRefs) {
         return value != null ? jsonFactory.booleanNode(value) : MissingNode.getInstance();
 
     }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/std/BooleanOverlay.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/std/BooleanOverlay.java
@@ -41,7 +41,7 @@ public class BooleanOverlay extends JsonOverlay<Boolean> {
     }
 
     @Override
-    public JsonNode createJson() {
+    public JsonNode _createJson() {
         return value != null ? jsonFactory.booleanNode(value) : MissingNode.getInstance();
 
     }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/std/BooleanOverlay.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/std/BooleanOverlay.java
@@ -41,7 +41,7 @@ public class BooleanOverlay extends JsonOverlay<Boolean> {
     }
 
     @Override
-    public JsonNode toJson() {
+    public JsonNode createJson() {
         return value != null ? jsonFactory.booleanNode(value) : MissingNode.getInstance();
 
     }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/std/IntegerOverlay.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/std/IntegerOverlay.java
@@ -41,7 +41,7 @@ public class IntegerOverlay extends JsonOverlay<Integer> {
     }
 
     @Override
-    public JsonNode _createJson() {
+    public JsonNode _createJson(boolean followRefs) {
         return value != null ? jsonFactory.numberNode(value) : MissingNode.getInstance();
     }
 

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/std/IntegerOverlay.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/std/IntegerOverlay.java
@@ -41,7 +41,7 @@ public class IntegerOverlay extends JsonOverlay<Integer> {
     }
 
     @Override
-    public JsonNode createJson() {
+    public JsonNode _createJson() {
         return value != null ? jsonFactory.numberNode(value) : MissingNode.getInstance();
     }
 

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/std/IntegerOverlay.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/std/IntegerOverlay.java
@@ -41,7 +41,7 @@ public class IntegerOverlay extends JsonOverlay<Integer> {
     }
 
     @Override
-    public JsonNode toJson() {
+    public JsonNode createJson() {
         return value != null ? jsonFactory.numberNode(value) : MissingNode.getInstance();
     }
 

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/std/NumberOverlay.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/std/NumberOverlay.java
@@ -65,7 +65,7 @@ public class NumberOverlay extends JsonOverlay<Number> {
     }
 
     @Override
-    public JsonNode _createJson() {
+    public JsonNode _createJson(boolean followRefs) {
         if (value != null) {
             NumberType type = NumberType.of(value);
             if (type == null) {

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/std/NumberOverlay.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/std/NumberOverlay.java
@@ -16,6 +16,7 @@ import java.util.Map;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.MissingNode;
+import com.google.common.collect.Maps;
 import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlayFactory;
 
@@ -121,6 +122,7 @@ public class NumberOverlay extends JsonOverlay<Number> {
         }
 
         private static void buildTypeMap() {
+        	typeMap = Maps.newHashMap();
             for (NumberType type : NumberType.values()) {
                 typeMap.put(type.cls, type);
             }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/std/NumberOverlay.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/std/NumberOverlay.java
@@ -65,7 +65,7 @@ public class NumberOverlay extends JsonOverlay<Number> {
     }
 
     @Override
-    public JsonNode createJson() {
+    public JsonNode _createJson() {
         if (value != null) {
             NumberType type = NumberType.of(value);
             if (type == null) {

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/std/NumberOverlay.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/std/NumberOverlay.java
@@ -64,7 +64,7 @@ public class NumberOverlay extends JsonOverlay<Number> {
     }
 
     @Override
-    public JsonNode toJson() {
+    public JsonNode createJson() {
         if (value != null) {
             NumberType type = NumberType.of(value);
             if (type == null) {

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/std/PrimitiveOverlay.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/std/PrimitiveOverlay.java
@@ -51,7 +51,7 @@ public class PrimitiveOverlay extends JsonOverlay<Object> {
     }
 
     @Override
-    public JsonNode toJson() {
+    public JsonNode createJson() {
         if (value instanceof String) {
             return jsonFactory.textNode((String) value);
         } else if (value instanceof BigDecimal) {

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/std/PrimitiveOverlay.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/std/PrimitiveOverlay.java
@@ -51,7 +51,7 @@ public class PrimitiveOverlay extends JsonOverlay<Object> {
     }
 
     @Override
-    public JsonNode createJson() {
+    public JsonNode _createJson() {
         if (value instanceof String) {
             return jsonFactory.textNode((String) value);
         } else if (value instanceof BigDecimal) {

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/std/PrimitiveOverlay.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/std/PrimitiveOverlay.java
@@ -51,7 +51,7 @@ public class PrimitiveOverlay extends JsonOverlay<Object> {
     }
 
     @Override
-    public JsonNode _createJson() {
+    public JsonNode _createJson(boolean followRefs) {
         if (value instanceof String) {
             return jsonFactory.textNode((String) value);
         } else if (value instanceof BigDecimal) {

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/std/StringOverlay.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/std/StringOverlay.java
@@ -42,7 +42,7 @@ public class StringOverlay extends JsonOverlay<String> {
 	}
 
 	@Override
-	public JsonNode _createJson() {
+	public JsonNode _createJson(boolean followRefs) {
 		return value != null ? jsonFactory.textNode(value) : MissingNode.getInstance();
 	}
 

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/std/StringOverlay.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/std/StringOverlay.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package com.reprezen.kaizen.oasparser.jsonoverlay.std;
 
+import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.MissingNode;
 import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
@@ -17,47 +18,47 @@ import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlayFactory;
 
 public class StringOverlay extends JsonOverlay<String> {
 
-    public StringOverlay(String key, JsonNode json, JsonOverlay<?> parent) {
-        super(key, json, parent);
-    }
+	public StringOverlay(String key, JsonNode json, JsonOverlay<?> parent) {
+		super(key, json, parent);
+	}
 
-    public StringOverlay(String key, JsonOverlay<?> parent) {
-        super(key, parent);
-    }
+	public StringOverlay(String key, JsonOverlay<?> parent) {
+		super(key, parent);
+	}
 
-    public StringOverlay(String key, String value, JsonOverlay<?> parent) {
-        super(key, value, parent);
-    }
+	public StringOverlay(String key, String value, JsonOverlay<?> parent) {
+		super(key, value, parent);
+	}
 
-    @Override
-    public boolean isMissing() {
-        return super.isMissing() || !getJson().isTextual();
-    }
+	@Override
+	public boolean isMissing() {
+		return super.isMissing() || !getJson().isTextual();
+	}
 
-    @Override
-    public String fromJson() {
-        JsonNode json = getJson();
-        return json.isTextual() ? json.textValue() : null;
-    }
+	@Override
+	public String fromJson() {
+		JsonNode json = getJson();
+		return json.isTextual() ? json.textValue() : null;
+	}
 
-    @Override
-    public JsonNode createJson() {
-        return value != null ? jsonFactory.textNode(value) : MissingNode.getInstance();
-    }
+	@Override
+	public JsonNode createJson() {
+		return value != null ? jsonFactory.textNode(value) : MissingNode.getInstance();
+	}
 
-    public static JsonOverlayFactory<StringOverlay> factory = new JsonOverlayFactory<StringOverlay>() {
-        @Override
-        public StringOverlay create(String key, JsonNode json, JsonOverlay<?> parent) {
-            return new StringOverlay(key, json, parent);
-        }
+	public static JsonOverlayFactory<StringOverlay> factory = new JsonOverlayFactory<StringOverlay>() {
+		@Override
+		public StringOverlay create(String key, JsonNode json, JsonOverlay<?> parent) {
+			return new StringOverlay(key, json, parent);
+		}
 
-        @Override
-        public StringOverlay create(String key, Object value, JsonOverlay<?> parent) {
-            if (value == null || value instanceof String) {
-                return new StringOverlay(key, (String) value, parent);
-            } else {
-                return super.create(key, value, parent);
-            }
-        }
-    };
+		@Override
+		public StringOverlay create(String key, Object value, JsonOverlay<?> parent) {
+			if (value == null || value instanceof String) {
+				return new StringOverlay(key, (String) value, parent);
+			} else {
+				return super.create(key, value, parent);
+			}
+		}
+	};
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/std/StringOverlay.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/std/StringOverlay.java
@@ -41,7 +41,7 @@ public class StringOverlay extends JsonOverlay<String> {
     }
 
     @Override
-    public JsonNode toJson() {
+    public JsonNode createJson() {
         return value != null ? jsonFactory.textNode(value) : MissingNode.getInstance();
     }
 

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/std/StringOverlay.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/std/StringOverlay.java
@@ -42,7 +42,7 @@ public class StringOverlay extends JsonOverlay<String> {
 	}
 
 	@Override
-	public JsonNode createJson() {
+	public JsonNode _createJson() {
 		return value != null ? jsonFactory.textNode(value) : MissingNode.getInstance();
 	}
 

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/OpenApiObject.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/OpenApiObject.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package com.reprezen.kaizen.oasparser.model3;
 
+import com.fasterxml.jackson.databind.JsonNode;
+
 public interface OpenApiObject {
 
     OpenApi3 getModel();
@@ -19,4 +21,8 @@ public interface OpenApiObject {
     boolean isMissing();
 
     String getKey();
+    
+    JsonNode toJson();
+    
+    JsonNode toJson(boolean followRefs);
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/CallbackImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/CallbackImpl.java
@@ -26,10 +26,10 @@ public class CallbackImpl extends OpenApiObjectImpl implements Callback {
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private MapOverlay<PathImpl> callbackPaths = registerField("", "callbackPaths", "(?!x-).*", new MapOverlay<PathImpl>("", this, PathImpl.factory, "(?!x-).*"));
+    private MapOverlay<PathImpl> callbackPaths = new MapOverlay<PathImpl>("", this, PathImpl.factory, "(?!x-).*");
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private ValMapOverlay<Object,AnyObjectOverlay> extensions = registerField("", "extensions", "x-.+", new ValMapOverlay<Object, AnyObjectOverlay>("", this, AnyObjectOverlay.factory, "x-.+"));
+    private ValMapOverlay<Object, AnyObjectOverlay> extensions = new ValMapOverlay<Object, AnyObjectOverlay>("", this, AnyObjectOverlay.factory, "x-.+");
 
     // CallbackPath
     @Override
@@ -114,5 +114,15 @@ public class CallbackImpl extends OpenApiObjectImpl implements Callback {
         return isEmptyRecursive(parent, CallbackImpl.class) ? null : new CallbackImpl(key, json, parent);
     }
 };
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    protected void installPropertyAccessors(PropertyAccessors accessors) {
+        OverlayGetter getter = null;
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return callbackPaths;}};
+            accessors.add("", "(?!x-).*", getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return extensions;}};
+            accessors.add("", "x-.+", getter);
+    }
 
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ContactImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ContactImpl.java
@@ -24,16 +24,16 @@ public class ContactImpl extends OpenApiObjectImpl implements Contact {
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private StringOverlay name = registerField("name", "name", null, new StringOverlay("name", this));
+    private StringOverlay name = new StringOverlay("name", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private StringOverlay url = registerField("url", "url", null, new StringOverlay("url", this));
+    private StringOverlay url = new StringOverlay("url", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private StringOverlay email = registerField("email", "email", null, new StringOverlay("email", this));
+    private StringOverlay email = new StringOverlay("email", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private ValMapOverlay<Object,AnyObjectOverlay> extensions = registerField("", "extensions", "x-.+", new ValMapOverlay<Object, AnyObjectOverlay>("", this, AnyObjectOverlay.factory, "x-.+"));
+    private ValMapOverlay<Object, AnyObjectOverlay> extensions = new ValMapOverlay<Object, AnyObjectOverlay>("", this, AnyObjectOverlay.factory, "x-.+");
 
     // Name
     @Override
@@ -118,5 +118,19 @@ public class ContactImpl extends OpenApiObjectImpl implements Contact {
         return isEmptyRecursive(parent, ContactImpl.class) ? null : new ContactImpl(key, json, parent);
     }
 };
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    protected void installPropertyAccessors(PropertyAccessors accessors) {
+        OverlayGetter getter = null;
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return name;}};
+            accessors.add("name", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return url;}};
+            accessors.add("url", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return email;}};
+            accessors.add("email", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return extensions;}};
+            accessors.add("", "x-.+", getter);
+    }
 
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/EncodingPropertyImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/EncodingPropertyImpl.java
@@ -25,19 +25,19 @@ public class EncodingPropertyImpl extends OpenApiObjectImpl implements EncodingP
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private StringOverlay contentType = registerField("contentType", "contentType", null, new StringOverlay("contentType", this));
+    private StringOverlay contentType = new StringOverlay("contentType", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private ValMapOverlay<String,StringOverlay> headers = registerField("Headers", "headers", null, new ValMapOverlay<String, StringOverlay>("Headers", this, StringOverlay.factory, null));
+    private ValMapOverlay<String, StringOverlay> headers = new ValMapOverlay<String, StringOverlay>("Headers", this, StringOverlay.factory, null);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private StringOverlay style = registerField("style", "style", null, new StringOverlay("style", this));
+    private StringOverlay style = new StringOverlay("style", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private BooleanOverlay explode = registerField("explode", "explode", null, new BooleanOverlay("explode", this));
+    private BooleanOverlay explode = new BooleanOverlay("explode", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private ValMapOverlay<Object,AnyObjectOverlay> extensions = registerField("", "extensions", "x-.+", new ValMapOverlay<Object, AnyObjectOverlay>("", this, AnyObjectOverlay.factory, "x-.+"));
+    private ValMapOverlay<Object, AnyObjectOverlay> extensions = new ValMapOverlay<Object, AnyObjectOverlay>("", this, AnyObjectOverlay.factory, "x-.+");
 
     // ContentType
     @Override
@@ -165,5 +165,21 @@ public class EncodingPropertyImpl extends OpenApiObjectImpl implements EncodingP
         return isEmptyRecursive(parent, EncodingPropertyImpl.class) ? null : new EncodingPropertyImpl(key, json, parent);
     }
 };
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    protected void installPropertyAccessors(PropertyAccessors accessors) {
+        OverlayGetter getter = null;
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return contentType;}};
+            accessors.add("contentType", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return headers;}};
+            accessors.add("Headers", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return style;}};
+            accessors.add("style", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return explode;}};
+            accessors.add("explode", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return extensions;}};
+            accessors.add("", "x-.+", getter);
+    }
 
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ExampleImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ExampleImpl.java
@@ -24,19 +24,19 @@ public class ExampleImpl extends OpenApiObjectImpl implements Example {
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private StringOverlay summary = registerField("summary", "summary", null, new StringOverlay("summary", this));
+    private StringOverlay summary = new StringOverlay("summary", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private StringOverlay description = registerField("description", "description", null, new StringOverlay("description", this));
+    private StringOverlay description = new StringOverlay("description", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private AnyObjectOverlay value = registerField("value", "value", null, new AnyObjectOverlay("value", this));
+    private AnyObjectOverlay value = new AnyObjectOverlay("value", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private StringOverlay externalValue = registerField("externalValue", "externalValue", null, new StringOverlay("externalValue", this));
+    private StringOverlay externalValue = new StringOverlay("externalValue", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private ValMapOverlay<Object,AnyObjectOverlay> extensions = registerField("", "extensions", "x-.+", new ValMapOverlay<Object, AnyObjectOverlay>("", this, AnyObjectOverlay.factory, "x-.+"));
+    private ValMapOverlay<Object, AnyObjectOverlay> extensions = new ValMapOverlay<Object, AnyObjectOverlay>("", this, AnyObjectOverlay.factory, "x-.+");
 
     // Summary
     @Override
@@ -134,5 +134,21 @@ public class ExampleImpl extends OpenApiObjectImpl implements Example {
         return isEmptyRecursive(parent, ExampleImpl.class) ? null : new ExampleImpl(key, json, parent);
     }
 };
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    protected void installPropertyAccessors(PropertyAccessors accessors) {
+        OverlayGetter getter = null;
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return summary;}};
+            accessors.add("summary", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return description;}};
+            accessors.add("description", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return value;}};
+            accessors.add("value", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return externalValue;}};
+            accessors.add("externalValue", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return extensions;}};
+            accessors.add("", "x-.+", getter);
+    }
 
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ExternalDocsImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ExternalDocsImpl.java
@@ -24,13 +24,13 @@ public class ExternalDocsImpl extends OpenApiObjectImpl implements ExternalDocs 
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private StringOverlay description = registerField("description", "description", null, new StringOverlay("description", this));
+    private StringOverlay description = new StringOverlay("description", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private StringOverlay url = registerField("url", "url", null, new StringOverlay("url", this));
+    private StringOverlay url = new StringOverlay("url", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private ValMapOverlay<Object,AnyObjectOverlay> extensions = registerField("", "extensions", "x-.+", new ValMapOverlay<Object, AnyObjectOverlay>("", this, AnyObjectOverlay.factory, "x-.+"));
+    private ValMapOverlay<Object, AnyObjectOverlay> extensions = new ValMapOverlay<Object, AnyObjectOverlay>("", this, AnyObjectOverlay.factory, "x-.+");
 
     // Description
     @Override
@@ -102,5 +102,17 @@ public class ExternalDocsImpl extends OpenApiObjectImpl implements ExternalDocs 
         return isEmptyRecursive(parent, ExternalDocsImpl.class) ? null : new ExternalDocsImpl(key, json, parent);
     }
 };
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    protected void installPropertyAccessors(PropertyAccessors accessors) {
+        OverlayGetter getter = null;
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return description;}};
+            accessors.add("description", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return url;}};
+            accessors.add("url", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return extensions;}};
+            accessors.add("", "x-.+", getter);
+    }
 
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/HeaderImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/HeaderImpl.java
@@ -27,4 +27,10 @@ public class HeaderImpl extends ParameterImpl implements Header {
     }
 };
 
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    protected void installPropertyAccessors(PropertyAccessors accessors) {
+        OverlayGetter getter = null;
+    }
+
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/HeaderImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/HeaderImpl.java
@@ -27,10 +27,4 @@ public class HeaderImpl extends ParameterImpl implements Header {
     }
 };
 
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    protected void installPropertyAccessors(PropertyAccessors accessors) {
-        OverlayGetter getter = null;
-    }
-
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/InfoImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/InfoImpl.java
@@ -28,25 +28,25 @@ public class InfoImpl extends OpenApiObjectImpl implements Info {
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private StringOverlay title = registerField("title", "title", null, new StringOverlay("title", this));
+    private StringOverlay title = new StringOverlay("title", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private StringOverlay description = registerField("description", "description", null, new StringOverlay("description", this));
+    private StringOverlay description = new StringOverlay("description", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private StringOverlay termsOfService = registerField("termsOfService", "termsOfService", null, new StringOverlay("termsOfService", this));
+    private StringOverlay termsOfService = new StringOverlay("termsOfService", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private ContactImpl contact = registerField("contact", "contact", null, ContactImpl.factory.create("contact", this));
+    private ContactImpl contact = ContactImpl.factory.create("contact", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private LicenseImpl license = registerField("license", "license", null, LicenseImpl.factory.create("license", this));
+    private LicenseImpl license = LicenseImpl.factory.create("license", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private StringOverlay version = registerField("version", "version", null, new StringOverlay("version", this));
+    private StringOverlay version = new StringOverlay("version", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private ValMapOverlay<Object,AnyObjectOverlay> extensions = registerField("", "extensions", "x-.+", new ValMapOverlay<Object, AnyObjectOverlay>("", this, AnyObjectOverlay.factory, "x-.+"));
+    private ValMapOverlay<Object, AnyObjectOverlay> extensions = new ValMapOverlay<Object, AnyObjectOverlay>("", this, AnyObjectOverlay.factory, "x-.+");
 
     // Title
     @Override
@@ -170,5 +170,25 @@ public class InfoImpl extends OpenApiObjectImpl implements Info {
         return isEmptyRecursive(parent, InfoImpl.class) ? null : new InfoImpl(key, json, parent);
     }
 };
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    protected void installPropertyAccessors(PropertyAccessors accessors) {
+        OverlayGetter getter = null;
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return title;}};
+            accessors.add("title", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return description;}};
+            accessors.add("description", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return termsOfService;}};
+            accessors.add("termsOfService", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return contact;}};
+            accessors.add("contact", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return license;}};
+            accessors.add("license", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return version;}};
+            accessors.add("version", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return extensions;}};
+            accessors.add("", "x-.+", getter);
+    }
 
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/LicenseImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/LicenseImpl.java
@@ -24,13 +24,13 @@ public class LicenseImpl extends OpenApiObjectImpl implements License {
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private StringOverlay name = registerField("name", "name", null, new StringOverlay("name", this));
+    private StringOverlay name = new StringOverlay("name", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private StringOverlay url = registerField("url", "url", null, new StringOverlay("url", this));
+    private StringOverlay url = new StringOverlay("url", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private ValMapOverlay<Object,AnyObjectOverlay> extensions = registerField("", "extensions", "x-.+", new ValMapOverlay<Object, AnyObjectOverlay>("", this, AnyObjectOverlay.factory, "x-.+"));
+    private ValMapOverlay<Object, AnyObjectOverlay> extensions = new ValMapOverlay<Object, AnyObjectOverlay>("", this, AnyObjectOverlay.factory, "x-.+");
 
     // Name
     @Override
@@ -102,5 +102,17 @@ public class LicenseImpl extends OpenApiObjectImpl implements License {
         return isEmptyRecursive(parent, LicenseImpl.class) ? null : new LicenseImpl(key, json, parent);
     }
 };
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    protected void installPropertyAccessors(PropertyAccessors accessors) {
+        OverlayGetter getter = null;
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return name;}};
+            accessors.add("name", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return url;}};
+            accessors.add("url", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return extensions;}};
+            accessors.add("", "x-.+", getter);
+    }
 
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/LinkImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/LinkImpl.java
@@ -29,25 +29,25 @@ public class LinkImpl extends OpenApiObjectImpl implements Link {
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private StringOverlay operationId = registerField("operationId", "operationId", null, new StringOverlay("operationId", this));
+    private StringOverlay operationId = new StringOverlay("operationId", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private StringOverlay operationRef = registerField("operationRef", "operationRef", null, new StringOverlay("operationRef", this));
+    private StringOverlay operationRef = new StringOverlay("operationRef", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private ValMapOverlay<String,StringOverlay> parameters = registerField("parameters", "parameters", null, new ValMapOverlay<String, StringOverlay>("parameters", this, StringOverlay.factory, null));
+    private ValMapOverlay<String, StringOverlay> parameters = new ValMapOverlay<String, StringOverlay>("parameters", this, StringOverlay.factory, null);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private MapOverlay<HeaderImpl> headers = registerField("headers", "headers", null, new MapOverlay<HeaderImpl>("headers", this, HeaderImpl.factory, null));
+    private MapOverlay<HeaderImpl> headers = new MapOverlay<HeaderImpl>("headers", this, HeaderImpl.factory, null);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private StringOverlay description = registerField("description", "description", null, new StringOverlay("description", this));
+    private StringOverlay description = new StringOverlay("description", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private ServerImpl server = registerField("server", "server", null, ServerImpl.factory.create("server", this));
+    private ServerImpl server = ServerImpl.factory.create("server", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private ValMapOverlay<Object,AnyObjectOverlay> extensions = registerField("", "extensions", "x-.+", new ValMapOverlay<Object, AnyObjectOverlay>("", this, AnyObjectOverlay.factory, "x-.+"));
+    private ValMapOverlay<Object, AnyObjectOverlay> extensions = new ValMapOverlay<Object, AnyObjectOverlay>("", this, AnyObjectOverlay.factory, "x-.+");
 
     // OperationId
     @Override
@@ -221,5 +221,25 @@ public class LinkImpl extends OpenApiObjectImpl implements Link {
         return isEmptyRecursive(parent, LinkImpl.class) ? null : new LinkImpl(key, json, parent);
     }
 };
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    protected void installPropertyAccessors(PropertyAccessors accessors) {
+        OverlayGetter getter = null;
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return operationId;}};
+            accessors.add("operationId", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return operationRef;}};
+            accessors.add("operationRef", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return parameters;}};
+            accessors.add("parameters", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return headers;}};
+            accessors.add("headers", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return description;}};
+            accessors.add("description", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return server;}};
+            accessors.add("server", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return extensions;}};
+            accessors.add("", "x-.+", getter);
+    }
 
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/MediaTypeImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/MediaTypeImpl.java
@@ -30,19 +30,19 @@ public class MediaTypeImpl extends OpenApiObjectImpl implements MediaType {
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private SchemaImpl schema = registerField("schema", "schema", null, SchemaImpl.factory.create("schema", this));
+    private SchemaImpl schema = SchemaImpl.factory.create("schema", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private MapOverlay<ExampleImpl> examples = registerField("examples", "examples", "[a-zA-Z0-9\\._-]+", new MapOverlay<ExampleImpl>("examples", this, ExampleImpl.factory, "[a-zA-Z0-9\\._-]+"));
+    private MapOverlay<ExampleImpl> examples = new MapOverlay<ExampleImpl>("examples", this, ExampleImpl.factory, "[a-zA-Z0-9\\._-]+");
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private AnyObjectOverlay example = registerField("example", "example", null, new AnyObjectOverlay("example", this));
+    private AnyObjectOverlay example = new AnyObjectOverlay("example", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private MapOverlay<EncodingPropertyImpl> encodingProperties = registerField("encoding", "encodingProperties", null, new MapOverlay<EncodingPropertyImpl>("encoding", this, EncodingPropertyImpl.factory, null));
+    private MapOverlay<EncodingPropertyImpl> encodingProperties = new MapOverlay<EncodingPropertyImpl>("encoding", this, EncodingPropertyImpl.factory, null);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private ValMapOverlay<Object,AnyObjectOverlay> extensions = registerField("", "extensions", "x-.+", new ValMapOverlay<Object, AnyObjectOverlay>("", this, AnyObjectOverlay.factory, "x-.+"));
+    private ValMapOverlay<Object, AnyObjectOverlay> extensions = new ValMapOverlay<Object, AnyObjectOverlay>("", this, AnyObjectOverlay.factory, "x-.+");
 
     // Schema
     @Override
@@ -192,5 +192,21 @@ public class MediaTypeImpl extends OpenApiObjectImpl implements MediaType {
         return isEmptyRecursive(parent, MediaTypeImpl.class) ? null : new MediaTypeImpl(key, json, parent);
     }
 };
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    protected void installPropertyAccessors(PropertyAccessors accessors) {
+        OverlayGetter getter = null;
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return schema;}};
+            accessors.add("schema", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return examples;}};
+            accessors.add("examples", "[a-zA-Z0-9\\._-]+", getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return example;}};
+            accessors.add("example", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return encodingProperties;}};
+            accessors.add("encoding", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return extensions;}};
+            accessors.add("", "x-.+", getter);
+    }
 
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/OAuthFlowImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/OAuthFlowImpl.java
@@ -24,22 +24,22 @@ public class OAuthFlowImpl extends OpenApiObjectImpl implements OAuthFlow {
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private StringOverlay authorizationUrl = registerField("authorizationUrl", "authorizationUrl", null, new StringOverlay("authorizationUrl", this));
+    private StringOverlay authorizationUrl = new StringOverlay("authorizationUrl", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private StringOverlay tokenUrl = registerField("tokenUrl", "tokenUrl", null, new StringOverlay("tokenUrl", this));
+    private StringOverlay tokenUrl = new StringOverlay("tokenUrl", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private StringOverlay refreshUrl = registerField("refreshUrl", "refreshUrl", null, new StringOverlay("refreshUrl", this));
+    private StringOverlay refreshUrl = new StringOverlay("refreshUrl", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private ValMapOverlay<String,StringOverlay> scopes = registerField("scopes", "scopes", "(?!x-).*", new ValMapOverlay<String, StringOverlay>("scopes", this, StringOverlay.factory, "(?!x-).*"));
+    private ValMapOverlay<String, StringOverlay> scopes = new ValMapOverlay<String, StringOverlay>("scopes", this, StringOverlay.factory, "(?!x-).*");
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private ValMapOverlay<Object,AnyObjectOverlay> scopesExtensions = registerField("scopes", "scopesExtensions", "x-.+", new ValMapOverlay<Object, AnyObjectOverlay>("scopes", this, AnyObjectOverlay.factory, "x-.+"));
+    private ValMapOverlay<Object, AnyObjectOverlay> scopesExtensions = new ValMapOverlay<Object, AnyObjectOverlay>("scopes", this, AnyObjectOverlay.factory, "x-.+");
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private ValMapOverlay<Object,AnyObjectOverlay> extensions = registerField("", "extensions", "x-.+", new ValMapOverlay<Object, AnyObjectOverlay>("", this, AnyObjectOverlay.factory, "x-.+"));
+    private ValMapOverlay<Object, AnyObjectOverlay> extensions = new ValMapOverlay<Object, AnyObjectOverlay>("", this, AnyObjectOverlay.factory, "x-.+");
 
     // AuthorizationUrl
     @Override
@@ -198,5 +198,23 @@ public class OAuthFlowImpl extends OpenApiObjectImpl implements OAuthFlow {
         return isEmptyRecursive(parent, OAuthFlowImpl.class) ? null : new OAuthFlowImpl(key, json, parent);
     }
 };
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    protected void installPropertyAccessors(PropertyAccessors accessors) {
+        OverlayGetter getter = null;
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return authorizationUrl;}};
+            accessors.add("authorizationUrl", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return tokenUrl;}};
+            accessors.add("tokenUrl", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return refreshUrl;}};
+            accessors.add("refreshUrl", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return scopes;}};
+            accessors.add("scopes", "(?!x-).*", getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return scopesExtensions;}};
+            accessors.add("scopes", "x-.+", getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return extensions;}};
+            accessors.add("", "x-.+", getter);
+    }
 
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/OpenApi3Impl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/OpenApi3Impl.java
@@ -98,61 +98,61 @@ public class OpenApi3Impl extends OpenApiObjectImpl implements OpenApi3 {
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private StringOverlay openApi = registerField("openapi", "openApi", null, new StringOverlay("openapi", this));
+    private StringOverlay openApi = new StringOverlay("openapi", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private InfoImpl info = registerField("info", "info", null, InfoImpl.factory.create("info", this));
+    private InfoImpl info = InfoImpl.factory.create("info", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private ListOverlay<ServerImpl> servers = registerField("servers", "servers", null, new ListOverlay<ServerImpl>("servers", this, ServerImpl.factory));
+    private ListOverlay<ServerImpl> servers = new ListOverlay<ServerImpl>("servers", this, ServerImpl.factory);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private MapOverlay<PathImpl> paths = registerField("paths", "paths", "/.*", new MapOverlay<PathImpl>("paths", this, PathImpl.factory, "/.*"));
+    private MapOverlay<PathImpl> paths = new MapOverlay<PathImpl>("paths", this, PathImpl.factory, "/.*");
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private ValMapOverlay<Object,AnyObjectOverlay> pathsExtensions = registerField("paths", "pathsExtensions", "x-.+", new ValMapOverlay<Object, AnyObjectOverlay>("paths", this, AnyObjectOverlay.factory, "x-.+"));
+    private ValMapOverlay<Object, AnyObjectOverlay> pathsExtensions = new ValMapOverlay<Object, AnyObjectOverlay>("paths", this, AnyObjectOverlay.factory, "x-.+");
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private MapOverlay<SchemaImpl> schemas = registerField("components/schemas", "schemas", "[a-zA-Z0-9\\._-]+", new MapOverlay<SchemaImpl>("components/schemas", this, SchemaImpl.factory, "[a-zA-Z0-9\\._-]+"));
+    private MapOverlay<SchemaImpl> schemas = new MapOverlay<SchemaImpl>("components/schemas", this, SchemaImpl.factory, "[a-zA-Z0-9\\._-]+");
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private MapOverlay<ResponseImpl> responses = registerField("components/responses", "responses", "[a-zA-Z0-9\\._-]+", new MapOverlay<ResponseImpl>("components/responses", this, ResponseImpl.factory, "[a-zA-Z0-9\\._-]+"));
+    private MapOverlay<ResponseImpl> responses = new MapOverlay<ResponseImpl>("components/responses", this, ResponseImpl.factory, "[a-zA-Z0-9\\._-]+");
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private MapOverlay<ParameterImpl> parameters = registerField("components/parameters", "parameters", "[a-zA-Z0-9\\._-]+", new MapOverlay<ParameterImpl>("components/parameters", this, ParameterImpl.factory, "[a-zA-Z0-9\\._-]+"));
+    private MapOverlay<ParameterImpl> parameters = new MapOverlay<ParameterImpl>("components/parameters", this, ParameterImpl.factory, "[a-zA-Z0-9\\._-]+");
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private MapOverlay<ExampleImpl> examples = registerField("components/examples", "examples", "[a-zA-Z0-9\\._-]+", new MapOverlay<ExampleImpl>("components/examples", this, ExampleImpl.factory, "[a-zA-Z0-9\\._-]+"));
+    private MapOverlay<ExampleImpl> examples = new MapOverlay<ExampleImpl>("components/examples", this, ExampleImpl.factory, "[a-zA-Z0-9\\._-]+");
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private MapOverlay<RequestBodyImpl> requestBodies = registerField("components/requestBodies", "requestBodies", "[a-zA-Z0-9\\._-]+", new MapOverlay<RequestBodyImpl>("components/requestBodies", this, RequestBodyImpl.factory, "[a-zA-Z0-9\\._-]+"));
+    private MapOverlay<RequestBodyImpl> requestBodies = new MapOverlay<RequestBodyImpl>("components/requestBodies", this, RequestBodyImpl.factory, "[a-zA-Z0-9\\._-]+");
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private MapOverlay<HeaderImpl> headers = registerField("components/headers", "headers", "[a-zA-Z0-9\\._-]+", new MapOverlay<HeaderImpl>("components/headers", this, HeaderImpl.factory, "[a-zA-Z0-9\\._-]+"));
+    private MapOverlay<HeaderImpl> headers = new MapOverlay<HeaderImpl>("components/headers", this, HeaderImpl.factory, "[a-zA-Z0-9\\._-]+");
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private MapOverlay<SecuritySchemeImpl> securitySchemes = registerField("components/securitySchemes", "securitySchemes", "[a-zA-Z0-9\\._-]+", new MapOverlay<SecuritySchemeImpl>("components/securitySchemes", this, SecuritySchemeImpl.factory, "[a-zA-Z0-9\\._-]+"));
+    private MapOverlay<SecuritySchemeImpl> securitySchemes = new MapOverlay<SecuritySchemeImpl>("components/securitySchemes", this, SecuritySchemeImpl.factory, "[a-zA-Z0-9\\._-]+");
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private MapOverlay<LinkImpl> links = registerField("components/links", "links", "[a-zA-Z0-9\\._-]+", new MapOverlay<LinkImpl>("components/links", this, LinkImpl.factory, "[a-zA-Z0-9\\._-]+"));
+    private MapOverlay<LinkImpl> links = new MapOverlay<LinkImpl>("components/links", this, LinkImpl.factory, "[a-zA-Z0-9\\._-]+");
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private MapOverlay<CallbackImpl> callbacks = registerField("components/callbacks", "callbacks", "(?!x-)[a-zA-Z0-9\\._-]+", new MapOverlay<CallbackImpl>("components/callbacks", this, CallbackImpl.factory, "(?!x-)[a-zA-Z0-9\\._-]+"));
+    private MapOverlay<CallbackImpl> callbacks = new MapOverlay<CallbackImpl>("components/callbacks", this, CallbackImpl.factory, "(?!x-)[a-zA-Z0-9\\._-]+");
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private ValMapOverlay<Object,AnyObjectOverlay> componentsExtensions = registerField("components", "componentsExtensions", "x-.+", new ValMapOverlay<Object, AnyObjectOverlay>("components", this, AnyObjectOverlay.factory, "x-.+"));
+    private ValMapOverlay<Object, AnyObjectOverlay> componentsExtensions = new ValMapOverlay<Object, AnyObjectOverlay>("components", this, AnyObjectOverlay.factory, "x-.+");
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private ListOverlay<SecurityRequirementImpl> securityRequirements = registerField("security", "securityRequirements", null, new ListOverlay<SecurityRequirementImpl>("security", this, SecurityRequirementImpl.factory));
+    private ListOverlay<SecurityRequirementImpl> securityRequirements = new ListOverlay<SecurityRequirementImpl>("security", this, SecurityRequirementImpl.factory);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private ListOverlay<TagImpl> tags = registerField("tags", "tags", null, new ListOverlay<TagImpl>("tags", this, TagImpl.factory));
+    private ListOverlay<TagImpl> tags = new ListOverlay<TagImpl>("tags", this, TagImpl.factory);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private ExternalDocsImpl externalDocs = registerField("externalDocs", "externalDocs", null, ExternalDocsImpl.factory.create("externalDocs", this));
+    private ExternalDocsImpl externalDocs = ExternalDocsImpl.factory.create("externalDocs", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private ValMapOverlay<Object,AnyObjectOverlay> extensions = registerField("", "extensions", "x-.+", new ValMapOverlay<Object, AnyObjectOverlay>("", this, AnyObjectOverlay.factory, "x-.+"));
+    private ValMapOverlay<Object, AnyObjectOverlay> extensions = new ValMapOverlay<Object, AnyObjectOverlay>("", this, AnyObjectOverlay.factory, "x-.+");
 
     // OpenApi
     @Override
@@ -836,5 +836,49 @@ public class OpenApi3Impl extends OpenApiObjectImpl implements OpenApi3 {
         return isEmptyRecursive(parent, OpenApi3Impl.class) ? null : new OpenApi3Impl(key, json, parent);
     }
 };
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    protected void installPropertyAccessors(PropertyAccessors accessors) {
+        OverlayGetter getter = null;
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return openApi;}};
+            accessors.add("openapi", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return info;}};
+            accessors.add("info", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return servers;}};
+            accessors.add("servers", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return paths;}};
+            accessors.add("paths", "/.*", getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return pathsExtensions;}};
+            accessors.add("paths", "x-.+", getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return schemas;}};
+            accessors.add("components/schemas", "[a-zA-Z0-9\\._-]+", getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return responses;}};
+            accessors.add("components/responses", "[a-zA-Z0-9\\._-]+", getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return parameters;}};
+            accessors.add("components/parameters", "[a-zA-Z0-9\\._-]+", getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return examples;}};
+            accessors.add("components/examples", "[a-zA-Z0-9\\._-]+", getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return requestBodies;}};
+            accessors.add("components/requestBodies", "[a-zA-Z0-9\\._-]+", getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return headers;}};
+            accessors.add("components/headers", "[a-zA-Z0-9\\._-]+", getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return securitySchemes;}};
+            accessors.add("components/securitySchemes", "[a-zA-Z0-9\\._-]+", getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return links;}};
+            accessors.add("components/links", "[a-zA-Z0-9\\._-]+", getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return callbacks;}};
+            accessors.add("components/callbacks", "(?!x-)[a-zA-Z0-9\\._-]+", getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return componentsExtensions;}};
+            accessors.add("components", "x-.+", getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return securityRequirements;}};
+            accessors.add("security", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return tags;}};
+            accessors.add("tags", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return externalDocs;}};
+            accessors.add("externalDocs", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return extensions;}};
+            accessors.add("", "x-.+", getter);
+    }
 
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/OpenApiObjectImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/OpenApiObjectImpl.java
@@ -18,7 +18,7 @@ import com.reprezen.kaizen.oasparser.model3.OpenApi3;
 import com.reprezen.kaizen.oasparser.model3.OpenApiObject;
 //import com.reprezen.swaggerparser.model3.OpenApi3;
 
-public class OpenApiObjectImpl extends ObjectOverlay<OpenApiObjectImpl> implements OpenApiObject {
+public abstract class OpenApiObjectImpl extends ObjectOverlay<OpenApiObjectImpl> implements OpenApiObject {
 
     protected OpenApiObjectImpl(String key, JsonNode json, JsonOverlay<?> parent, ReferenceRegistry referenceRegistry) {
         super(key, json, parent, referenceRegistry);

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/OperationImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/OperationImpl.java
@@ -43,49 +43,49 @@ public class OperationImpl extends OpenApiObjectImpl implements Operation {
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private ValListOverlay<String, StringOverlay> tags = registerField("tags", "tags", null, new ValListOverlay<String, StringOverlay>("tags", this, StringOverlay.factory));;
+    private ValListOverlay<String, StringOverlay> tags = new ValListOverlay<String, StringOverlay>("tags", this, StringOverlay.factory);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private StringOverlay summary = registerField("summary", "summary", null, new StringOverlay("summary", this));
+    private StringOverlay summary = new StringOverlay("summary", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private StringOverlay description = registerField("description", "description", null, new StringOverlay("description", this));
+    private StringOverlay description = new StringOverlay("description", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private ExternalDocsImpl externalDocs = registerField("externalDocs", "externalDocs", null, ExternalDocsImpl.factory.create("externalDocs", this));
+    private ExternalDocsImpl externalDocs = ExternalDocsImpl.factory.create("externalDocs", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private StringOverlay operationId = registerField("operationId", "operationId", null, new StringOverlay("operationId", this));
+    private StringOverlay operationId = new StringOverlay("operationId", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private ListOverlay<ParameterImpl> parameters = registerField("parameters", "parameters", null, new ListOverlay<ParameterImpl>("parameters", this, ParameterImpl.factory));
+    private ListOverlay<ParameterImpl> parameters = new ListOverlay<ParameterImpl>("parameters", this, ParameterImpl.factory);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private RequestBodyImpl requestBody = registerField("requestBody", "requestBody", null, RequestBodyImpl.factory.create("requestBody", this));
+    private RequestBodyImpl requestBody = RequestBodyImpl.factory.create("requestBody", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private MapOverlay<ResponseImpl> responses = registerField("responses", "responses", "default|(\\d\\d\\d)", new MapOverlay<ResponseImpl>("responses", this, ResponseImpl.factory, "default|(\\d\\d\\d)"));
+    private MapOverlay<ResponseImpl> responses = new MapOverlay<ResponseImpl>("responses", this, ResponseImpl.factory, "default|(\\d\\d\\d)");
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private ValMapOverlay<Object,AnyObjectOverlay> responsesExtensions = registerField("responses", "responsesExtensions", "x-.+", new ValMapOverlay<Object, AnyObjectOverlay>("responses", this, AnyObjectOverlay.factory, "x-.+"));
+    private ValMapOverlay<Object, AnyObjectOverlay> responsesExtensions = new ValMapOverlay<Object, AnyObjectOverlay>("responses", this, AnyObjectOverlay.factory, "x-.+");
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private MapOverlay<CallbackImpl> callbacks = registerField("callbacks", "callbacks", "(?!x-)[a-zA-Z0-9\\._-]+", new MapOverlay<CallbackImpl>("callbacks", this, CallbackImpl.factory, "(?!x-)[a-zA-Z0-9\\._-]+"));
+    private MapOverlay<CallbackImpl> callbacks = new MapOverlay<CallbackImpl>("callbacks", this, CallbackImpl.factory, "(?!x-)[a-zA-Z0-9\\._-]+");
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private ValMapOverlay<Object,AnyObjectOverlay> callbacksExtensions = registerField("callbacks", "callbacksExtensions", "x-.+", new ValMapOverlay<Object, AnyObjectOverlay>("callbacks", this, AnyObjectOverlay.factory, "x-.+"));
+    private ValMapOverlay<Object, AnyObjectOverlay> callbacksExtensions = new ValMapOverlay<Object, AnyObjectOverlay>("callbacks", this, AnyObjectOverlay.factory, "x-.+");
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private BooleanOverlay deprecated = registerField("deprecated", "deprecated", null, new BooleanOverlay("deprecated", this));
+    private BooleanOverlay deprecated = new BooleanOverlay("deprecated", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private ListOverlay<SecurityRequirementImpl> securityRequirements = registerField("security", "securityRequirements", null, new ListOverlay<SecurityRequirementImpl>("security", this, SecurityRequirementImpl.factory));
+    private ListOverlay<SecurityRequirementImpl> securityRequirements = new ListOverlay<SecurityRequirementImpl>("security", this, SecurityRequirementImpl.factory);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private ListOverlay<ServerImpl> servers = registerField("servers", "servers", null, new ListOverlay<ServerImpl>("servers", this, ServerImpl.factory));
+    private ListOverlay<ServerImpl> servers = new ListOverlay<ServerImpl>("servers", this, ServerImpl.factory);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private ValMapOverlay<Object,AnyObjectOverlay> extensions = registerField("", "extensions", "x-.+", new ValMapOverlay<Object, AnyObjectOverlay>("", this, AnyObjectOverlay.factory, "x-.+"));
+    private ValMapOverlay<Object, AnyObjectOverlay> extensions = new ValMapOverlay<Object, AnyObjectOverlay>("", this, AnyObjectOverlay.factory, "x-.+");
 
     // Tag
     @Override
@@ -545,5 +545,41 @@ public class OperationImpl extends OpenApiObjectImpl implements Operation {
         return isEmptyRecursive(parent, OperationImpl.class) ? null : new OperationImpl(key, json, parent);
     }
 };
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    protected void installPropertyAccessors(PropertyAccessors accessors) {
+        OverlayGetter getter = null;
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return tags;}};
+            accessors.add("tags", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return summary;}};
+            accessors.add("summary", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return description;}};
+            accessors.add("description", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return externalDocs;}};
+            accessors.add("externalDocs", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return operationId;}};
+            accessors.add("operationId", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return parameters;}};
+            accessors.add("parameters", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return requestBody;}};
+            accessors.add("requestBody", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return responses;}};
+            accessors.add("responses", "default|(\\d\\d\\d)", getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return responsesExtensions;}};
+            accessors.add("responses", "x-.+", getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return callbacks;}};
+            accessors.add("callbacks", "(?!x-)[a-zA-Z0-9\\._-]+", getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return callbacksExtensions;}};
+            accessors.add("callbacks", "x-.+", getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return deprecated;}};
+            accessors.add("deprecated", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return securityRequirements;}};
+            accessors.add("security", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return servers;}};
+            accessors.add("servers", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return extensions;}};
+            accessors.add("", "x-.+", getter);
+    }
 
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ParameterImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ParameterImpl.java
@@ -32,46 +32,46 @@ public class ParameterImpl extends OpenApiObjectImpl implements Parameter {
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private StringOverlay name = registerField("name", "name", null, new StringOverlay("name", this));
+    private StringOverlay name = new StringOverlay("name", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private StringOverlay in = registerField("in", "in", null, new StringOverlay("in", this));
+    private StringOverlay in = new StringOverlay("in", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private StringOverlay description = registerField("description", "description", null, new StringOverlay("description", this));
+    private StringOverlay description = new StringOverlay("description", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private BooleanOverlay required = registerField("required", "required", null, new BooleanOverlay("required", this));
+    private BooleanOverlay required = new BooleanOverlay("required", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private BooleanOverlay deprecated = registerField("deprecated", "deprecated", null, new BooleanOverlay("deprecated", this));
+    private BooleanOverlay deprecated = new BooleanOverlay("deprecated", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private BooleanOverlay allowEmptyValue = registerField("allowEmptyValue", "allowEmptyValue", null, new BooleanOverlay("allowEmptyValue", this));
+    private BooleanOverlay allowEmptyValue = new BooleanOverlay("allowEmptyValue", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private StringOverlay style = registerField("style", "style", null, new StringOverlay("style", this));
+    private StringOverlay style = new StringOverlay("style", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private BooleanOverlay explode = registerField("explode", "explode", null, new BooleanOverlay("explode", this));
+    private BooleanOverlay explode = new BooleanOverlay("explode", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private BooleanOverlay allowReserved = registerField("allowReserved", "allowReserved", null, new BooleanOverlay("allowReserved", this));
+    private BooleanOverlay allowReserved = new BooleanOverlay("allowReserved", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private SchemaImpl schema = registerField("schema", "schema", null, SchemaImpl.factory.create("schema", this));
+    private SchemaImpl schema = SchemaImpl.factory.create("schema", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private AnyObjectOverlay example = registerField("example", "example", null, new AnyObjectOverlay("example", this));
+    private AnyObjectOverlay example = new AnyObjectOverlay("example", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private MapOverlay<ExampleImpl> examples = registerField("examples", "examples", "[a-zA-Z0-9\\._-]+", new MapOverlay<ExampleImpl>("examples", this, ExampleImpl.factory, "[a-zA-Z0-9\\._-]+"));
+    private MapOverlay<ExampleImpl> examples = new MapOverlay<ExampleImpl>("examples", this, ExampleImpl.factory, "[a-zA-Z0-9\\._-]+");
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private MapOverlay<MediaTypeImpl> contentMediaTypes = registerField("content", "contentMediaTypes", null, new MapOverlay<MediaTypeImpl>("content", this, MediaTypeImpl.factory, null));
+    private MapOverlay<MediaTypeImpl> contentMediaTypes = new MapOverlay<MediaTypeImpl>("content", this, MediaTypeImpl.factory, null);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private ValMapOverlay<Object,AnyObjectOverlay> extensions = registerField("", "extensions", "x-.+", new ValMapOverlay<Object, AnyObjectOverlay>("", this, AnyObjectOverlay.factory, "x-.+"));
+    private ValMapOverlay<Object, AnyObjectOverlay> extensions = new ValMapOverlay<Object, AnyObjectOverlay>("", this, AnyObjectOverlay.factory, "x-.+");
 
     // Name
     @Override
@@ -368,5 +368,39 @@ public class ParameterImpl extends OpenApiObjectImpl implements Parameter {
         return isEmptyRecursive(parent, ParameterImpl.class) ? null : new ParameterImpl(key, json, parent);
     }
 };
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    protected void installPropertyAccessors(PropertyAccessors accessors) {
+        OverlayGetter getter = null;
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return name;}};
+            accessors.add("name", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return in;}};
+            accessors.add("in", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return description;}};
+            accessors.add("description", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return required;}};
+            accessors.add("required", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return deprecated;}};
+            accessors.add("deprecated", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return allowEmptyValue;}};
+            accessors.add("allowEmptyValue", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return style;}};
+            accessors.add("style", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return explode;}};
+            accessors.add("explode", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return allowReserved;}};
+            accessors.add("allowReserved", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return schema;}};
+            accessors.add("schema", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return example;}};
+            accessors.add("example", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return examples;}};
+            accessors.add("examples", "[a-zA-Z0-9\\._-]+", getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return contentMediaTypes;}};
+            accessors.add("content", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return extensions;}};
+            accessors.add("", "x-.+", getter);
+    }
 
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/PathImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/PathImpl.java
@@ -113,22 +113,22 @@ public class PathImpl extends OpenApiObjectImpl implements Path {
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private StringOverlay summary = registerField("summary", "summary", null, new StringOverlay("summary", this));
+    private StringOverlay summary = new StringOverlay("summary", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private StringOverlay description = registerField("description", "description", null, new StringOverlay("description", this));
+    private StringOverlay description = new StringOverlay("description", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private MapOverlay<OperationImpl> operations = registerField("", "operations", "get|put|post|delete|options|head|patch|trace", new MapOverlay<OperationImpl>("", this, OperationImpl.factory, "get|put|post|delete|options|head|patch|trace"));
+    private MapOverlay<OperationImpl> operations = new MapOverlay<OperationImpl>("", this, OperationImpl.factory, "get|put|post|delete|options|head|patch|trace");
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private ListOverlay<ServerImpl> servers = registerField("servers", "servers", null, new ListOverlay<ServerImpl>("servers", this, ServerImpl.factory));
+    private ListOverlay<ServerImpl> servers = new ListOverlay<ServerImpl>("servers", this, ServerImpl.factory);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private ListOverlay<ParameterImpl> parameters = registerField("parameters", "parameters", null, new ListOverlay<ParameterImpl>("parameters", this, ParameterImpl.factory));
+    private ListOverlay<ParameterImpl> parameters = new ListOverlay<ParameterImpl>("parameters", this, ParameterImpl.factory);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private ValMapOverlay<Object,AnyObjectOverlay> extensions = registerField("", "extensions", "x-.+", new ValMapOverlay<Object, AnyObjectOverlay>("", this, AnyObjectOverlay.factory, "x-.+"));
+    private ValMapOverlay<Object, AnyObjectOverlay> extensions = new ValMapOverlay<Object, AnyObjectOverlay>("", this, AnyObjectOverlay.factory, "x-.+");
 
     // Summary
     @Override
@@ -329,5 +329,23 @@ public class PathImpl extends OpenApiObjectImpl implements Path {
         return isEmptyRecursive(parent, PathImpl.class) ? null : new PathImpl(key, json, parent);
     }
 };
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    protected void installPropertyAccessors(PropertyAccessors accessors) {
+        OverlayGetter getter = null;
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return summary;}};
+            accessors.add("summary", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return description;}};
+            accessors.add("description", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return operations;}};
+            accessors.add("", "get|put|post|delete|options|head|patch|trace", getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return servers;}};
+            accessors.add("servers", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return parameters;}};
+            accessors.add("parameters", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return extensions;}};
+            accessors.add("", "x-.+", getter);
+    }
 
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/RequestBodyImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/RequestBodyImpl.java
@@ -28,16 +28,16 @@ public class RequestBodyImpl extends OpenApiObjectImpl implements RequestBody {
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private StringOverlay description = registerField("description", "description", null, new StringOverlay("description", this));
+    private StringOverlay description = new StringOverlay("description", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private MapOverlay<MediaTypeImpl> contentMediaTypes = registerField("content", "contentMediaTypes", null, new MapOverlay<MediaTypeImpl>("content", this, MediaTypeImpl.factory, null));
+    private MapOverlay<MediaTypeImpl> contentMediaTypes = new MapOverlay<MediaTypeImpl>("content", this, MediaTypeImpl.factory, null);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private BooleanOverlay required = registerField("required", "required", null, new BooleanOverlay("required", this));
+    private BooleanOverlay required = new BooleanOverlay("required", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private ValMapOverlay<Object,AnyObjectOverlay> extensions = registerField("", "extensions", "x-.+", new ValMapOverlay<Object, AnyObjectOverlay>("", this, AnyObjectOverlay.factory, "x-.+"));
+    private ValMapOverlay<Object, AnyObjectOverlay> extensions = new ValMapOverlay<Object, AnyObjectOverlay>("", this, AnyObjectOverlay.factory, "x-.+");
 
     // Description
     @Override
@@ -154,5 +154,19 @@ public class RequestBodyImpl extends OpenApiObjectImpl implements RequestBody {
         return isEmptyRecursive(parent, RequestBodyImpl.class) ? null : new RequestBodyImpl(key, json, parent);
     }
 };
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    protected void installPropertyAccessors(PropertyAccessors accessors) {
+        OverlayGetter getter = null;
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return description;}};
+            accessors.add("description", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return contentMediaTypes;}};
+            accessors.add("content", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return required;}};
+            accessors.add("required", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return extensions;}};
+            accessors.add("", "x-.+", getter);
+    }
 
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ResponseImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ResponseImpl.java
@@ -31,19 +31,19 @@ public class ResponseImpl extends OpenApiObjectImpl implements Response {
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private StringOverlay description = registerField("description", "description", null, new StringOverlay("description", this));
+    private StringOverlay description = new StringOverlay("description", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private MapOverlay<HeaderImpl> headers = registerField("headers", "headers", null, new MapOverlay<HeaderImpl>("headers", this, HeaderImpl.factory, null));
+    private MapOverlay<HeaderImpl> headers = new MapOverlay<HeaderImpl>("headers", this, HeaderImpl.factory, null);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private MapOverlay<MediaTypeImpl> contentMediaTypes = registerField("content", "contentMediaTypes", null, new MapOverlay<MediaTypeImpl>("content", this, MediaTypeImpl.factory, null));
+    private MapOverlay<MediaTypeImpl> contentMediaTypes = new MapOverlay<MediaTypeImpl>("content", this, MediaTypeImpl.factory, null);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private MapOverlay<LinkImpl> links = registerField("links", "links", null, new MapOverlay<LinkImpl>("links", this, LinkImpl.factory, null));
+    private MapOverlay<LinkImpl> links = new MapOverlay<LinkImpl>("links", this, LinkImpl.factory, null);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private ValMapOverlay<Object,AnyObjectOverlay> extensions = registerField("", "extensions", "x-.+", new ValMapOverlay<Object, AnyObjectOverlay>("", this, AnyObjectOverlay.factory, "x-.+"));
+    private ValMapOverlay<Object, AnyObjectOverlay> extensions = new ValMapOverlay<Object, AnyObjectOverlay>("", this, AnyObjectOverlay.factory, "x-.+");
 
     // Description
     @Override
@@ -219,5 +219,21 @@ public class ResponseImpl extends OpenApiObjectImpl implements Response {
         return isEmptyRecursive(parent, ResponseImpl.class) ? null : new ResponseImpl(key, json, parent);
     }
 };
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    protected void installPropertyAccessors(PropertyAccessors accessors) {
+        OverlayGetter getter = null;
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return description;}};
+            accessors.add("description", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return headers;}};
+            accessors.add("headers", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return contentMediaTypes;}};
+            accessors.add("content", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return links;}};
+            accessors.add("links", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return extensions;}};
+            accessors.add("", "x-.+", getter);
+    }
 
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/SchemaImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/SchemaImpl.java
@@ -7,7 +7,6 @@ import javax.annotation.Generated;
 
 import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.google.common.base.Optional;
 import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlayFactory;
 import com.reprezen.kaizen.oasparser.jsonoverlay.coll.ListOverlay;
@@ -26,1159 +25,1002 @@ import com.reprezen.kaizen.oasparser.model3.Xml;
 
 public class SchemaImpl extends OpenApiObjectImpl implements Schema {
 
-	@Override
-	public JsonOverlay<?> find(JsonPointer path) {
-		JsonOverlay<?> result = super.find(path);
-		if (result == null && path.mayMatchProperty() && additionalPropertiesSchema != null
-				&& !additionalPropertiesSchema.isMissing()) {
-			result = additionalProperties.find(path);
-		}
-		return result;
-	}
+    @Override
+    public JsonOverlay<?> find(JsonPointer path) {
+    	if (path.matchesProperty("additionalProperties")) {
+    		return path.tail().matches() ? additionalProperties : additionalPropertiesSchema.find(path.tail());
+    	} else {
+    		return super.find(path);
+    	}
+    	
+    }
 
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public SchemaImpl(String key, JsonNode json, JsonOverlay<?> parent) {
-		super(key, json, parent);
-	}
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public SchemaImpl(String key, JsonNode json, JsonOverlay<?> parent) {
+        super(key, json, parent);
+    }
 
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public SchemaImpl(String key, JsonOverlay<?> parent) {
-		super(key, parent);
-	}
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public SchemaImpl(String key, JsonOverlay<?> parent) {
+        super(key, parent);
+    }
 
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	private StringOverlay title = new StringOverlay("title", this);
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private StringOverlay title = new StringOverlay("title", this);
 
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	private NumberOverlay multipleOf = new NumberOverlay("multipleOf", this);
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private NumberOverlay multipleOf = new NumberOverlay("multipleOf", this);
 
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	private NumberOverlay maximum = new NumberOverlay("maximum", this);
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private NumberOverlay maximum = new NumberOverlay("maximum", this);
 
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	private BooleanOverlay exclusiveMaximum = new BooleanOverlay("exclusiveMaximum", this);
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private BooleanOverlay exclusiveMaximum = new BooleanOverlay("exclusiveMaximum", this);
 
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	private NumberOverlay minimum = new NumberOverlay("minimum", this);
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private NumberOverlay minimum = new NumberOverlay("minimum", this);
 
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	private BooleanOverlay exclusiveMinimum = new BooleanOverlay("exclusiveMinimum", this);
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private BooleanOverlay exclusiveMinimum = new BooleanOverlay("exclusiveMinimum", this);
 
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	private IntegerOverlay maxLength = new IntegerOverlay("maxLength", this);
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private IntegerOverlay maxLength = new IntegerOverlay("maxLength", this);
 
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	private IntegerOverlay minLength = new IntegerOverlay("minLength", this);
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private IntegerOverlay minLength = new IntegerOverlay("minLength", this);
 
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	private StringOverlay pattern = new StringOverlay("pattern", this);
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private StringOverlay pattern = new StringOverlay("pattern", this);
 
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	private IntegerOverlay maxItems = new IntegerOverlay("maxItems", this);
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private IntegerOverlay maxItems = new IntegerOverlay("maxItems", this);
 
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	private IntegerOverlay minItems = new IntegerOverlay("minItems", this);
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private IntegerOverlay minItems = new IntegerOverlay("minItems", this);
 
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	private BooleanOverlay uniqueItems = new BooleanOverlay("uniqueItems", this);
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private BooleanOverlay uniqueItems = new BooleanOverlay("uniqueItems", this);
 
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	private IntegerOverlay maxProperties = new IntegerOverlay("maxProperties", this);
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private IntegerOverlay maxProperties = new IntegerOverlay("maxProperties", this);
 
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	private IntegerOverlay minProperties = new IntegerOverlay("minProperties", this);
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private IntegerOverlay minProperties = new IntegerOverlay("minProperties", this);
 
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	private ValListOverlay<String, StringOverlay> requiredFields = new ValListOverlay<String, StringOverlay>("required",
-			this, StringOverlay.factory);
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private ValListOverlay<String, StringOverlay> requiredFields = new ValListOverlay<String, StringOverlay>("required", this, StringOverlay.factory);
 
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	private ValListOverlay<Object, AnyObjectOverlay> enums = new ValListOverlay<Object, AnyObjectOverlay>("enum", this,
-			AnyObjectOverlay.factory);
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private ValListOverlay<Object, AnyObjectOverlay> enums = new ValListOverlay<Object, AnyObjectOverlay>("enum", this, AnyObjectOverlay.factory);
 
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	private StringOverlay type = new StringOverlay("type", this);
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private StringOverlay type = new StringOverlay("type", this);
 
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	private ListOverlay<SchemaImpl> allOfSchemas = new ListOverlay<SchemaImpl>("allOf", this, SchemaImpl.factory);
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private ListOverlay<SchemaImpl> allOfSchemas = new ListOverlay<SchemaImpl>("allOf", this, SchemaImpl.factory);
 
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	private ListOverlay<SchemaImpl> oneOfSchemas = new ListOverlay<SchemaImpl>("oneOf", this, SchemaImpl.factory);
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private ListOverlay<SchemaImpl> oneOfSchemas = new ListOverlay<SchemaImpl>("oneOf", this, SchemaImpl.factory);
 
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	private ListOverlay<SchemaImpl> anyOfSchemas = new ListOverlay<SchemaImpl>("anyOf", this, SchemaImpl.factory);
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private ListOverlay<SchemaImpl> anyOfSchemas = new ListOverlay<SchemaImpl>("anyOf", this, SchemaImpl.factory);
 
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	private SchemaImpl notSchema = SchemaImpl.factory.create("not", this);
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private SchemaImpl notSchema = SchemaImpl.factory.create("not", this);
 
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	private SchemaImpl itemsSchema = SchemaImpl.factory.create("items", this);
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private SchemaImpl itemsSchema = SchemaImpl.factory.create("items", this);
 
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	private MapOverlay<SchemaImpl> properties = new MapOverlay<SchemaImpl>("properties", this, SchemaImpl.factory,
-			null);
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private MapOverlay<SchemaImpl> properties = new MapOverlay<SchemaImpl>("properties", this, SchemaImpl.factory, null);
 
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	private SchemaImpl additionalPropertiesSchema = SchemaImpl.factory.create("additionalProperties", this);
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private SchemaImpl additionalPropertiesSchema = SchemaImpl.factory.create("additionalProperties", this);
 
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	private BooleanOverlay additionalProperties = new BooleanOverlay("additionalProperties", this);
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private BooleanOverlay additionalProperties = new BooleanOverlay("additionalProperties", this);
 
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	private StringOverlay description = new StringOverlay("description", this);
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private StringOverlay description = new StringOverlay("description", this);
 
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	private StringOverlay format = new StringOverlay("format", this);
-
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	private AnyObjectOverlay defaultValue = new AnyObjectOverlay("default", this);
-
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	private BooleanOverlay nullable = new BooleanOverlay("nullable", this);
-
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	private StringOverlay discriminator = new StringOverlay("discriminator", this);
-
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	private BooleanOverlay readOnly = new BooleanOverlay("readOnly", this);
-
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	private BooleanOverlay writeOnly = new BooleanOverlay("writeOnly", this);
-
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	private XmlImpl xml = XmlImpl.factory.create("xml", this);
-
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	private ExternalDocsImpl externalDocs = ExternalDocsImpl.factory.create("externalDocs", this);
-
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	private MapOverlay<ExampleImpl> examples = new MapOverlay<ExampleImpl>("examples", this, ExampleImpl.factory,
-			"[a-zA-Z0-9\\._-]+");
-
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	private AnyObjectOverlay example = new AnyObjectOverlay("example", this);
-
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	private BooleanOverlay deprecated = new BooleanOverlay("deprecated", this);
-
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	private ValMapOverlay<Object, AnyObjectOverlay> extensions = new ValMapOverlay<Object, AnyObjectOverlay>("", this,
-			AnyObjectOverlay.factory, "x-.+");
-
-	// Title
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public String getTitle() {
-		return title.get();
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public void setTitle(String title) {
-		this.title.set(title);
-	}
-
-	// MultipleOf
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public Number getMultipleOf() {
-		return multipleOf.get();
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public void setMultipleOf(Number multipleOf) {
-		this.multipleOf.set(multipleOf);
-	}
-
-	// Maximum
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public Number getMaximum() {
-		return maximum.get();
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public void setMaximum(Number maximum) {
-		this.maximum.set(maximum);
-	}
-
-	// ExclusiveMaximum
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public Boolean getExclusiveMaximum() {
-		return exclusiveMaximum.get();
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public boolean isExclusiveMaximum() {
-		return exclusiveMaximum.get() != null ? exclusiveMaximum.get() : false;
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public void setExclusiveMaximum(Boolean exclusiveMaximum) {
-		this.exclusiveMaximum.set(exclusiveMaximum);
-	}
-
-	// Minimum
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public Number getMinimum() {
-		return minimum.get();
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public void setMinimum(Number minimum) {
-		this.minimum.set(minimum);
-	}
-
-	// ExclusiveMinimum
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public Boolean getExclusiveMinimum() {
-		return exclusiveMinimum.get();
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public boolean isExclusiveMinimum() {
-		return exclusiveMinimum.get() != null ? exclusiveMinimum.get() : false;
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public void setExclusiveMinimum(Boolean exclusiveMinimum) {
-		this.exclusiveMinimum.set(exclusiveMinimum);
-	}
-
-	// MaxLength
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public Integer getMaxLength() {
-		return maxLength.get();
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public void setMaxLength(Integer maxLength) {
-		this.maxLength.set(maxLength);
-	}
-
-	// MinLength
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public Integer getMinLength() {
-		return minLength.get();
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public void setMinLength(Integer minLength) {
-		this.minLength.set(minLength);
-	}
-
-	// Pattern
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public String getPattern() {
-		return pattern.get();
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public void setPattern(String pattern) {
-		this.pattern.set(pattern);
-	}
-
-	// MaxItems
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public Integer getMaxItems() {
-		return maxItems.get();
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public void setMaxItems(Integer maxItems) {
-		this.maxItems.set(maxItems);
-	}
-
-	// MinItems
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public Integer getMinItems() {
-		return minItems.get();
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public void setMinItems(Integer minItems) {
-		this.minItems.set(minItems);
-	}
-
-	// UniqueItems
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public Boolean getUniqueItems() {
-		return uniqueItems.get();
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public boolean isUniqueItems() {
-		return uniqueItems.get() != null ? uniqueItems.get() : false;
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public void setUniqueItems(Boolean uniqueItems) {
-		this.uniqueItems.set(uniqueItems);
-	}
-
-	// MaxProperties
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public Integer getMaxProperties() {
-		return maxProperties.get();
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public void setMaxProperties(Integer maxProperties) {
-		this.maxProperties.set(maxProperties);
-	}
-
-	// MinProperties
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public Integer getMinProperties() {
-		return minProperties.get();
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public void setMinProperties(Integer minProperties) {
-		this.minProperties.set(minProperties);
-	}
-
-	// RequiredField
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public Collection<String> getRequiredFields() {
-		return requiredFields.get();
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public boolean hasRequiredFields() {
-		return !requiredFields.isMissing();
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public String getRequiredField(int index) {
-		return requiredFields.get(index);
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public void setRequiredFields(Collection<String> requiredFields) {
-		this.requiredFields.set((Collection<String>) requiredFields);
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public void setRequiredField(int index, String requiredField) {
-		requiredFields.set(index, requiredField);
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public void addRequiredField(String requiredField) {
-		requiredFields.add(requiredField);
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public void removeRequiredField(int index) {
-		requiredFields.remove(index);
-	}
-
-	// Enum
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public Collection<Object> getEnums() {
-		return enums.get();
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public boolean hasEnums() {
-		return !enums.isMissing();
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public Object getEnum(int index) {
-		return enums.get(index);
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public void setEnums(Collection<Object> enums) {
-		this.enums.set((Collection<Object>) enums);
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public void setEnum(int index, Object enumValue) {
-		enums.set(index, enumValue);
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public void addEnum(Object enumValue) {
-		enums.add(enumValue);
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public void removeEnum(int index) {
-		enums.remove(index);
-	}
-
-	// Type
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public String getType() {
-		return type.get();
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public void setType(String type) {
-		this.type.set(type);
-	}
-
-	// AllOfSchema
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public Collection<? extends Schema> getAllOfSchemas() {
-		return allOfSchemas.get();
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public boolean hasAllOfSchemas() {
-		return !allOfSchemas.isMissing();
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public Schema getAllOfSchema(int index) {
-		return allOfSchemas.get(index);
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public void setAllOfSchemas(Collection<? extends Schema> allOfSchemas) {
-		@SuppressWarnings("unchecked")
-		Collection<SchemaImpl> implAllOfSchemas = (Collection<SchemaImpl>) allOfSchemas;
-		this.allOfSchemas.set(implAllOfSchemas);
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public void setAllOfSchema(int index, Schema allOfSchema) {
-		allOfSchemas.set(index, (SchemaImpl) allOfSchema);
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public void addAllOfSchema(Schema allOfSchema) {
-		allOfSchemas.add((SchemaImpl) allOfSchema);
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public void removeAllOfSchema(int index) {
-		allOfSchemas.remove(index);
-	}
-
-	// OneOfSchema
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public Collection<? extends Schema> getOneOfSchemas() {
-		return oneOfSchemas.get();
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public boolean hasOneOfSchemas() {
-		return !oneOfSchemas.isMissing();
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public Schema getOneOfSchema(int index) {
-		return oneOfSchemas.get(index);
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public void setOneOfSchemas(Collection<? extends Schema> oneOfSchemas) {
-		@SuppressWarnings("unchecked")
-		Collection<SchemaImpl> implOneOfSchemas = (Collection<SchemaImpl>) oneOfSchemas;
-		this.oneOfSchemas.set(implOneOfSchemas);
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public void setOneOfSchema(int index, Schema oneOfSchema) {
-		oneOfSchemas.set(index, (SchemaImpl) oneOfSchema);
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public void addOneOfSchema(Schema oneOfSchema) {
-		oneOfSchemas.add((SchemaImpl) oneOfSchema);
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public void removeOneOfSchema(int index) {
-		oneOfSchemas.remove(index);
-	}
-
-	// AnyOfSchema
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public Collection<? extends Schema> getAnyOfSchemas() {
-		return anyOfSchemas.get();
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public boolean hasAnyOfSchemas() {
-		return !anyOfSchemas.isMissing();
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public Schema getAnyOfSchema(int index) {
-		return anyOfSchemas.get(index);
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public void setAnyOfSchemas(Collection<? extends Schema> anyOfSchemas) {
-		@SuppressWarnings("unchecked")
-		Collection<SchemaImpl> implAnyOfSchemas = (Collection<SchemaImpl>) anyOfSchemas;
-		this.anyOfSchemas.set(implAnyOfSchemas);
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public void setAnyOfSchema(int index, Schema anyOfSchema) {
-		anyOfSchemas.set(index, (SchemaImpl) anyOfSchema);
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public void addAnyOfSchema(Schema anyOfSchema) {
-		anyOfSchemas.add((SchemaImpl) anyOfSchema);
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public void removeAnyOfSchema(int index) {
-		anyOfSchemas.remove(index);
-	}
-
-	// NotSchema
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public Schema getNotSchema() {
-		return notSchema;
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public void setNotSchema(Schema notSchema) {
-		this.notSchema.set((SchemaImpl) notSchema);
-	}
-
-	// ItemsSchema
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public Schema getItemsSchema() {
-		return itemsSchema;
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public void setItemsSchema(Schema itemsSchema) {
-		this.itemsSchema.set((SchemaImpl) itemsSchema);
-	}
-
-	// Property
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public Map<String, ? extends Schema> getProperties() {
-		return properties.get();
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public boolean hasProperty(String name) {
-		return properties.containsKey(name);
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public Schema getProperty(String name) {
-		return properties.get(name);
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public void setProperties(Map<String, ? extends Schema> properties) {
-		@SuppressWarnings("unchecked")
-		Map<String, SchemaImpl> implProperties = (Map<String, SchemaImpl>) properties;
-		this.properties.set(implProperties);
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public void setProperty(String name, Schema property) {
-		properties.set(name, (SchemaImpl) property);
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public void removeProperty(String name) {
-		properties.remove(name);
-	}
-
-	// AdditionalPropertiesSchema
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public Schema getAdditionalPropertiesSchema() {
-		return additionalPropertiesSchema;
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public void setAdditionalPropertiesSchema(Schema additionalPropertiesSchema) {
-		this.additionalPropertiesSchema.set((SchemaImpl) additionalPropertiesSchema);
-	}
-
-	// AdditionalProperties
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public Boolean getAdditionalProperties() {
-		return additionalProperties.get();
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public boolean isAdditionalProperties() {
-		return additionalProperties.get() != null ? additionalProperties.get() : false;
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public void setAdditionalProperties(Boolean additionalProperties) {
-		this.additionalProperties.set(additionalProperties);
-	}
-
-	// Description
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public String getDescription() {
-		return description.get();
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public void setDescription(String description) {
-		this.description.set(description);
-	}
-
-	// Format
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public String getFormat() {
-		return format.get();
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public void setFormat(String format) {
-		this.format.set(format);
-	}
-
-	// Default
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public Object getDefault() {
-		return defaultValue.get();
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public void setDefault(Object defaultValue) {
-		this.defaultValue.set(defaultValue);
-	}
-
-	// Nullable
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public Boolean getNullable() {
-		return nullable.get();
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public boolean isNullable() {
-		return nullable.get() != null ? nullable.get() : false;
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public void setNullable(Boolean nullable) {
-		this.nullable.set(nullable);
-	}
-
-	// Discriminator
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public String getDiscriminator() {
-		return discriminator.get();
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public void setDiscriminator(String discriminator) {
-		this.discriminator.set(discriminator);
-	}
-
-	// ReadOnly
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public Boolean getReadOnly() {
-		return readOnly.get();
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public boolean isReadOnly() {
-		return readOnly.get() != null ? readOnly.get() : false;
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public void setReadOnly(Boolean readOnly) {
-		this.readOnly.set(readOnly);
-	}
-
-	// WriteOnly
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public Boolean getWriteOnly() {
-		return writeOnly.get();
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public boolean isWriteOnly() {
-		return writeOnly.get() != null ? writeOnly.get() : false;
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public void setWriteOnly(Boolean writeOnly) {
-		this.writeOnly.set(writeOnly);
-	}
-
-	// Xml
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public Xml getXml() {
-		return xml;
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public void setXml(Xml xml) {
-		this.xml.set((XmlImpl) xml);
-	}
-
-	// ExternalDocs
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public ExternalDocs getExternalDocs() {
-		return externalDocs;
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public void setExternalDocs(ExternalDocs externalDocs) {
-		this.externalDocs.set((ExternalDocsImpl) externalDocs);
-	}
-
-	// Example
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public Map<String, ? extends Example> getExamples() {
-		return examples.get();
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public boolean hasExample(String name) {
-		return examples.containsKey(name);
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public Example getExample(String name) {
-		return examples.get(name);
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public void setExamples(Map<String, ? extends Example> examples) {
-		@SuppressWarnings("unchecked")
-		Map<String, ExampleImpl> implExamples = (Map<String, ExampleImpl>) examples;
-		this.examples.set(implExamples);
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public void setExample(String name, Example example) {
-		examples.set(name, (ExampleImpl) example);
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public void removeExample(String name) {
-		examples.remove(name);
-	}
-
-	// Example
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public Object getExample() {
-		return example.get();
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public void setExample(Object example) {
-		this.example.set(example);
-	}
-
-	// Deprecated
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public Boolean getDeprecated() {
-		return deprecated.get();
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public boolean isDeprecated() {
-		return deprecated.get() != null ? deprecated.get() : false;
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public void setDeprecated(Boolean deprecated) {
-		this.deprecated.set(deprecated);
-	}
-
-	// Extension
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public Map<String, Object> getExtensions() {
-		return extensions.get();
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public boolean hasExtension(String name) {
-		return extensions.containsKey(name);
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public Object getExtension(String name) {
-		return extensions.get(name);
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public void setExtensions(Map<String, Object> extensions) {
-		this.extensions.set(extensions);
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public void setExtension(String name, Object extension) {
-		extensions.set(name, extension);
-	}
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public void removeExtension(String name) {
-		extensions.remove(name);
-	}
-
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public static JsonOverlayFactory<SchemaImpl> factory = new JsonOverlayFactory<SchemaImpl>() {
-		@Override
-		public SchemaImpl create(String key, JsonNode json, JsonOverlay<?> parent) {
-			return isEmptyRecursive(parent, SchemaImpl.class) ? null : new SchemaImpl(key, json, parent);
-		}
-	};
-
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	protected void installPropertyAccessors(PropertyAccessors accessors) {
-		OverlayGetter getter = null;
-		getter = new OverlayGetter() {
-			public JsonOverlay<?> get() {
-				return title;
-			}
-		};
-		accessors.add("title", null, getter);
-		getter = new OverlayGetter() {
-			public JsonOverlay<?> get() {
-				return multipleOf;
-			}
-		};
-		accessors.add("multipleOf", null, getter);
-		getter = new OverlayGetter() {
-			public JsonOverlay<?> get() {
-				return maximum;
-			}
-		};
-		accessors.add("maximum", null, getter);
-		getter = new OverlayGetter() {
-			public JsonOverlay<?> get() {
-				return exclusiveMaximum;
-			}
-		};
-		accessors.add("exclusiveMaximum", null, getter);
-		getter = new OverlayGetter() {
-			public JsonOverlay<?> get() {
-				return minimum;
-			}
-		};
-		accessors.add("minimum", null, getter);
-		getter = new OverlayGetter() {
-			public JsonOverlay<?> get() {
-				return exclusiveMinimum;
-			}
-		};
-		accessors.add("exclusiveMinimum", null, getter);
-		getter = new OverlayGetter() {
-			public JsonOverlay<?> get() {
-				return maxLength;
-			}
-		};
-		accessors.add("maxLength", null, getter);
-		getter = new OverlayGetter() {
-			public JsonOverlay<?> get() {
-				return minLength;
-			}
-		};
-		accessors.add("minLength", null, getter);
-		getter = new OverlayGetter() {
-			public JsonOverlay<?> get() {
-				return pattern;
-			}
-		};
-		accessors.add("pattern", null, getter);
-		getter = new OverlayGetter() {
-			public JsonOverlay<?> get() {
-				return maxItems;
-			}
-		};
-		accessors.add("maxItems", null, getter);
-		getter = new OverlayGetter() {
-			public JsonOverlay<?> get() {
-				return minItems;
-			}
-		};
-		accessors.add("minItems", null, getter);
-		getter = new OverlayGetter() {
-			public JsonOverlay<?> get() {
-				return uniqueItems;
-			}
-		};
-		accessors.add("uniqueItems", null, getter);
-		getter = new OverlayGetter() {
-			public JsonOverlay<?> get() {
-				return maxProperties;
-			}
-		};
-		accessors.add("maxProperties", null, getter);
-		getter = new OverlayGetter() {
-			public JsonOverlay<?> get() {
-				return minProperties;
-			}
-		};
-		accessors.add("minProperties", null, getter);
-		getter = new OverlayGetter() {
-			public JsonOverlay<?> get() {
-				return requiredFields;
-			}
-		};
-		accessors.add("required", null, getter);
-		getter = new OverlayGetter() {
-			public JsonOverlay<?> get() {
-				return enums;
-			}
-		};
-		accessors.add("enum", null, getter);
-		getter = new OverlayGetter() {
-			public JsonOverlay<?> get() {
-				return type;
-			}
-		};
-		accessors.add("type", null, getter);
-		getter = new OverlayGetter() {
-			public JsonOverlay<?> get() {
-				return allOfSchemas;
-			}
-		};
-		accessors.add("allOf", null, getter);
-		getter = new OverlayGetter() {
-			public JsonOverlay<?> get() {
-				return oneOfSchemas;
-			}
-		};
-		accessors.add("oneOf", null, getter);
-		getter = new OverlayGetter() {
-			public JsonOverlay<?> get() {
-				return anyOfSchemas;
-			}
-		};
-		accessors.add("anyOf", null, getter);
-		getter = new OverlayGetter() {
-			public JsonOverlay<?> get() {
-				return notSchema;
-			}
-		};
-		accessors.add("not", null, getter);
-		getter = new OverlayGetter() {
-			public JsonOverlay<?> get() {
-				return itemsSchema;
-			}
-		};
-		accessors.add("items", null, getter);
-		getter = new OverlayGetter() {
-			public JsonOverlay<?> get() {
-				return properties;
-			}
-		};
-		accessors.add("properties", null, getter);
-		getter = new OverlayGetter() {
-			public JsonOverlay<?> get() {
-				return additionalPropertiesSchema;
-			}
-		};
-		accessors.add("additionalProperties", null, getter);
-		getter = new OverlayGetter() {
-			public JsonOverlay<?> get() {
-				return additionalProperties;
-			}
-		};
-		accessors.add("additionalProperties", null, getter);
-		getter = new OverlayGetter() {
-			public JsonOverlay<?> get() {
-				return description;
-			}
-		};
-		accessors.add("description", null, getter);
-		getter = new OverlayGetter() {
-			public JsonOverlay<?> get() {
-				return format;
-			}
-		};
-		accessors.add("format", null, getter);
-		getter = new OverlayGetter() {
-			public JsonOverlay<?> get() {
-				return defaultValue;
-			}
-		};
-		accessors.add("default", null, getter);
-		getter = new OverlayGetter() {
-			public JsonOverlay<?> get() {
-				return nullable;
-			}
-		};
-		accessors.add("nullable", null, getter);
-		getter = new OverlayGetter() {
-			public JsonOverlay<?> get() {
-				return discriminator;
-			}
-		};
-		accessors.add("discriminator", null, getter);
-		getter = new OverlayGetter() {
-			public JsonOverlay<?> get() {
-				return readOnly;
-			}
-		};
-		accessors.add("readOnly", null, getter);
-		getter = new OverlayGetter() {
-			public JsonOverlay<?> get() {
-				return writeOnly;
-			}
-		};
-		accessors.add("writeOnly", null, getter);
-		getter = new OverlayGetter() {
-			public JsonOverlay<?> get() {
-				return xml;
-			}
-		};
-		accessors.add("xml", null, getter);
-		getter = new OverlayGetter() {
-			public JsonOverlay<?> get() {
-				return externalDocs;
-			}
-		};
-		accessors.add("externalDocs", null, getter);
-		getter = new OverlayGetter() {
-			public JsonOverlay<?> get() {
-				return examples;
-			}
-		};
-		accessors.add("examples", "[a-zA-Z0-9\\._-]+", getter);
-		getter = new OverlayGetter() {
-			public JsonOverlay<?> get() {
-				return example;
-			}
-		};
-		accessors.add("example", null, getter);
-		getter = new OverlayGetter() {
-			public JsonOverlay<?> get() {
-				return deprecated;
-			}
-		};
-		accessors.add("deprecated", null, getter);
-		getter = new OverlayGetter() {
-			public JsonOverlay<?> get() {
-				return extensions;
-			}
-		};
-		accessors.add("", "x-.+", getter);
-	}
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private StringOverlay format = new StringOverlay("format", this);
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private AnyObjectOverlay defaultValue = new AnyObjectOverlay("default", this);
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private BooleanOverlay nullable = new BooleanOverlay("nullable", this);
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private StringOverlay discriminator = new StringOverlay("discriminator", this);
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private BooleanOverlay readOnly = new BooleanOverlay("readOnly", this);
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private BooleanOverlay writeOnly = new BooleanOverlay("writeOnly", this);
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private XmlImpl xml = XmlImpl.factory.create("xml", this);
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private ExternalDocsImpl externalDocs = ExternalDocsImpl.factory.create("externalDocs", this);
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private MapOverlay<ExampleImpl> examples = new MapOverlay<ExampleImpl>("examples", this, ExampleImpl.factory, "[a-zA-Z0-9\\._-]+");
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private AnyObjectOverlay example = new AnyObjectOverlay("example", this);
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private BooleanOverlay deprecated = new BooleanOverlay("deprecated", this);
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private ValMapOverlay<Object, AnyObjectOverlay> extensions = new ValMapOverlay<Object, AnyObjectOverlay>("", this, AnyObjectOverlay.factory, "x-.+");
+
+    // Title
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public String getTitle() {
+        return title.get();
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public void setTitle(String title) {
+        this.title.set(title);
+    }
+
+    // MultipleOf
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public Number getMultipleOf() {
+        return multipleOf.get();
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public void setMultipleOf(Number multipleOf) {
+        this.multipleOf.set(multipleOf);
+    }
+
+    // Maximum
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public Number getMaximum() {
+        return maximum.get();
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public void setMaximum(Number maximum) {
+        this.maximum.set(maximum);
+    }
+
+    // ExclusiveMaximum
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public Boolean getExclusiveMaximum() {
+        return exclusiveMaximum.get();
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public boolean isExclusiveMaximum() {
+        return exclusiveMaximum.get() != null ? exclusiveMaximum.get() : false;
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public void setExclusiveMaximum(Boolean exclusiveMaximum) {
+        this.exclusiveMaximum.set(exclusiveMaximum);
+    }
+
+    // Minimum
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public Number getMinimum() {
+        return minimum.get();
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public void setMinimum(Number minimum) {
+        this.minimum.set(minimum);
+    }
+
+    // ExclusiveMinimum
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public Boolean getExclusiveMinimum() {
+        return exclusiveMinimum.get();
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public boolean isExclusiveMinimum() {
+        return exclusiveMinimum.get() != null ? exclusiveMinimum.get() : false;
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public void setExclusiveMinimum(Boolean exclusiveMinimum) {
+        this.exclusiveMinimum.set(exclusiveMinimum);
+    }
+
+    // MaxLength
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public Integer getMaxLength() {
+        return maxLength.get();
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public void setMaxLength(Integer maxLength) {
+        this.maxLength.set(maxLength);
+    }
+
+    // MinLength
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public Integer getMinLength() {
+        return minLength.get();
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public void setMinLength(Integer minLength) {
+        this.minLength.set(minLength);
+    }
+
+    // Pattern
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public String getPattern() {
+        return pattern.get();
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public void setPattern(String pattern) {
+        this.pattern.set(pattern);
+    }
+
+    // MaxItems
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public Integer getMaxItems() {
+        return maxItems.get();
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public void setMaxItems(Integer maxItems) {
+        this.maxItems.set(maxItems);
+    }
+
+    // MinItems
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public Integer getMinItems() {
+        return minItems.get();
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public void setMinItems(Integer minItems) {
+        this.minItems.set(minItems);
+    }
+
+    // UniqueItems
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public Boolean getUniqueItems() {
+        return uniqueItems.get();
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public boolean isUniqueItems() {
+        return uniqueItems.get() != null ? uniqueItems.get() : false;
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public void setUniqueItems(Boolean uniqueItems) {
+        this.uniqueItems.set(uniqueItems);
+    }
+
+    // MaxProperties
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public Integer getMaxProperties() {
+        return maxProperties.get();
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public void setMaxProperties(Integer maxProperties) {
+        this.maxProperties.set(maxProperties);
+    }
+
+    // MinProperties
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public Integer getMinProperties() {
+        return minProperties.get();
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public void setMinProperties(Integer minProperties) {
+        this.minProperties.set(minProperties);
+    }
+
+    // RequiredField
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public Collection<String> getRequiredFields() {
+        return requiredFields.get();
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public boolean hasRequiredFields() {
+        return !requiredFields.isMissing();
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public String getRequiredField(int index) {
+        return requiredFields.get(index);
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public void setRequiredFields(Collection<String> requiredFields) {
+        this.requiredFields.set((Collection<String>) requiredFields);
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public void setRequiredField(int index, String requiredField) {
+        requiredFields.set(index, requiredField);
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public void addRequiredField(String requiredField) {
+        requiredFields.add(requiredField);
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public void removeRequiredField(int index) {
+        requiredFields.remove(index);
+    }
+
+    // Enum
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public Collection<Object> getEnums() {
+        return enums.get();
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public boolean hasEnums() {
+        return !enums.isMissing();
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public Object getEnum(int index) {
+        return enums.get(index);
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public void setEnums(Collection<Object> enums) {
+        this.enums.set((Collection<Object>) enums);
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public void setEnum(int index, Object enumValue) {
+        enums.set(index, enumValue);
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public void addEnum(Object enumValue) {
+        enums.add(enumValue);
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public void removeEnum(int index) {
+        enums.remove(index);
+    }
+
+    // Type
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public String getType() {
+        return type.get();
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public void setType(String type) {
+        this.type.set(type);
+    }
+
+    // AllOfSchema
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public Collection<? extends Schema> getAllOfSchemas() {
+        return allOfSchemas.get();
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public boolean hasAllOfSchemas() {
+        return !allOfSchemas.isMissing();
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public Schema getAllOfSchema(int index) {
+        return allOfSchemas.get(index);
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public void setAllOfSchemas(Collection<? extends Schema> allOfSchemas) {
+        @SuppressWarnings("unchecked")
+            Collection<SchemaImpl> implAllOfSchemas = (Collection<SchemaImpl>) allOfSchemas;
+            this.allOfSchemas.set(implAllOfSchemas);
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public void setAllOfSchema(int index, Schema allOfSchema) {
+        allOfSchemas.set(index, (SchemaImpl) allOfSchema);
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public void addAllOfSchema(Schema allOfSchema) {
+        allOfSchemas.add((SchemaImpl) allOfSchema);
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public void removeAllOfSchema(int index) {
+        allOfSchemas.remove(index);
+    }
+
+    // OneOfSchema
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public Collection<? extends Schema> getOneOfSchemas() {
+        return oneOfSchemas.get();
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public boolean hasOneOfSchemas() {
+        return !oneOfSchemas.isMissing();
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public Schema getOneOfSchema(int index) {
+        return oneOfSchemas.get(index);
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public void setOneOfSchemas(Collection<? extends Schema> oneOfSchemas) {
+        @SuppressWarnings("unchecked")
+            Collection<SchemaImpl> implOneOfSchemas = (Collection<SchemaImpl>) oneOfSchemas;
+            this.oneOfSchemas.set(implOneOfSchemas);
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public void setOneOfSchema(int index, Schema oneOfSchema) {
+        oneOfSchemas.set(index, (SchemaImpl) oneOfSchema);
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public void addOneOfSchema(Schema oneOfSchema) {
+        oneOfSchemas.add((SchemaImpl) oneOfSchema);
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public void removeOneOfSchema(int index) {
+        oneOfSchemas.remove(index);
+    }
+
+    // AnyOfSchema
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public Collection<? extends Schema> getAnyOfSchemas() {
+        return anyOfSchemas.get();
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public boolean hasAnyOfSchemas() {
+        return !anyOfSchemas.isMissing();
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public Schema getAnyOfSchema(int index) {
+        return anyOfSchemas.get(index);
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public void setAnyOfSchemas(Collection<? extends Schema> anyOfSchemas) {
+        @SuppressWarnings("unchecked")
+            Collection<SchemaImpl> implAnyOfSchemas = (Collection<SchemaImpl>) anyOfSchemas;
+            this.anyOfSchemas.set(implAnyOfSchemas);
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public void setAnyOfSchema(int index, Schema anyOfSchema) {
+        anyOfSchemas.set(index, (SchemaImpl) anyOfSchema);
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public void addAnyOfSchema(Schema anyOfSchema) {
+        anyOfSchemas.add((SchemaImpl) anyOfSchema);
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public void removeAnyOfSchema(int index) {
+        anyOfSchemas.remove(index);
+    }
+
+    // NotSchema
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public Schema getNotSchema() {
+        return notSchema;
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public void setNotSchema(Schema notSchema) {
+        this.notSchema.set((SchemaImpl) notSchema);
+    }
+
+    // ItemsSchema
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public Schema getItemsSchema() {
+        return itemsSchema;
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public void setItemsSchema(Schema itemsSchema) {
+        this.itemsSchema.set((SchemaImpl) itemsSchema);
+    }
+
+    // Property
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public Map<String, ? extends Schema> getProperties() {
+        return properties.get();
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public boolean hasProperty(String name) {
+        return properties.containsKey(name);
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public Schema getProperty(String name) {
+        return properties.get(name);
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public void setProperties(Map<String, ? extends Schema> properties) {
+        @SuppressWarnings("unchecked")
+            Map<String,SchemaImpl> implProperties = (Map<String, SchemaImpl>) properties;
+            this.properties.set(implProperties);
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public void setProperty(String name, Schema property) {
+        properties.set(name, (SchemaImpl) property);
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public void removeProperty(String name) {
+        properties.remove(name);
+    }
+
+    // AdditionalPropertiesSchema
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public Schema getAdditionalPropertiesSchema() {
+        return additionalPropertiesSchema;
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public void setAdditionalPropertiesSchema(Schema additionalPropertiesSchema) {
+        this.additionalPropertiesSchema.set((SchemaImpl) additionalPropertiesSchema);
+    }
+
+    // AdditionalProperties
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public Boolean getAdditionalProperties() {
+        return additionalProperties.get();
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public boolean isAdditionalProperties() {
+        return additionalProperties.get() != null ? additionalProperties.get() : false;
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public void setAdditionalProperties(Boolean additionalProperties) {
+        this.additionalProperties.set(additionalProperties);
+    }
+
+    // Description
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public String getDescription() {
+        return description.get();
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public void setDescription(String description) {
+        this.description.set(description);
+    }
+
+    // Format
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public String getFormat() {
+        return format.get();
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public void setFormat(String format) {
+        this.format.set(format);
+    }
+
+    // Default
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public Object getDefault() {
+        return defaultValue.get();
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public void setDefault(Object defaultValue) {
+        this.defaultValue.set(defaultValue);
+    }
+
+    // Nullable
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public Boolean getNullable() {
+        return nullable.get();
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public boolean isNullable() {
+        return nullable.get() != null ? nullable.get() : false;
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public void setNullable(Boolean nullable) {
+        this.nullable.set(nullable);
+    }
+
+    // Discriminator
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public String getDiscriminator() {
+        return discriminator.get();
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public void setDiscriminator(String discriminator) {
+        this.discriminator.set(discriminator);
+    }
+
+    // ReadOnly
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public Boolean getReadOnly() {
+        return readOnly.get();
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public boolean isReadOnly() {
+        return readOnly.get() != null ? readOnly.get() : false;
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public void setReadOnly(Boolean readOnly) {
+        this.readOnly.set(readOnly);
+    }
+
+    // WriteOnly
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public Boolean getWriteOnly() {
+        return writeOnly.get();
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public boolean isWriteOnly() {
+        return writeOnly.get() != null ? writeOnly.get() : false;
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public void setWriteOnly(Boolean writeOnly) {
+        this.writeOnly.set(writeOnly);
+    }
+
+    // Xml
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public Xml getXml() {
+        return xml;
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public void setXml(Xml xml) {
+        this.xml.set((XmlImpl) xml);
+    }
+
+    // ExternalDocs
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public ExternalDocs getExternalDocs() {
+        return externalDocs;
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public void setExternalDocs(ExternalDocs externalDocs) {
+        this.externalDocs.set((ExternalDocsImpl) externalDocs);
+    }
+
+    // Example
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public Map<String, ? extends Example> getExamples() {
+        return examples.get();
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public boolean hasExample(String name) {
+        return examples.containsKey(name);
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public Example getExample(String name) {
+        return examples.get(name);
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public void setExamples(Map<String, ? extends Example> examples) {
+        @SuppressWarnings("unchecked")
+            Map<String,ExampleImpl> implExamples = (Map<String, ExampleImpl>) examples;
+            this.examples.set(implExamples);
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public void setExample(String name, Example example) {
+        examples.set(name, (ExampleImpl) example);
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public void removeExample(String name) {
+        examples.remove(name);
+    }
+
+    // Example
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public Object getExample() {
+        return example.get();
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public void setExample(Object example) {
+        this.example.set(example);
+    }
+
+    // Deprecated
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public Boolean getDeprecated() {
+        return deprecated.get();
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public boolean isDeprecated() {
+        return deprecated.get() != null ? deprecated.get() : false;
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public void setDeprecated(Boolean deprecated) {
+        this.deprecated.set(deprecated);
+    }
+
+    // Extension
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public Map<String, Object> getExtensions() {
+        return extensions.get();
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public boolean hasExtension(String name) {
+        return extensions.containsKey(name);
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public Object getExtension(String name) {
+        return extensions.get(name);
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public void setExtensions(Map<String, Object> extensions) {
+        this.extensions.set(extensions);
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public void setExtension(String name, Object extension) {
+        extensions.set(name, extension);
+    }
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public void removeExtension(String name) {
+        extensions.remove(name);
+    }
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public static JsonOverlayFactory<SchemaImpl> factory = new JsonOverlayFactory<SchemaImpl>() {
+    @Override
+    public SchemaImpl create(String key, JsonNode json, JsonOverlay<?> parent) {
+        return isEmptyRecursive(parent, SchemaImpl.class) ? null : new SchemaImpl(key, json, parent);
+    }
+};
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    protected void installPropertyAccessors(PropertyAccessors accessors) {
+        OverlayGetter getter = null;
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return title;}};
+            accessors.add("title", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return multipleOf;}};
+            accessors.add("multipleOf", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return maximum;}};
+            accessors.add("maximum", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return exclusiveMaximum;}};
+            accessors.add("exclusiveMaximum", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return minimum;}};
+            accessors.add("minimum", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return exclusiveMinimum;}};
+            accessors.add("exclusiveMinimum", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return maxLength;}};
+            accessors.add("maxLength", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return minLength;}};
+            accessors.add("minLength", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return pattern;}};
+            accessors.add("pattern", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return maxItems;}};
+            accessors.add("maxItems", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return minItems;}};
+            accessors.add("minItems", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return uniqueItems;}};
+            accessors.add("uniqueItems", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return maxProperties;}};
+            accessors.add("maxProperties", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return minProperties;}};
+            accessors.add("minProperties", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return requiredFields;}};
+            accessors.add("required", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return enums;}};
+            accessors.add("enum", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return type;}};
+            accessors.add("type", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return allOfSchemas;}};
+            accessors.add("allOf", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return oneOfSchemas;}};
+            accessors.add("oneOf", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return anyOfSchemas;}};
+            accessors.add("anyOf", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return notSchema;}};
+            accessors.add("not", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return itemsSchema;}};
+            accessors.add("items", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return properties;}};
+            accessors.add("properties", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return additionalPropertiesSchema;}};
+            accessors.add("additionalProperties", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return additionalProperties;}};
+            accessors.add("additionalProperties", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return description;}};
+            accessors.add("description", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return format;}};
+            accessors.add("format", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return defaultValue;}};
+            accessors.add("default", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return nullable;}};
+            accessors.add("nullable", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return discriminator;}};
+            accessors.add("discriminator", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return readOnly;}};
+            accessors.add("readOnly", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return writeOnly;}};
+            accessors.add("writeOnly", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return xml;}};
+            accessors.add("xml", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return externalDocs;}};
+            accessors.add("externalDocs", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return examples;}};
+            accessors.add("examples", "[a-zA-Z0-9\\._-]+", getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return example;}};
+            accessors.add("example", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return deprecated;}};
+            accessors.add("deprecated", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return extensions;}};
+            accessors.add("", "x-.+", getter);
+    }
 
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/SchemaImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/SchemaImpl.java
@@ -1,5 +1,11 @@
 package com.reprezen.kaizen.oasparser.ovl3;
 
+import java.util.Collection;
+import java.util.Map;
+
+import javax.annotation.Generated;
+
+import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.base.Optional;
 import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
@@ -17,936 +23,1162 @@ import com.reprezen.kaizen.oasparser.model3.Example;
 import com.reprezen.kaizen.oasparser.model3.ExternalDocs;
 import com.reprezen.kaizen.oasparser.model3.Schema;
 import com.reprezen.kaizen.oasparser.model3.Xml;
-import com.reprezen.kaizen.oasparser.ovl3.ExampleImpl;
-import com.reprezen.kaizen.oasparser.ovl3.ExternalDocsImpl;
-import com.reprezen.kaizen.oasparser.ovl3.OpenApiObjectImpl;
-import com.reprezen.kaizen.oasparser.ovl3.SchemaImpl;
-import com.reprezen.kaizen.oasparser.ovl3.XmlImpl;
-import java.util.Collection;
-import java.util.Map;
-import javax.annotation.Generated;
 
 public class SchemaImpl extends OpenApiObjectImpl implements Schema {
 
-    @Override
-    public Optional<JsonOverlay<?>> getFieldValue(String path) throws IllegalArgumentException, IllegalAccessException {
-        if (path.equals("additionalProperties")) {
-            if (additionalPropertiesSchema != null && !additionalPropertiesSchema.isMissing()) {
-                return Optional.<JsonOverlay<?>>of(additionalPropertiesSchema);
-            } else if (additionalProperties != null && !additionalProperties.isMissing()) {
-                return Optional.<JsonOverlay<?>>of(additionalProperties);
-            } else {
-                return Optional.absent();
-            }
-        } else {
-            return super.getFieldValue(path);
-        }
-    }
+	@Override
+	public JsonOverlay<?> find(JsonPointer path) {
+		JsonOverlay<?> result = super.find(path);
+		if (result == null && path.mayMatchProperty() && additionalPropertiesSchema != null
+				&& !additionalPropertiesSchema.isMissing()) {
+			result = additionalProperties.find(path);
+		}
+		return result;
+	}
 
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public SchemaImpl(String key, JsonNode json, JsonOverlay<?> parent) {
-        super(key, json, parent);
-    }
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public SchemaImpl(String key, JsonNode json, JsonOverlay<?> parent) {
+		super(key, json, parent);
+	}
 
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public SchemaImpl(String key, JsonOverlay<?> parent) {
-        super(key, parent);
-    }
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public SchemaImpl(String key, JsonOverlay<?> parent) {
+		super(key, parent);
+	}
 
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private StringOverlay title = registerField("title", "title", null, new StringOverlay("title", this));
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	private StringOverlay title = new StringOverlay("title", this);
 
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private NumberOverlay multipleOf = registerField("multipleOf", "multipleOf", null, new NumberOverlay("multipleOf", this));
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	private NumberOverlay multipleOf = new NumberOverlay("multipleOf", this);
 
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private NumberOverlay maximum = registerField("maximum", "maximum", null, new NumberOverlay("maximum", this));
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	private NumberOverlay maximum = new NumberOverlay("maximum", this);
 
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private BooleanOverlay exclusiveMaximum = registerField("exclusiveMaximum", "exclusiveMaximum", null, new BooleanOverlay("exclusiveMaximum", this));
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	private BooleanOverlay exclusiveMaximum = new BooleanOverlay("exclusiveMaximum", this);
 
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private NumberOverlay minimum = registerField("minimum", "minimum", null, new NumberOverlay("minimum", this));
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	private NumberOverlay minimum = new NumberOverlay("minimum", this);
 
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private BooleanOverlay exclusiveMinimum = registerField("exclusiveMinimum", "exclusiveMinimum", null, new BooleanOverlay("exclusiveMinimum", this));
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	private BooleanOverlay exclusiveMinimum = new BooleanOverlay("exclusiveMinimum", this);
 
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private IntegerOverlay maxLength = registerField("maxLength", "maxLength", null, new IntegerOverlay("maxLength", this));
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	private IntegerOverlay maxLength = new IntegerOverlay("maxLength", this);
 
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private IntegerOverlay minLength = registerField("minLength", "minLength", null, new IntegerOverlay("minLength", this));
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	private IntegerOverlay minLength = new IntegerOverlay("minLength", this);
 
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private StringOverlay pattern = registerField("pattern", "pattern", null, new StringOverlay("pattern", this));
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	private StringOverlay pattern = new StringOverlay("pattern", this);
 
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private IntegerOverlay maxItems = registerField("maxItems", "maxItems", null, new IntegerOverlay("maxItems", this));
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	private IntegerOverlay maxItems = new IntegerOverlay("maxItems", this);
 
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private IntegerOverlay minItems = registerField("minItems", "minItems", null, new IntegerOverlay("minItems", this));
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	private IntegerOverlay minItems = new IntegerOverlay("minItems", this);
 
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private BooleanOverlay uniqueItems = registerField("uniqueItems", "uniqueItems", null, new BooleanOverlay("uniqueItems", this));
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	private BooleanOverlay uniqueItems = new BooleanOverlay("uniqueItems", this);
 
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private IntegerOverlay maxProperties = registerField("maxProperties", "maxProperties", null, new IntegerOverlay("maxProperties", this));
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	private IntegerOverlay maxProperties = new IntegerOverlay("maxProperties", this);
 
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private IntegerOverlay minProperties = registerField("minProperties", "minProperties", null, new IntegerOverlay("minProperties", this));
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	private IntegerOverlay minProperties = new IntegerOverlay("minProperties", this);
 
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private ValListOverlay<String, StringOverlay> requiredFields = registerField("required", "requiredFields", null, new ValListOverlay<String, StringOverlay>("required", this, StringOverlay.factory));;
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	private ValListOverlay<String, StringOverlay> requiredFields = new ValListOverlay<String, StringOverlay>("required",
+			this, StringOverlay.factory);
 
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private ValListOverlay<Object, AnyObjectOverlay> enums = registerField("enum", "enums", null, new ValListOverlay<Object, AnyObjectOverlay>("enum", this, AnyObjectOverlay.factory));;
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	private ValListOverlay<Object, AnyObjectOverlay> enums = new ValListOverlay<Object, AnyObjectOverlay>("enum", this,
+			AnyObjectOverlay.factory);
 
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private StringOverlay type = registerField("type", "type", null, new StringOverlay("type", this));
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	private StringOverlay type = new StringOverlay("type", this);
 
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private ListOverlay<SchemaImpl> allOfSchemas = registerField("allOf", "allOfSchemas", null, new ListOverlay<SchemaImpl>("allOf", this, SchemaImpl.factory));
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	private ListOverlay<SchemaImpl> allOfSchemas = new ListOverlay<SchemaImpl>("allOf", this, SchemaImpl.factory);
 
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private ListOverlay<SchemaImpl> oneOfSchemas = registerField("oneOf", "oneOfSchemas", null, new ListOverlay<SchemaImpl>("oneOf", this, SchemaImpl.factory));
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	private ListOverlay<SchemaImpl> oneOfSchemas = new ListOverlay<SchemaImpl>("oneOf", this, SchemaImpl.factory);
 
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private ListOverlay<SchemaImpl> anyOfSchemas = registerField("anyOf", "anyOfSchemas", null, new ListOverlay<SchemaImpl>("anyOf", this, SchemaImpl.factory));
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	private ListOverlay<SchemaImpl> anyOfSchemas = new ListOverlay<SchemaImpl>("anyOf", this, SchemaImpl.factory);
 
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private SchemaImpl notSchema = registerField("not", "notSchema", null, SchemaImpl.factory.create("not", this));
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	private SchemaImpl notSchema = SchemaImpl.factory.create("not", this);
 
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private SchemaImpl itemsSchema = registerField("items", "itemsSchema", null, SchemaImpl.factory.create("items", this));
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	private SchemaImpl itemsSchema = SchemaImpl.factory.create("items", this);
 
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private MapOverlay<SchemaImpl> properties = registerField("properties", "properties", null, new MapOverlay<SchemaImpl>("properties", this, SchemaImpl.factory, null));
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	private MapOverlay<SchemaImpl> properties = new MapOverlay<SchemaImpl>("properties", this, SchemaImpl.factory,
+			null);
 
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private SchemaImpl additionalPropertiesSchema = registerField("additionalProperties", "additionalPropertiesSchema", null, SchemaImpl.factory.create("additionalProperties", this));
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	private SchemaImpl additionalPropertiesSchema = SchemaImpl.factory.create("additionalProperties", this);
 
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private BooleanOverlay additionalProperties = registerField("additionalProperties", "additionalProperties", null, new BooleanOverlay("additionalProperties", this));
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	private BooleanOverlay additionalProperties = new BooleanOverlay("additionalProperties", this);
 
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private StringOverlay description = registerField("description", "description", null, new StringOverlay("description", this));
-
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private StringOverlay format = registerField("format", "format", null, new StringOverlay("format", this));
-
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private AnyObjectOverlay defaultValue = registerField("default", "defaultValue", null, new AnyObjectOverlay("default", this));
-
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private BooleanOverlay nullable = registerField("nullable", "nullable", null, new BooleanOverlay("nullable", this));
-
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private StringOverlay discriminator = registerField("discriminator", "discriminator", null, new StringOverlay("discriminator", this));
-
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private BooleanOverlay readOnly = registerField("readOnly", "readOnly", null, new BooleanOverlay("readOnly", this));
-
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private BooleanOverlay writeOnly = registerField("writeOnly", "writeOnly", null, new BooleanOverlay("writeOnly", this));
-
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private XmlImpl xml = registerField("xml", "xml", null, XmlImpl.factory.create("xml", this));
-
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private ExternalDocsImpl externalDocs = registerField("externalDocs", "externalDocs", null, ExternalDocsImpl.factory.create("externalDocs", this));
-
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private MapOverlay<ExampleImpl> examples = registerField("examples", "examples", "[a-zA-Z0-9\\._-]+", new MapOverlay<ExampleImpl>("examples", this, ExampleImpl.factory, "[a-zA-Z0-9\\._-]+"));
-
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private AnyObjectOverlay example = registerField("example", "example", null, new AnyObjectOverlay("example", this));
-
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private BooleanOverlay deprecated = registerField("deprecated", "deprecated", null, new BooleanOverlay("deprecated", this));
-
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private ValMapOverlay<Object,AnyObjectOverlay> extensions = registerField("", "extensions", "x-.+", new ValMapOverlay<Object, AnyObjectOverlay>("", this, AnyObjectOverlay.factory, "x-.+"));
-
-    // Title
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public String getTitle() {
-        return title.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void setTitle(String title) {
-        this.title.set(title);
-    }
-
-    // MultipleOf
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public Number getMultipleOf() {
-        return multipleOf.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void setMultipleOf(Number multipleOf) {
-        this.multipleOf.set(multipleOf);
-    }
-
-    // Maximum
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public Number getMaximum() {
-        return maximum.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void setMaximum(Number maximum) {
-        this.maximum.set(maximum);
-    }
-
-    // ExclusiveMaximum
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public Boolean getExclusiveMaximum() {
-        return exclusiveMaximum.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public boolean isExclusiveMaximum() {
-        return exclusiveMaximum.get() != null ? exclusiveMaximum.get() : false;
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void setExclusiveMaximum(Boolean exclusiveMaximum) {
-        this.exclusiveMaximum.set(exclusiveMaximum);
-    }
-
-    // Minimum
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public Number getMinimum() {
-        return minimum.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void setMinimum(Number minimum) {
-        this.minimum.set(minimum);
-    }
-
-    // ExclusiveMinimum
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public Boolean getExclusiveMinimum() {
-        return exclusiveMinimum.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public boolean isExclusiveMinimum() {
-        return exclusiveMinimum.get() != null ? exclusiveMinimum.get() : false;
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void setExclusiveMinimum(Boolean exclusiveMinimum) {
-        this.exclusiveMinimum.set(exclusiveMinimum);
-    }
-
-    // MaxLength
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public Integer getMaxLength() {
-        return maxLength.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void setMaxLength(Integer maxLength) {
-        this.maxLength.set(maxLength);
-    }
-
-    // MinLength
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public Integer getMinLength() {
-        return minLength.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void setMinLength(Integer minLength) {
-        this.minLength.set(minLength);
-    }
-
-    // Pattern
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public String getPattern() {
-        return pattern.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void setPattern(String pattern) {
-        this.pattern.set(pattern);
-    }
-
-    // MaxItems
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public Integer getMaxItems() {
-        return maxItems.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void setMaxItems(Integer maxItems) {
-        this.maxItems.set(maxItems);
-    }
-
-    // MinItems
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public Integer getMinItems() {
-        return minItems.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void setMinItems(Integer minItems) {
-        this.minItems.set(minItems);
-    }
-
-    // UniqueItems
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public Boolean getUniqueItems() {
-        return uniqueItems.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public boolean isUniqueItems() {
-        return uniqueItems.get() != null ? uniqueItems.get() : false;
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void setUniqueItems(Boolean uniqueItems) {
-        this.uniqueItems.set(uniqueItems);
-    }
-
-    // MaxProperties
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public Integer getMaxProperties() {
-        return maxProperties.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void setMaxProperties(Integer maxProperties) {
-        this.maxProperties.set(maxProperties);
-    }
-
-    // MinProperties
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public Integer getMinProperties() {
-        return minProperties.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void setMinProperties(Integer minProperties) {
-        this.minProperties.set(minProperties);
-    }
-
-    // RequiredField
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public Collection<String> getRequiredFields() {
-        return requiredFields.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public boolean hasRequiredFields() {
-        return !requiredFields.isMissing();
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public String getRequiredField(int index) {
-        return requiredFields.get(index);
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void setRequiredFields(Collection<String> requiredFields) {
-        this.requiredFields.set((Collection<String>) requiredFields);
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void setRequiredField(int index, String requiredField) {
-        requiredFields.set(index, requiredField);
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void addRequiredField(String requiredField) {
-        requiredFields.add(requiredField);
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void removeRequiredField(int index) {
-        requiredFields.remove(index);
-    }
-
-    // Enum
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public Collection<Object> getEnums() {
-        return enums.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public boolean hasEnums() {
-        return !enums.isMissing();
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public Object getEnum(int index) {
-        return enums.get(index);
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void setEnums(Collection<Object> enums) {
-        this.enums.set((Collection<Object>) enums);
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void setEnum(int index, Object enumValue) {
-        enums.set(index, enumValue);
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void addEnum(Object enumValue) {
-        enums.add(enumValue);
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void removeEnum(int index) {
-        enums.remove(index);
-    }
-
-    // Type
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public String getType() {
-        return type.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void setType(String type) {
-        this.type.set(type);
-    }
-
-    // AllOfSchema
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public Collection<? extends Schema> getAllOfSchemas() {
-        return allOfSchemas.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public boolean hasAllOfSchemas() {
-        return !allOfSchemas.isMissing();
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public Schema getAllOfSchema(int index) {
-        return allOfSchemas.get(index);
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void setAllOfSchemas(Collection<? extends Schema> allOfSchemas) {
-        @SuppressWarnings("unchecked")
-            Collection<SchemaImpl> implAllOfSchemas = (Collection<SchemaImpl>) allOfSchemas;
-            this.allOfSchemas.set(implAllOfSchemas);
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void setAllOfSchema(int index, Schema allOfSchema) {
-        allOfSchemas.set(index, (SchemaImpl) allOfSchema);
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void addAllOfSchema(Schema allOfSchema) {
-        allOfSchemas.add((SchemaImpl) allOfSchema);
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void removeAllOfSchema(int index) {
-        allOfSchemas.remove(index);
-    }
-
-    // OneOfSchema
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public Collection<? extends Schema> getOneOfSchemas() {
-        return oneOfSchemas.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public boolean hasOneOfSchemas() {
-        return !oneOfSchemas.isMissing();
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public Schema getOneOfSchema(int index) {
-        return oneOfSchemas.get(index);
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void setOneOfSchemas(Collection<? extends Schema> oneOfSchemas) {
-        @SuppressWarnings("unchecked")
-            Collection<SchemaImpl> implOneOfSchemas = (Collection<SchemaImpl>) oneOfSchemas;
-            this.oneOfSchemas.set(implOneOfSchemas);
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void setOneOfSchema(int index, Schema oneOfSchema) {
-        oneOfSchemas.set(index, (SchemaImpl) oneOfSchema);
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void addOneOfSchema(Schema oneOfSchema) {
-        oneOfSchemas.add((SchemaImpl) oneOfSchema);
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void removeOneOfSchema(int index) {
-        oneOfSchemas.remove(index);
-    }
-
-    // AnyOfSchema
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public Collection<? extends Schema> getAnyOfSchemas() {
-        return anyOfSchemas.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public boolean hasAnyOfSchemas() {
-        return !anyOfSchemas.isMissing();
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public Schema getAnyOfSchema(int index) {
-        return anyOfSchemas.get(index);
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void setAnyOfSchemas(Collection<? extends Schema> anyOfSchemas) {
-        @SuppressWarnings("unchecked")
-            Collection<SchemaImpl> implAnyOfSchemas = (Collection<SchemaImpl>) anyOfSchemas;
-            this.anyOfSchemas.set(implAnyOfSchemas);
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void setAnyOfSchema(int index, Schema anyOfSchema) {
-        anyOfSchemas.set(index, (SchemaImpl) anyOfSchema);
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void addAnyOfSchema(Schema anyOfSchema) {
-        anyOfSchemas.add((SchemaImpl) anyOfSchema);
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void removeAnyOfSchema(int index) {
-        anyOfSchemas.remove(index);
-    }
-
-    // NotSchema
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public Schema getNotSchema() {
-        return notSchema;
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void setNotSchema(Schema notSchema) {
-        this.notSchema.set((SchemaImpl) notSchema);
-    }
-
-    // ItemsSchema
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public Schema getItemsSchema() {
-        return itemsSchema;
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void setItemsSchema(Schema itemsSchema) {
-        this.itemsSchema.set((SchemaImpl) itemsSchema);
-    }
-
-    // Property
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public Map<String, ? extends Schema> getProperties() {
-        return properties.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public boolean hasProperty(String name) {
-        return properties.containsKey(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public Schema getProperty(String name) {
-        return properties.get(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void setProperties(Map<String, ? extends Schema> properties) {
-        @SuppressWarnings("unchecked")
-            Map<String,SchemaImpl> implProperties = (Map<String, SchemaImpl>) properties;
-            this.properties.set(implProperties);
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void setProperty(String name, Schema property) {
-        properties.set(name, (SchemaImpl) property);
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void removeProperty(String name) {
-        properties.remove(name);
-    }
-
-    // AdditionalPropertiesSchema
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public Schema getAdditionalPropertiesSchema() {
-        return additionalPropertiesSchema;
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void setAdditionalPropertiesSchema(Schema additionalPropertiesSchema) {
-        this.additionalPropertiesSchema.set((SchemaImpl) additionalPropertiesSchema);
-    }
-
-    // AdditionalProperties
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public Boolean getAdditionalProperties() {
-        return additionalProperties.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public boolean isAdditionalProperties() {
-        return additionalProperties.get() != null ? additionalProperties.get() : false;
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void setAdditionalProperties(Boolean additionalProperties) {
-        this.additionalProperties.set(additionalProperties);
-    }
-
-    // Description
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public String getDescription() {
-        return description.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void setDescription(String description) {
-        this.description.set(description);
-    }
-
-    // Format
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public String getFormat() {
-        return format.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void setFormat(String format) {
-        this.format.set(format);
-    }
-
-    // Default
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public Object getDefault() {
-        return defaultValue.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void setDefault(Object defaultValue) {
-        this.defaultValue.set(defaultValue);
-    }
-
-    // Nullable
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public Boolean getNullable() {
-        return nullable.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public boolean isNullable() {
-        return nullable.get() != null ? nullable.get() : false;
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void setNullable(Boolean nullable) {
-        this.nullable.set(nullable);
-    }
-
-    // Discriminator
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public String getDiscriminator() {
-        return discriminator.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void setDiscriminator(String discriminator) {
-        this.discriminator.set(discriminator);
-    }
-
-    // ReadOnly
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public Boolean getReadOnly() {
-        return readOnly.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public boolean isReadOnly() {
-        return readOnly.get() != null ? readOnly.get() : false;
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void setReadOnly(Boolean readOnly) {
-        this.readOnly.set(readOnly);
-    }
-
-    // WriteOnly
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public Boolean getWriteOnly() {
-        return writeOnly.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public boolean isWriteOnly() {
-        return writeOnly.get() != null ? writeOnly.get() : false;
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void setWriteOnly(Boolean writeOnly) {
-        this.writeOnly.set(writeOnly);
-    }
-
-    // Xml
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public Xml getXml() {
-        return xml;
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void setXml(Xml xml) {
-        this.xml.set((XmlImpl) xml);
-    }
-
-    // ExternalDocs
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public ExternalDocs getExternalDocs() {
-        return externalDocs;
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void setExternalDocs(ExternalDocs externalDocs) {
-        this.externalDocs.set((ExternalDocsImpl) externalDocs);
-    }
-
-    // Example
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public Map<String, ? extends Example> getExamples() {
-        return examples.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public boolean hasExample(String name) {
-        return examples.containsKey(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public Example getExample(String name) {
-        return examples.get(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void setExamples(Map<String, ? extends Example> examples) {
-        @SuppressWarnings("unchecked")
-            Map<String,ExampleImpl> implExamples = (Map<String, ExampleImpl>) examples;
-            this.examples.set(implExamples);
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void setExample(String name, Example example) {
-        examples.set(name, (ExampleImpl) example);
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void removeExample(String name) {
-        examples.remove(name);
-    }
-
-    // Example
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public Object getExample() {
-        return example.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void setExample(Object example) {
-        this.example.set(example);
-    }
-
-    // Deprecated
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public Boolean getDeprecated() {
-        return deprecated.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public boolean isDeprecated() {
-        return deprecated.get() != null ? deprecated.get() : false;
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void setDeprecated(Boolean deprecated) {
-        this.deprecated.set(deprecated);
-    }
-
-    // Extension
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public Map<String, Object> getExtensions() {
-        return extensions.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public boolean hasExtension(String name) {
-        return extensions.containsKey(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public Object getExtension(String name) {
-        return extensions.get(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void setExtensions(Map<String, Object> extensions) {
-        this.extensions.set(extensions);
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void setExtension(String name, Object extension) {
-        extensions.set(name, extension);
-    }
-
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void removeExtension(String name) {
-        extensions.remove(name);
-    }
-
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public static JsonOverlayFactory<SchemaImpl> factory = new JsonOverlayFactory<SchemaImpl>() {
-    @Override
-    public SchemaImpl create(String key, JsonNode json, JsonOverlay<?> parent) {
-        return isEmptyRecursive(parent, SchemaImpl.class) ? null : new SchemaImpl(key, json, parent);
-    }
-};
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	private StringOverlay description = new StringOverlay("description", this);
+
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	private StringOverlay format = new StringOverlay("format", this);
+
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	private AnyObjectOverlay defaultValue = new AnyObjectOverlay("default", this);
+
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	private BooleanOverlay nullable = new BooleanOverlay("nullable", this);
+
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	private StringOverlay discriminator = new StringOverlay("discriminator", this);
+
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	private BooleanOverlay readOnly = new BooleanOverlay("readOnly", this);
+
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	private BooleanOverlay writeOnly = new BooleanOverlay("writeOnly", this);
+
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	private XmlImpl xml = XmlImpl.factory.create("xml", this);
+
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	private ExternalDocsImpl externalDocs = ExternalDocsImpl.factory.create("externalDocs", this);
+
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	private MapOverlay<ExampleImpl> examples = new MapOverlay<ExampleImpl>("examples", this, ExampleImpl.factory,
+			"[a-zA-Z0-9\\._-]+");
+
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	private AnyObjectOverlay example = new AnyObjectOverlay("example", this);
+
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	private BooleanOverlay deprecated = new BooleanOverlay("deprecated", this);
+
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	private ValMapOverlay<Object, AnyObjectOverlay> extensions = new ValMapOverlay<Object, AnyObjectOverlay>("", this,
+			AnyObjectOverlay.factory, "x-.+");
+
+	// Title
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public String getTitle() {
+		return title.get();
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public void setTitle(String title) {
+		this.title.set(title);
+	}
+
+	// MultipleOf
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public Number getMultipleOf() {
+		return multipleOf.get();
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public void setMultipleOf(Number multipleOf) {
+		this.multipleOf.set(multipleOf);
+	}
+
+	// Maximum
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public Number getMaximum() {
+		return maximum.get();
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public void setMaximum(Number maximum) {
+		this.maximum.set(maximum);
+	}
+
+	// ExclusiveMaximum
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public Boolean getExclusiveMaximum() {
+		return exclusiveMaximum.get();
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public boolean isExclusiveMaximum() {
+		return exclusiveMaximum.get() != null ? exclusiveMaximum.get() : false;
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public void setExclusiveMaximum(Boolean exclusiveMaximum) {
+		this.exclusiveMaximum.set(exclusiveMaximum);
+	}
+
+	// Minimum
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public Number getMinimum() {
+		return minimum.get();
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public void setMinimum(Number minimum) {
+		this.minimum.set(minimum);
+	}
+
+	// ExclusiveMinimum
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public Boolean getExclusiveMinimum() {
+		return exclusiveMinimum.get();
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public boolean isExclusiveMinimum() {
+		return exclusiveMinimum.get() != null ? exclusiveMinimum.get() : false;
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public void setExclusiveMinimum(Boolean exclusiveMinimum) {
+		this.exclusiveMinimum.set(exclusiveMinimum);
+	}
+
+	// MaxLength
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public Integer getMaxLength() {
+		return maxLength.get();
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public void setMaxLength(Integer maxLength) {
+		this.maxLength.set(maxLength);
+	}
+
+	// MinLength
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public Integer getMinLength() {
+		return minLength.get();
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public void setMinLength(Integer minLength) {
+		this.minLength.set(minLength);
+	}
+
+	// Pattern
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public String getPattern() {
+		return pattern.get();
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public void setPattern(String pattern) {
+		this.pattern.set(pattern);
+	}
+
+	// MaxItems
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public Integer getMaxItems() {
+		return maxItems.get();
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public void setMaxItems(Integer maxItems) {
+		this.maxItems.set(maxItems);
+	}
+
+	// MinItems
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public Integer getMinItems() {
+		return minItems.get();
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public void setMinItems(Integer minItems) {
+		this.minItems.set(minItems);
+	}
+
+	// UniqueItems
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public Boolean getUniqueItems() {
+		return uniqueItems.get();
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public boolean isUniqueItems() {
+		return uniqueItems.get() != null ? uniqueItems.get() : false;
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public void setUniqueItems(Boolean uniqueItems) {
+		this.uniqueItems.set(uniqueItems);
+	}
+
+	// MaxProperties
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public Integer getMaxProperties() {
+		return maxProperties.get();
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public void setMaxProperties(Integer maxProperties) {
+		this.maxProperties.set(maxProperties);
+	}
+
+	// MinProperties
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public Integer getMinProperties() {
+		return minProperties.get();
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public void setMinProperties(Integer minProperties) {
+		this.minProperties.set(minProperties);
+	}
+
+	// RequiredField
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public Collection<String> getRequiredFields() {
+		return requiredFields.get();
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public boolean hasRequiredFields() {
+		return !requiredFields.isMissing();
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public String getRequiredField(int index) {
+		return requiredFields.get(index);
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public void setRequiredFields(Collection<String> requiredFields) {
+		this.requiredFields.set((Collection<String>) requiredFields);
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public void setRequiredField(int index, String requiredField) {
+		requiredFields.set(index, requiredField);
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public void addRequiredField(String requiredField) {
+		requiredFields.add(requiredField);
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public void removeRequiredField(int index) {
+		requiredFields.remove(index);
+	}
+
+	// Enum
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public Collection<Object> getEnums() {
+		return enums.get();
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public boolean hasEnums() {
+		return !enums.isMissing();
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public Object getEnum(int index) {
+		return enums.get(index);
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public void setEnums(Collection<Object> enums) {
+		this.enums.set((Collection<Object>) enums);
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public void setEnum(int index, Object enumValue) {
+		enums.set(index, enumValue);
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public void addEnum(Object enumValue) {
+		enums.add(enumValue);
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public void removeEnum(int index) {
+		enums.remove(index);
+	}
+
+	// Type
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public String getType() {
+		return type.get();
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public void setType(String type) {
+		this.type.set(type);
+	}
+
+	// AllOfSchema
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public Collection<? extends Schema> getAllOfSchemas() {
+		return allOfSchemas.get();
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public boolean hasAllOfSchemas() {
+		return !allOfSchemas.isMissing();
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public Schema getAllOfSchema(int index) {
+		return allOfSchemas.get(index);
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public void setAllOfSchemas(Collection<? extends Schema> allOfSchemas) {
+		@SuppressWarnings("unchecked")
+		Collection<SchemaImpl> implAllOfSchemas = (Collection<SchemaImpl>) allOfSchemas;
+		this.allOfSchemas.set(implAllOfSchemas);
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public void setAllOfSchema(int index, Schema allOfSchema) {
+		allOfSchemas.set(index, (SchemaImpl) allOfSchema);
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public void addAllOfSchema(Schema allOfSchema) {
+		allOfSchemas.add((SchemaImpl) allOfSchema);
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public void removeAllOfSchema(int index) {
+		allOfSchemas.remove(index);
+	}
+
+	// OneOfSchema
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public Collection<? extends Schema> getOneOfSchemas() {
+		return oneOfSchemas.get();
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public boolean hasOneOfSchemas() {
+		return !oneOfSchemas.isMissing();
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public Schema getOneOfSchema(int index) {
+		return oneOfSchemas.get(index);
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public void setOneOfSchemas(Collection<? extends Schema> oneOfSchemas) {
+		@SuppressWarnings("unchecked")
+		Collection<SchemaImpl> implOneOfSchemas = (Collection<SchemaImpl>) oneOfSchemas;
+		this.oneOfSchemas.set(implOneOfSchemas);
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public void setOneOfSchema(int index, Schema oneOfSchema) {
+		oneOfSchemas.set(index, (SchemaImpl) oneOfSchema);
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public void addOneOfSchema(Schema oneOfSchema) {
+		oneOfSchemas.add((SchemaImpl) oneOfSchema);
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public void removeOneOfSchema(int index) {
+		oneOfSchemas.remove(index);
+	}
+
+	// AnyOfSchema
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public Collection<? extends Schema> getAnyOfSchemas() {
+		return anyOfSchemas.get();
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public boolean hasAnyOfSchemas() {
+		return !anyOfSchemas.isMissing();
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public Schema getAnyOfSchema(int index) {
+		return anyOfSchemas.get(index);
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public void setAnyOfSchemas(Collection<? extends Schema> anyOfSchemas) {
+		@SuppressWarnings("unchecked")
+		Collection<SchemaImpl> implAnyOfSchemas = (Collection<SchemaImpl>) anyOfSchemas;
+		this.anyOfSchemas.set(implAnyOfSchemas);
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public void setAnyOfSchema(int index, Schema anyOfSchema) {
+		anyOfSchemas.set(index, (SchemaImpl) anyOfSchema);
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public void addAnyOfSchema(Schema anyOfSchema) {
+		anyOfSchemas.add((SchemaImpl) anyOfSchema);
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public void removeAnyOfSchema(int index) {
+		anyOfSchemas.remove(index);
+	}
+
+	// NotSchema
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public Schema getNotSchema() {
+		return notSchema;
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public void setNotSchema(Schema notSchema) {
+		this.notSchema.set((SchemaImpl) notSchema);
+	}
+
+	// ItemsSchema
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public Schema getItemsSchema() {
+		return itemsSchema;
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public void setItemsSchema(Schema itemsSchema) {
+		this.itemsSchema.set((SchemaImpl) itemsSchema);
+	}
+
+	// Property
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public Map<String, ? extends Schema> getProperties() {
+		return properties.get();
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public boolean hasProperty(String name) {
+		return properties.containsKey(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public Schema getProperty(String name) {
+		return properties.get(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public void setProperties(Map<String, ? extends Schema> properties) {
+		@SuppressWarnings("unchecked")
+		Map<String, SchemaImpl> implProperties = (Map<String, SchemaImpl>) properties;
+		this.properties.set(implProperties);
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public void setProperty(String name, Schema property) {
+		properties.set(name, (SchemaImpl) property);
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public void removeProperty(String name) {
+		properties.remove(name);
+	}
+
+	// AdditionalPropertiesSchema
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public Schema getAdditionalPropertiesSchema() {
+		return additionalPropertiesSchema;
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public void setAdditionalPropertiesSchema(Schema additionalPropertiesSchema) {
+		this.additionalPropertiesSchema.set((SchemaImpl) additionalPropertiesSchema);
+	}
+
+	// AdditionalProperties
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public Boolean getAdditionalProperties() {
+		return additionalProperties.get();
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public boolean isAdditionalProperties() {
+		return additionalProperties.get() != null ? additionalProperties.get() : false;
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public void setAdditionalProperties(Boolean additionalProperties) {
+		this.additionalProperties.set(additionalProperties);
+	}
+
+	// Description
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public String getDescription() {
+		return description.get();
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public void setDescription(String description) {
+		this.description.set(description);
+	}
+
+	// Format
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public String getFormat() {
+		return format.get();
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public void setFormat(String format) {
+		this.format.set(format);
+	}
+
+	// Default
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public Object getDefault() {
+		return defaultValue.get();
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public void setDefault(Object defaultValue) {
+		this.defaultValue.set(defaultValue);
+	}
+
+	// Nullable
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public Boolean getNullable() {
+		return nullable.get();
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public boolean isNullable() {
+		return nullable.get() != null ? nullable.get() : false;
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public void setNullable(Boolean nullable) {
+		this.nullable.set(nullable);
+	}
+
+	// Discriminator
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public String getDiscriminator() {
+		return discriminator.get();
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public void setDiscriminator(String discriminator) {
+		this.discriminator.set(discriminator);
+	}
+
+	// ReadOnly
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public Boolean getReadOnly() {
+		return readOnly.get();
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public boolean isReadOnly() {
+		return readOnly.get() != null ? readOnly.get() : false;
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public void setReadOnly(Boolean readOnly) {
+		this.readOnly.set(readOnly);
+	}
+
+	// WriteOnly
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public Boolean getWriteOnly() {
+		return writeOnly.get();
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public boolean isWriteOnly() {
+		return writeOnly.get() != null ? writeOnly.get() : false;
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public void setWriteOnly(Boolean writeOnly) {
+		this.writeOnly.set(writeOnly);
+	}
+
+	// Xml
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public Xml getXml() {
+		return xml;
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public void setXml(Xml xml) {
+		this.xml.set((XmlImpl) xml);
+	}
+
+	// ExternalDocs
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public ExternalDocs getExternalDocs() {
+		return externalDocs;
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public void setExternalDocs(ExternalDocs externalDocs) {
+		this.externalDocs.set((ExternalDocsImpl) externalDocs);
+	}
+
+	// Example
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public Map<String, ? extends Example> getExamples() {
+		return examples.get();
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public boolean hasExample(String name) {
+		return examples.containsKey(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public Example getExample(String name) {
+		return examples.get(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public void setExamples(Map<String, ? extends Example> examples) {
+		@SuppressWarnings("unchecked")
+		Map<String, ExampleImpl> implExamples = (Map<String, ExampleImpl>) examples;
+		this.examples.set(implExamples);
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public void setExample(String name, Example example) {
+		examples.set(name, (ExampleImpl) example);
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public void removeExample(String name) {
+		examples.remove(name);
+	}
+
+	// Example
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public Object getExample() {
+		return example.get();
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public void setExample(Object example) {
+		this.example.set(example);
+	}
+
+	// Deprecated
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public Boolean getDeprecated() {
+		return deprecated.get();
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public boolean isDeprecated() {
+		return deprecated.get() != null ? deprecated.get() : false;
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public void setDeprecated(Boolean deprecated) {
+		this.deprecated.set(deprecated);
+	}
+
+	// Extension
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public Map<String, Object> getExtensions() {
+		return extensions.get();
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public boolean hasExtension(String name) {
+		return extensions.containsKey(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public Object getExtension(String name) {
+		return extensions.get(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public void setExtensions(Map<String, Object> extensions) {
+		this.extensions.set(extensions);
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public void setExtension(String name, Object extension) {
+		extensions.set(name, extension);
+	}
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public void removeExtension(String name) {
+		extensions.remove(name);
+	}
+
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public static JsonOverlayFactory<SchemaImpl> factory = new JsonOverlayFactory<SchemaImpl>() {
+		@Override
+		public SchemaImpl create(String key, JsonNode json, JsonOverlay<?> parent) {
+			return isEmptyRecursive(parent, SchemaImpl.class) ? null : new SchemaImpl(key, json, parent);
+		}
+	};
+
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	protected void installPropertyAccessors(PropertyAccessors accessors) {
+		OverlayGetter getter = null;
+		getter = new OverlayGetter() {
+			public JsonOverlay<?> get() {
+				return title;
+			}
+		};
+		accessors.add("title", null, getter);
+		getter = new OverlayGetter() {
+			public JsonOverlay<?> get() {
+				return multipleOf;
+			}
+		};
+		accessors.add("multipleOf", null, getter);
+		getter = new OverlayGetter() {
+			public JsonOverlay<?> get() {
+				return maximum;
+			}
+		};
+		accessors.add("maximum", null, getter);
+		getter = new OverlayGetter() {
+			public JsonOverlay<?> get() {
+				return exclusiveMaximum;
+			}
+		};
+		accessors.add("exclusiveMaximum", null, getter);
+		getter = new OverlayGetter() {
+			public JsonOverlay<?> get() {
+				return minimum;
+			}
+		};
+		accessors.add("minimum", null, getter);
+		getter = new OverlayGetter() {
+			public JsonOverlay<?> get() {
+				return exclusiveMinimum;
+			}
+		};
+		accessors.add("exclusiveMinimum", null, getter);
+		getter = new OverlayGetter() {
+			public JsonOverlay<?> get() {
+				return maxLength;
+			}
+		};
+		accessors.add("maxLength", null, getter);
+		getter = new OverlayGetter() {
+			public JsonOverlay<?> get() {
+				return minLength;
+			}
+		};
+		accessors.add("minLength", null, getter);
+		getter = new OverlayGetter() {
+			public JsonOverlay<?> get() {
+				return pattern;
+			}
+		};
+		accessors.add("pattern", null, getter);
+		getter = new OverlayGetter() {
+			public JsonOverlay<?> get() {
+				return maxItems;
+			}
+		};
+		accessors.add("maxItems", null, getter);
+		getter = new OverlayGetter() {
+			public JsonOverlay<?> get() {
+				return minItems;
+			}
+		};
+		accessors.add("minItems", null, getter);
+		getter = new OverlayGetter() {
+			public JsonOverlay<?> get() {
+				return uniqueItems;
+			}
+		};
+		accessors.add("uniqueItems", null, getter);
+		getter = new OverlayGetter() {
+			public JsonOverlay<?> get() {
+				return maxProperties;
+			}
+		};
+		accessors.add("maxProperties", null, getter);
+		getter = new OverlayGetter() {
+			public JsonOverlay<?> get() {
+				return minProperties;
+			}
+		};
+		accessors.add("minProperties", null, getter);
+		getter = new OverlayGetter() {
+			public JsonOverlay<?> get() {
+				return requiredFields;
+			}
+		};
+		accessors.add("required", null, getter);
+		getter = new OverlayGetter() {
+			public JsonOverlay<?> get() {
+				return enums;
+			}
+		};
+		accessors.add("enum", null, getter);
+		getter = new OverlayGetter() {
+			public JsonOverlay<?> get() {
+				return type;
+			}
+		};
+		accessors.add("type", null, getter);
+		getter = new OverlayGetter() {
+			public JsonOverlay<?> get() {
+				return allOfSchemas;
+			}
+		};
+		accessors.add("allOf", null, getter);
+		getter = new OverlayGetter() {
+			public JsonOverlay<?> get() {
+				return oneOfSchemas;
+			}
+		};
+		accessors.add("oneOf", null, getter);
+		getter = new OverlayGetter() {
+			public JsonOverlay<?> get() {
+				return anyOfSchemas;
+			}
+		};
+		accessors.add("anyOf", null, getter);
+		getter = new OverlayGetter() {
+			public JsonOverlay<?> get() {
+				return notSchema;
+			}
+		};
+		accessors.add("not", null, getter);
+		getter = new OverlayGetter() {
+			public JsonOverlay<?> get() {
+				return itemsSchema;
+			}
+		};
+		accessors.add("items", null, getter);
+		getter = new OverlayGetter() {
+			public JsonOverlay<?> get() {
+				return properties;
+			}
+		};
+		accessors.add("properties", null, getter);
+		getter = new OverlayGetter() {
+			public JsonOverlay<?> get() {
+				return additionalPropertiesSchema;
+			}
+		};
+		accessors.add("additionalProperties", null, getter);
+		getter = new OverlayGetter() {
+			public JsonOverlay<?> get() {
+				return additionalProperties;
+			}
+		};
+		accessors.add("additionalProperties", null, getter);
+		getter = new OverlayGetter() {
+			public JsonOverlay<?> get() {
+				return description;
+			}
+		};
+		accessors.add("description", null, getter);
+		getter = new OverlayGetter() {
+			public JsonOverlay<?> get() {
+				return format;
+			}
+		};
+		accessors.add("format", null, getter);
+		getter = new OverlayGetter() {
+			public JsonOverlay<?> get() {
+				return defaultValue;
+			}
+		};
+		accessors.add("default", null, getter);
+		getter = new OverlayGetter() {
+			public JsonOverlay<?> get() {
+				return nullable;
+			}
+		};
+		accessors.add("nullable", null, getter);
+		getter = new OverlayGetter() {
+			public JsonOverlay<?> get() {
+				return discriminator;
+			}
+		};
+		accessors.add("discriminator", null, getter);
+		getter = new OverlayGetter() {
+			public JsonOverlay<?> get() {
+				return readOnly;
+			}
+		};
+		accessors.add("readOnly", null, getter);
+		getter = new OverlayGetter() {
+			public JsonOverlay<?> get() {
+				return writeOnly;
+			}
+		};
+		accessors.add("writeOnly", null, getter);
+		getter = new OverlayGetter() {
+			public JsonOverlay<?> get() {
+				return xml;
+			}
+		};
+		accessors.add("xml", null, getter);
+		getter = new OverlayGetter() {
+			public JsonOverlay<?> get() {
+				return externalDocs;
+			}
+		};
+		accessors.add("externalDocs", null, getter);
+		getter = new OverlayGetter() {
+			public JsonOverlay<?> get() {
+				return examples;
+			}
+		};
+		accessors.add("examples", "[a-zA-Z0-9\\._-]+", getter);
+		getter = new OverlayGetter() {
+			public JsonOverlay<?> get() {
+				return example;
+			}
+		};
+		accessors.add("example", null, getter);
+		getter = new OverlayGetter() {
+			public JsonOverlay<?> get() {
+				return deprecated;
+			}
+		};
+		accessors.add("deprecated", null, getter);
+		getter = new OverlayGetter() {
+			public JsonOverlay<?> get() {
+				return extensions;
+			}
+		};
+		accessors.add("", "x-.+", getter);
+	}
 
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/SchemaImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/SchemaImpl.java
@@ -1,12 +1,8 @@
 package com.reprezen.kaizen.oasparser.ovl3;
 
-import java.util.Collection;
-import java.util.Map;
-
-import javax.annotation.Generated;
-
 import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.base.Optional;
 import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlayFactory;
 import com.reprezen.kaizen.oasparser.jsonoverlay.coll.ListOverlay;
@@ -22,17 +18,24 @@ import com.reprezen.kaizen.oasparser.model3.Example;
 import com.reprezen.kaizen.oasparser.model3.ExternalDocs;
 import com.reprezen.kaizen.oasparser.model3.Schema;
 import com.reprezen.kaizen.oasparser.model3.Xml;
+import com.reprezen.kaizen.oasparser.ovl3.ExampleImpl;
+import com.reprezen.kaizen.oasparser.ovl3.ExternalDocsImpl;
+import com.reprezen.kaizen.oasparser.ovl3.OpenApiObjectImpl;
+import com.reprezen.kaizen.oasparser.ovl3.SchemaImpl;
+import com.reprezen.kaizen.oasparser.ovl3.XmlImpl;
+import java.util.Collection;
+import java.util.Map;
+import javax.annotation.Generated;
 
 public class SchemaImpl extends OpenApiObjectImpl implements Schema {
 
     @Override
     public JsonOverlay<?> find(JsonPointer path) {
-    	if (path.matchesProperty("additionalProperties")) {
-    		return path.tail().matches() ? additionalProperties : additionalPropertiesSchema.find(path.tail());
-    	} else {
-    		return super.find(path);
-    	}
-    	
+        if (path.matchesProperty("additionalProperties")) {
+            return path.tail().matches() ? additionalProperties : additionalPropertiesSchema.find(path.tail());
+        } else {
+            return super.find(path);
+        }
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/SecurityParameterImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/SecurityParameterImpl.java
@@ -23,7 +23,7 @@ public class SecurityParameterImpl extends OpenApiObjectImpl implements Security
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private ValListOverlay<String, StringOverlay> parameters = registerField("", "parameters", null, new ValListOverlay<String, StringOverlay>("", this, StringOverlay.factory));;
+    private ValListOverlay<String, StringOverlay> parameters = new ValListOverlay<String, StringOverlay>("", this, StringOverlay.factory);
 
     // Parameter
     @Override
@@ -75,5 +75,13 @@ public class SecurityParameterImpl extends OpenApiObjectImpl implements Security
         return isEmptyRecursive(parent, SecurityParameterImpl.class) ? null : new SecurityParameterImpl(key, json, parent);
     }
 };
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    protected void installPropertyAccessors(PropertyAccessors accessors) {
+        OverlayGetter getter = null;
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return parameters;}};
+            accessors.add("", null, getter);
+    }
 
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/SecurityRequirementImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/SecurityRequirementImpl.java
@@ -24,7 +24,7 @@ public class SecurityRequirementImpl extends OpenApiObjectImpl implements Securi
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private MapOverlay<SecurityParameterImpl> requirements = registerField("", "requirements", null, new MapOverlay<SecurityParameterImpl>("", this, SecurityParameterImpl.factory, null));
+    private MapOverlay<SecurityParameterImpl> requirements = new MapOverlay<SecurityParameterImpl>("", this, SecurityParameterImpl.factory, null);
 
     // Requirement
     @Override
@@ -72,5 +72,13 @@ public class SecurityRequirementImpl extends OpenApiObjectImpl implements Securi
         return isEmptyRecursive(parent, SecurityRequirementImpl.class) ? null : new SecurityRequirementImpl(key, json, parent);
     }
 };
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    protected void installPropertyAccessors(PropertyAccessors accessors) {
+        OverlayGetter getter = null;
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return requirements;}};
+            accessors.add("", null, getter);
+    }
 
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/SecurityRequirementImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/SecurityRequirementImpl.java
@@ -1,84 +1,91 @@
 package com.reprezen.kaizen.oasparser.ovl3;
 
+import java.util.Map;
+
+import javax.annotation.Generated;
+
+import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlayFactory;
 import com.reprezen.kaizen.oasparser.jsonoverlay.coll.MapOverlay;
 import com.reprezen.kaizen.oasparser.model3.SecurityParameter;
 import com.reprezen.kaizen.oasparser.model3.SecurityRequirement;
-import com.reprezen.kaizen.oasparser.ovl3.OpenApiObjectImpl;
-import com.reprezen.kaizen.oasparser.ovl3.SecurityParameterImpl;
-import java.util.Map;
-import javax.annotation.Generated;
 
 public class SecurityRequirementImpl extends OpenApiObjectImpl implements SecurityRequirement {
 
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public SecurityRequirementImpl(String key, JsonNode json, JsonOverlay<?> parent) {
-        super(key, json, parent);
-    }
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public SecurityRequirementImpl(String key, JsonNode json, JsonOverlay<?> parent) {
+		super(key, json, parent);
+	}
 
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public SecurityRequirementImpl(String key, JsonOverlay<?> parent) {
-        super(key, parent);
-    }
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public SecurityRequirementImpl(String key, JsonOverlay<?> parent) {
+		super(key, parent);
+	}
 
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private MapOverlay<SecurityParameterImpl> requirements = new MapOverlay<SecurityParameterImpl>("", this, SecurityParameterImpl.factory, null);
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	private MapOverlay<SecurityParameterImpl> requirements = new MapOverlay<SecurityParameterImpl>("", this,
+			SecurityParameterImpl.factory, "[a-zA-Z0-9\\._-]+");
 
-    // Requirement
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public Map<String, ? extends SecurityParameter> getRequirements() {
-        return requirements.get();
-    }
+	// Requirement
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public Map<String, ? extends SecurityParameter> getRequirements() {
+		return requirements.get();
+	}
 
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public boolean hasRequirement(String name) {
-        return requirements.containsKey(name);
-    }
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public boolean hasRequirement(String name) {
+		return requirements.containsKey(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public SecurityParameter getRequirement(String name) {
-        return requirements.get(name);
-    }
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public SecurityParameter getRequirement(String name) {
+		return requirements.get(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void setRequirements(Map<String, ? extends SecurityParameter> requirements) {
-        @SuppressWarnings("unchecked")
-            Map<String,SecurityParameterImpl> implRequirements = (Map<String, SecurityParameterImpl>) requirements;
-            this.requirements.set(implRequirements);
-    }
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public void setRequirements(Map<String, ? extends SecurityParameter> requirements) {
+		@SuppressWarnings("unchecked")
+		Map<String, SecurityParameterImpl> implRequirements = (Map<String, SecurityParameterImpl>) requirements;
+		this.requirements.set(implRequirements);
+	}
 
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void setRequirement(String name, SecurityParameter requirement) {
-        requirements.set(name, (SecurityParameterImpl) requirement);
-    }
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public void setRequirement(String name, SecurityParameter requirement) {
+		requirements.set(name, (SecurityParameterImpl) requirement);
+	}
 
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public void removeRequirement(String name) {
-        requirements.remove(name);
-    }
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public void removeRequirement(String name) {
+		requirements.remove(name);
+	}
 
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    public static JsonOverlayFactory<SecurityRequirementImpl> factory = new JsonOverlayFactory<SecurityRequirementImpl>() {
-    @Override
-    public SecurityRequirementImpl create(String key, JsonNode json, JsonOverlay<?> parent) {
-        return isEmptyRecursive(parent, SecurityRequirementImpl.class) ? null : new SecurityRequirementImpl(key, json, parent);
-    }
-};
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	public static JsonOverlayFactory<SecurityRequirementImpl> factory = new JsonOverlayFactory<SecurityRequirementImpl>() {
+		@Override
+		public SecurityRequirementImpl create(String key, JsonNode json, JsonOverlay<?> parent) {
+			return isEmptyRecursive(parent, SecurityRequirementImpl.class) ? null
+					: new SecurityRequirementImpl(key, json, parent);
+		}
+	};
 
-    @Override
-    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    protected void installPropertyAccessors(PropertyAccessors accessors) {
-        OverlayGetter getter = null;
-            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return requirements;}};
-            accessors.add("", null, getter);
-    }
+	@Override
+	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+	protected void installPropertyAccessors(PropertyAccessors accessors) {
+		OverlayGetter getter = null;
+		getter = new OverlayGetter() {
+			public JsonOverlay<?> get() {
+				return requirements;
+			}
+		};
+		accessors.add("", "[a-zA-Z0-9\\._-]+", getter);
+	}
 
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/SecurityRequirementImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/SecurityRequirementImpl.java
@@ -1,91 +1,84 @@
 package com.reprezen.kaizen.oasparser.ovl3;
 
-import java.util.Map;
-
-import javax.annotation.Generated;
-
-import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlayFactory;
 import com.reprezen.kaizen.oasparser.jsonoverlay.coll.MapOverlay;
 import com.reprezen.kaizen.oasparser.model3.SecurityParameter;
 import com.reprezen.kaizen.oasparser.model3.SecurityRequirement;
+import com.reprezen.kaizen.oasparser.ovl3.OpenApiObjectImpl;
+import com.reprezen.kaizen.oasparser.ovl3.SecurityParameterImpl;
+import java.util.Map;
+import javax.annotation.Generated;
 
 public class SecurityRequirementImpl extends OpenApiObjectImpl implements SecurityRequirement {
 
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public SecurityRequirementImpl(String key, JsonNode json, JsonOverlay<?> parent) {
-		super(key, json, parent);
-	}
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public SecurityRequirementImpl(String key, JsonNode json, JsonOverlay<?> parent) {
+        super(key, json, parent);
+    }
 
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public SecurityRequirementImpl(String key, JsonOverlay<?> parent) {
-		super(key, parent);
-	}
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public SecurityRequirementImpl(String key, JsonOverlay<?> parent) {
+        super(key, parent);
+    }
 
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	private MapOverlay<SecurityParameterImpl> requirements = new MapOverlay<SecurityParameterImpl>("", this,
-			SecurityParameterImpl.factory, "[a-zA-Z0-9\\._-]+");
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private MapOverlay<SecurityParameterImpl> requirements = new MapOverlay<SecurityParameterImpl>("", this, SecurityParameterImpl.factory, "[a-zA-Z0-9\\._-]+");
 
-	// Requirement
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public Map<String, ? extends SecurityParameter> getRequirements() {
-		return requirements.get();
-	}
+    // Requirement
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public Map<String, ? extends SecurityParameter> getRequirements() {
+        return requirements.get();
+    }
 
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public boolean hasRequirement(String name) {
-		return requirements.containsKey(name);
-	}
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public boolean hasRequirement(String name) {
+        return requirements.containsKey(name);
+    }
 
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public SecurityParameter getRequirement(String name) {
-		return requirements.get(name);
-	}
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public SecurityParameter getRequirement(String name) {
+        return requirements.get(name);
+    }
 
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public void setRequirements(Map<String, ? extends SecurityParameter> requirements) {
-		@SuppressWarnings("unchecked")
-		Map<String, SecurityParameterImpl> implRequirements = (Map<String, SecurityParameterImpl>) requirements;
-		this.requirements.set(implRequirements);
-	}
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public void setRequirements(Map<String, ? extends SecurityParameter> requirements) {
+        @SuppressWarnings("unchecked")
+            Map<String,SecurityParameterImpl> implRequirements = (Map<String, SecurityParameterImpl>) requirements;
+            this.requirements.set(implRequirements);
+    }
 
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public void setRequirement(String name, SecurityParameter requirement) {
-		requirements.set(name, (SecurityParameterImpl) requirement);
-	}
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public void setRequirement(String name, SecurityParameter requirement) {
+        requirements.set(name, (SecurityParameterImpl) requirement);
+    }
 
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public void removeRequirement(String name) {
-		requirements.remove(name);
-	}
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public void removeRequirement(String name) {
+        requirements.remove(name);
+    }
 
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	public static JsonOverlayFactory<SecurityRequirementImpl> factory = new JsonOverlayFactory<SecurityRequirementImpl>() {
-		@Override
-		public SecurityRequirementImpl create(String key, JsonNode json, JsonOverlay<?> parent) {
-			return isEmptyRecursive(parent, SecurityRequirementImpl.class) ? null
-					: new SecurityRequirementImpl(key, json, parent);
-		}
-	};
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    public static JsonOverlayFactory<SecurityRequirementImpl> factory = new JsonOverlayFactory<SecurityRequirementImpl>() {
+    @Override
+    public SecurityRequirementImpl create(String key, JsonNode json, JsonOverlay<?> parent) {
+        return isEmptyRecursive(parent, SecurityRequirementImpl.class) ? null : new SecurityRequirementImpl(key, json, parent);
+    }
+};
 
-	@Override
-	@Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-	protected void installPropertyAccessors(PropertyAccessors accessors) {
-		OverlayGetter getter = null;
-		getter = new OverlayGetter() {
-			public JsonOverlay<?> get() {
-				return requirements;
-			}
-		};
-		accessors.add("", "[a-zA-Z0-9\\._-]+", getter);
-	}
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    protected void installPropertyAccessors(PropertyAccessors accessors) {
+        OverlayGetter getter = null;
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return requirements;}};
+            accessors.add("", "[a-zA-Z0-9\\._-]+", getter);
+    }
 
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/SecuritySchemeImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/SecuritySchemeImpl.java
@@ -26,43 +26,43 @@ public class SecuritySchemeImpl extends OpenApiObjectImpl implements SecuritySch
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private StringOverlay type = registerField("type", "type", null, new StringOverlay("type", this));
+    private StringOverlay type = new StringOverlay("type", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private StringOverlay description = registerField("description", "description", null, new StringOverlay("description", this));
+    private StringOverlay description = new StringOverlay("description", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private StringOverlay name = registerField("name", "name", null, new StringOverlay("name", this));
+    private StringOverlay name = new StringOverlay("name", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private StringOverlay in = registerField("in", "in", null, new StringOverlay("in", this));
+    private StringOverlay in = new StringOverlay("in", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private StringOverlay scheme = registerField("scheme", "scheme", null, new StringOverlay("scheme", this));
+    private StringOverlay scheme = new StringOverlay("scheme", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private StringOverlay bearerFormat = registerField("bearerFormat", "bearerFormat", null, new StringOverlay("bearerFormat", this));
+    private StringOverlay bearerFormat = new StringOverlay("bearerFormat", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private OAuthFlowImpl implicitOAuthFlow = registerField("flow/implicit", "implicitOAuthFlow", null, OAuthFlowImpl.factory.create("flow/implicit", this));
+    private OAuthFlowImpl implicitOAuthFlow = OAuthFlowImpl.factory.create("flow/implicit", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private OAuthFlowImpl passwordOAuthFlow = registerField("flow/password", "passwordOAuthFlow", null, OAuthFlowImpl.factory.create("flow/password", this));
+    private OAuthFlowImpl passwordOAuthFlow = OAuthFlowImpl.factory.create("flow/password", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private OAuthFlowImpl clientCredentialsOAuthFlow = registerField("flow/clientCredentials", "clientCredentialsOAuthFlow", null, OAuthFlowImpl.factory.create("flow/clientCredentials", this));
+    private OAuthFlowImpl clientCredentialsOAuthFlow = OAuthFlowImpl.factory.create("flow/clientCredentials", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private OAuthFlowImpl authorizationCodeOAuthFlow = registerField("flow/authorizationCode", "authorizationCodeOAuthFlow", null, OAuthFlowImpl.factory.create("flow/authorizationCode", this));
+    private OAuthFlowImpl authorizationCodeOAuthFlow = OAuthFlowImpl.factory.create("flow/authorizationCode", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private ValMapOverlay<Object,AnyObjectOverlay> oAuthFlowsExtensions = registerField("flow", "oAuthFlowsExtensions", "x-.+", new ValMapOverlay<Object, AnyObjectOverlay>("flow", this, AnyObjectOverlay.factory, "x-.+"));
+    private ValMapOverlay<Object, AnyObjectOverlay> oAuthFlowsExtensions = new ValMapOverlay<Object, AnyObjectOverlay>("flow", this, AnyObjectOverlay.factory, "x-.+");
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private StringOverlay openIdConnectUrl = registerField("openIdConnectUrl", "openIdConnectUrl", null, new StringOverlay("openIdConnectUrl", this));
+    private StringOverlay openIdConnectUrl = new StringOverlay("openIdConnectUrl", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private ValMapOverlay<Object,AnyObjectOverlay> extensions = registerField("", "extensions", "x-.+", new ValMapOverlay<Object, AnyObjectOverlay>("", this, AnyObjectOverlay.factory, "x-.+"));
+    private ValMapOverlay<Object, AnyObjectOverlay> extensions = new ValMapOverlay<Object, AnyObjectOverlay>("", this, AnyObjectOverlay.factory, "x-.+");
 
     // Type
     @Override
@@ -288,5 +288,37 @@ public class SecuritySchemeImpl extends OpenApiObjectImpl implements SecuritySch
         return isEmptyRecursive(parent, SecuritySchemeImpl.class) ? null : new SecuritySchemeImpl(key, json, parent);
     }
 };
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    protected void installPropertyAccessors(PropertyAccessors accessors) {
+        OverlayGetter getter = null;
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return type;}};
+            accessors.add("type", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return description;}};
+            accessors.add("description", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return name;}};
+            accessors.add("name", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return in;}};
+            accessors.add("in", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return scheme;}};
+            accessors.add("scheme", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return bearerFormat;}};
+            accessors.add("bearerFormat", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return implicitOAuthFlow;}};
+            accessors.add("flow/implicit", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return passwordOAuthFlow;}};
+            accessors.add("flow/password", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return clientCredentialsOAuthFlow;}};
+            accessors.add("flow/clientCredentials", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return authorizationCodeOAuthFlow;}};
+            accessors.add("flow/authorizationCode", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return oAuthFlowsExtensions;}};
+            accessors.add("flow", "x-.+", getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return openIdConnectUrl;}};
+            accessors.add("openIdConnectUrl", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return extensions;}};
+            accessors.add("", "x-.+", getter);
+    }
 
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ServerImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ServerImpl.java
@@ -27,19 +27,19 @@ public class ServerImpl extends OpenApiObjectImpl implements Server {
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private StringOverlay url = registerField("url", "url", null, new StringOverlay("url", this));
+    private StringOverlay url = new StringOverlay("url", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private StringOverlay description = registerField("description", "description", null, new StringOverlay("description", this));
+    private StringOverlay description = new StringOverlay("description", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private MapOverlay<ServerVariableImpl> serverVariables = registerField("variables", "serverVariables", "(?!x-)[a-zA-Z0-9\\._-]+", new MapOverlay<ServerVariableImpl>("variables", this, ServerVariableImpl.factory, "(?!x-)[a-zA-Z0-9\\._-]+"));
+    private MapOverlay<ServerVariableImpl> serverVariables = new MapOverlay<ServerVariableImpl>("variables", this, ServerVariableImpl.factory, "(?!x-)[a-zA-Z0-9\\._-]+");
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private ValMapOverlay<Object,AnyObjectOverlay> variablesExtensions = registerField("variables", "variablesExtensions", "x-.+", new ValMapOverlay<Object, AnyObjectOverlay>("variables", this, AnyObjectOverlay.factory, "x-.+"));
+    private ValMapOverlay<Object, AnyObjectOverlay> variablesExtensions = new ValMapOverlay<Object, AnyObjectOverlay>("variables", this, AnyObjectOverlay.factory, "x-.+");
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private ValMapOverlay<Object,AnyObjectOverlay> extensions = registerField("", "extensions", "x-.+", new ValMapOverlay<Object, AnyObjectOverlay>("", this, AnyObjectOverlay.factory, "x-.+"));
+    private ValMapOverlay<Object, AnyObjectOverlay> extensions = new ValMapOverlay<Object, AnyObjectOverlay>("", this, AnyObjectOverlay.factory, "x-.+");
 
     // Url
     @Override
@@ -187,5 +187,21 @@ public class ServerImpl extends OpenApiObjectImpl implements Server {
         return isEmptyRecursive(parent, ServerImpl.class) ? null : new ServerImpl(key, json, parent);
     }
 };
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    protected void installPropertyAccessors(PropertyAccessors accessors) {
+        OverlayGetter getter = null;
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return url;}};
+            accessors.add("url", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return description;}};
+            accessors.add("description", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return serverVariables;}};
+            accessors.add("variables", "(?!x-)[a-zA-Z0-9\\._-]+", getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return variablesExtensions;}};
+            accessors.add("variables", "x-.+", getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return extensions;}};
+            accessors.add("", "x-.+", getter);
+    }
 
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ServerVariableImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ServerVariableImpl.java
@@ -27,16 +27,16 @@ public class ServerVariableImpl extends OpenApiObjectImpl implements ServerVaria
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private ValListOverlay<Object, PrimitiveOverlay> enumValues = registerField("enum", "enumValues", null, new ValListOverlay<Object, PrimitiveOverlay>("enum", this, PrimitiveOverlay.factory));;
+    private ValListOverlay<Object, PrimitiveOverlay> enumValues = new ValListOverlay<Object, PrimitiveOverlay>("enum", this, PrimitiveOverlay.factory);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private PrimitiveOverlay defaultValue = registerField("default", "defaultValue", null, new PrimitiveOverlay("default", this));
+    private PrimitiveOverlay defaultValue = new PrimitiveOverlay("default", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private StringOverlay description = registerField("description", "description", null, new StringOverlay("description", this));
+    private StringOverlay description = new StringOverlay("description", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private ValMapOverlay<Object,AnyObjectOverlay> extensions = registerField("", "extensions", "x-.+", new ValMapOverlay<Object, AnyObjectOverlay>("", this, AnyObjectOverlay.factory, "x-.+"));
+    private ValMapOverlay<Object, AnyObjectOverlay> extensions = new ValMapOverlay<Object, AnyObjectOverlay>("", this, AnyObjectOverlay.factory, "x-.+");
 
     // EnumValue
     @Override
@@ -151,5 +151,19 @@ public class ServerVariableImpl extends OpenApiObjectImpl implements ServerVaria
         return isEmptyRecursive(parent, ServerVariableImpl.class) ? null : new ServerVariableImpl(key, json, parent);
     }
 };
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    protected void installPropertyAccessors(PropertyAccessors accessors) {
+        OverlayGetter getter = null;
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return enumValues;}};
+            accessors.add("enum", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return defaultValue;}};
+            accessors.add("default", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return description;}};
+            accessors.add("description", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return extensions;}};
+            accessors.add("", "x-.+", getter);
+    }
 
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/TagImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/TagImpl.java
@@ -26,16 +26,16 @@ public class TagImpl extends OpenApiObjectImpl implements Tag {
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private StringOverlay name = registerField("name", "name", null, new StringOverlay("name", this));
+    private StringOverlay name = new StringOverlay("name", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private StringOverlay description = registerField("description", "description", null, new StringOverlay("description", this));
+    private StringOverlay description = new StringOverlay("description", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private ExternalDocsImpl externalDocs = registerField("externalDocs", "externalDocs", null, ExternalDocsImpl.factory.create("externalDocs", this));
+    private ExternalDocsImpl externalDocs = ExternalDocsImpl.factory.create("externalDocs", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private ValMapOverlay<Object,AnyObjectOverlay> extensions = registerField("", "extensions", "x-.+", new ValMapOverlay<Object, AnyObjectOverlay>("", this, AnyObjectOverlay.factory, "x-.+"));
+    private ValMapOverlay<Object, AnyObjectOverlay> extensions = new ValMapOverlay<Object, AnyObjectOverlay>("", this, AnyObjectOverlay.factory, "x-.+");
 
     // Name
     @Override
@@ -120,5 +120,19 @@ public class TagImpl extends OpenApiObjectImpl implements Tag {
         return isEmptyRecursive(parent, TagImpl.class) ? null : new TagImpl(key, json, parent);
     }
 };
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    protected void installPropertyAccessors(PropertyAccessors accessors) {
+        OverlayGetter getter = null;
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return name;}};
+            accessors.add("name", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return description;}};
+            accessors.add("description", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return externalDocs;}};
+            accessors.add("externalDocs", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return extensions;}};
+            accessors.add("", "x-.+", getter);
+    }
 
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/XmlImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/XmlImpl.java
@@ -25,22 +25,22 @@ public class XmlImpl extends OpenApiObjectImpl implements Xml {
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private StringOverlay name = registerField("name", "name", null, new StringOverlay("name", this));
+    private StringOverlay name = new StringOverlay("name", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private StringOverlay namespace = registerField("namespace", "namespace", null, new StringOverlay("namespace", this));
+    private StringOverlay namespace = new StringOverlay("namespace", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private StringOverlay prefix = registerField("prefix", "prefix", null, new StringOverlay("prefix", this));
+    private StringOverlay prefix = new StringOverlay("prefix", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private BooleanOverlay attribute = registerField("attribute", "attribute", null, new BooleanOverlay("attribute", this));
+    private BooleanOverlay attribute = new BooleanOverlay("attribute", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private BooleanOverlay wrapped = registerField("wrapped", "wrapped", null, new BooleanOverlay("wrapped", this));
+    private BooleanOverlay wrapped = new BooleanOverlay("wrapped", this);
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
-    private ValMapOverlay<Object,AnyObjectOverlay> extensions = registerField("", "extensions", "x-.+", new ValMapOverlay<Object, AnyObjectOverlay>("", this, AnyObjectOverlay.factory, "x-.+"));
+    private ValMapOverlay<Object, AnyObjectOverlay> extensions = new ValMapOverlay<Object, AnyObjectOverlay>("", this, AnyObjectOverlay.factory, "x-.+");
 
     // Name
     @Override
@@ -163,5 +163,23 @@ public class XmlImpl extends OpenApiObjectImpl implements Xml {
         return isEmptyRecursive(parent, XmlImpl.class) ? null : new XmlImpl(key, json, parent);
     }
 };
+
+    @Override
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    protected void installPropertyAccessors(PropertyAccessors accessors) {
+        OverlayGetter getter = null;
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return name;}};
+            accessors.add("name", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return namespace;}};
+            accessors.add("namespace", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return prefix;}};
+            accessors.add("prefix", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return attribute;}};
+            accessors.add("attribute", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return wrapped;}};
+            accessors.add("wrapped", null, getter);
+            getter = new OverlayGetter(){ public JsonOverlay<?> get(){return extensions;}};
+            accessors.add("", "x-.+", getter);
+    }
 
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/types3.yaml
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/types3.yaml
@@ -371,6 +371,7 @@ types:
         type: SecurityParameter
         parentPath: ""
         structure: map
+        keyPattern: *namePat
 
   - name: SecurityParameter
     fields:

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/types3.yaml
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/types3.yaml
@@ -528,7 +528,7 @@ types:
 
   - name: Schema
     imports:
-      impl: [ Optional ]
+      impl: [ Optional, JsonPointer ]
     fields:
       title:
         name: Title

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val/OverlayValidator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val/OverlayValidator.java
@@ -32,7 +32,7 @@ public class OverlayValidator<T> extends ValidatorBase<T> {
 
     public void validate(T object, ValidationResults results, Set<Class<? extends JsonNode>> allowedNodeTypes) {
         JsonOverlay<?> overlay = (JsonOverlay<?>) object;
-        JsonNode json = overlay.getJson();
+        JsonNode json = overlay.toJson();
         boolean isValidJsonType = false;
         for (Class<? extends JsonNode> type : allowedNodeTypes) {
             if (type.isAssignableFrom(json.getClass())) {

--- a/kaizen-openapi-parser/src/test/java/com/reprezen/swaggerparser/test/BigParseTest.java
+++ b/kaizen-openapi-parser/src/test/java/com/reprezen/swaggerparser/test/BigParseTest.java
@@ -12,12 +12,9 @@ package com.reprezen.swaggerparser.test;
 
 import java.io.IOException;
 import java.net.URL;
-import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Deque;
 
-import org.apache.commons.lang3.StringUtils;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -26,29 +23,20 @@ import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 import org.yaml.snakeyaml.Yaml;
 
+import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
-import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
-import com.google.common.collect.Queues;
 import com.reprezen.kaizen.oasparser.OpenApiParser;
 import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.coll.CollectionOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.coll.CollectionStore;
-import com.reprezen.kaizen.oasparser.jsonoverlay.coll.ListOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.coll.MapOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.coll.ObjectOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.coll.ValListOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.coll.ValMapOverlay;
 import com.reprezen.kaizen.oasparser.model3.OpenApi3;
 import com.reprezen.kaizen.oasparser.ovl3.OpenApi3Impl;
-import com.reprezen.swaggerparser.test.JsonTreeWalker.PathKey;
 import com.reprezen.swaggerparser.test.JsonTreeWalker.WalkMethod;
 
 /**
- * Tests basic parser operation by loading a swagger spec and then verifying that all values can be obtained reliably
- * from the model
+ * Tests basic parser operation by loading a swagger spec and then verifying
+ * that all values can be obtained reliably from the model
  * 
  * @author Andy Lowry
  *
@@ -57,119 +45,50 @@ import com.reprezen.swaggerparser.test.JsonTreeWalker.WalkMethod;
 @RunWith(Parameterized.class)
 public class BigParseTest extends Assert {
 
-    @Parameters
-    public static Collection<Object[]> resources() {
-        return Arrays.asList(new Object[][] { new URL[] { BigParseTest.class.getResource("/models/parseTest.yaml") } });
-    }
+	@Parameters
+	public static Collection<Object[]> resources() {
+		return Arrays.asList(new Object[][] { new URL[] { BigParseTest.class.getResource("/models/parseTest.yaml") } });
+	}
 
-    @Parameter
-    public URL modelUrl;
+	@Parameter
+	public URL modelUrl;
 
-    @Test
-    public void test() throws JsonProcessingException, IOException {
-        Object parsedYaml = new Yaml().load(modelUrl.openStream());
-        JsonNode tree = new YAMLMapper().convertValue(parsedYaml, JsonNode.class);
-        final OpenApi3 model = (OpenApi3) new OpenApiParser().parse(modelUrl, false);
-        Predicate<JsonNode> valueNodePredicate = new Predicate<JsonNode>() {
-            @Override
-            public boolean apply(JsonNode node) {
-                return node.isValueNode();
-            }
-        };
-        WalkMethod valueChecker = new WalkMethod() {
-            @Override
-            public void run(JsonNode node, Collection<PathKey> path) {
-                System.out.println(StringUtils.join(path, "."));
-                Object fromModel = getFromModelObject((OpenApi3Impl) model, Queues.newArrayDeque(path));
-                Object fromJson = getValue(node);
-                assertEquals(fromJson, fromModel);
-            }
-        };
-        JsonTreeWalker.walkTree(tree, valueNodePredicate, valueChecker);
-    }
+	@Test
+	public void test() throws JsonProcessingException, IOException {
+		Object parsedYaml = new Yaml().load(modelUrl.openStream());
+		JsonNode tree = new YAMLMapper().convertValue(parsedYaml, JsonNode.class);
+		final OpenApi3 model = (OpenApi3) new OpenApiParser().parse(modelUrl, false);
+		Predicate<JsonNode> valueNodePredicate = new Predicate<JsonNode>() {
+			@Override
+			public boolean apply(JsonNode node) {
+				return node.isValueNode();
+			}
+		};
+		WalkMethod valueChecker = new WalkMethod() {
+			@Override
+			public void run(JsonNode node, JsonPointer path) {
+				JsonOverlay<?> overlay = ((OpenApi3Impl) model).find(path);
+				assertNotNull("No overlay object found for path: " + path, overlay);
+				Object fromJson = getValue(node);
+				String msg = String.format("Wrong overlay value for path '%s': expected '%s', got '%s'", path, fromJson,
+						overlay.get());
+				assertEquals(msg, fromJson, overlay.get());
+			}
+		};
+		JsonTreeWalker.walkTree(tree, valueNodePredicate, valueChecker);
+	}
 
-    private Object getValue(JsonNode node) {
-        if (node.isNumber()) {
-            return node.numberValue();
-        } else if (node.isTextual()) {
-            return node.textValue();
-        } else if (node.isBoolean()) {
-            return node.booleanValue();
-        } else if (node.isNull()) {
-            return null;
-        } else {
-            throw new IllegalArgumentException("Non-value JSON node got through value node filter");
-        }
-    }
-
-    private Object getFromModelObject(JsonOverlay<?> modelObj, Deque<PathKey> path) {
-        if (modelObj == null) {
-            throw new NullPointerException("Attempt to get value of a null overlay");
-        } else if (path.isEmpty()) {
-            return modelObj.get();
-        } else {
-            PathKey key = path.remove();
-            if (modelObj instanceof CollectionOverlay<?>) {
-                JsonOverlay<?> item = getFromCollectionOverlay((CollectionOverlay<?>) modelObj, key);
-                return getFromModelObject(item, path);
-            } else if (modelObj instanceof ObjectOverlay<?>) {
-                path.addFirst(key);
-                ArrayDeque<PathKey> origPath = Queues.newArrayDeque(path);
-                Optional<? extends JsonOverlay<?>> field;
-                try {
-                    field = getField((ObjectOverlay<?>) modelObj, path);
-                } catch (IllegalArgumentException | IllegalAccessException e) {
-                    throw new IllegalStateException("Cannot access object overlay field value", e);
-                }
-                if (field.isPresent()) {
-                    return getFromModelObject(field.get(), path);
-                } else {
-                    throw new IllegalArgumentException("Path does not identify an object overlay field: " + origPath);
-                }
-
-            } else {
-                throw new UnsupportedOperationException("Attempt to get a component from a primitive overlay");
-            }
-        }
-    }
-
-    private JsonOverlay<?> getFromCollectionOverlay(CollectionOverlay<?> modelObj, PathKey key) {
-        CollectionStore<?> store = modelObj.getStore();
-        if (key.isString()) {
-            if (modelObj instanceof ListOverlay<?> || modelObj instanceof ValListOverlay<?, ?>) {
-                throw new UnsupportedOperationException("Attempt to use string key for list overlay");
-            }
-            return store.getOverlay(key.getString());
-        } else {
-            if (modelObj instanceof MapOverlay<?> || modelObj instanceof ValMapOverlay<?, ?>) {
-                throw new UnsupportedOperationException("Attempt to use index for map overlay");
-            }
-            return store.get(key.getIndex());
-        }
-    }
-
-    private Optional<? extends JsonOverlay<?>> getField(ObjectOverlay<?> modelObj, Deque<PathKey> path)
-            throws IllegalArgumentException, IllegalAccessException {
-        String key = "";
-        boolean first = true;
-        Optional<? extends JsonOverlay<?>> value = Optional.absent();
-        if (path.peek() != null && path.peek().isIndex()) {
-            // next path item is an index, so our only shot is to get a list overlay bound directly to this object's
-            // json node
-            value = modelObj.getFieldValue("");
-            if (value.isPresent() && (value.get() instanceof ListOverlay || value.get() instanceof ValListOverlay)) {
-                return value;
-            }
-        }
-        while (!value.isPresent()) {
-            if (path.peek() == null || path.peek().isIndex()) {
-                break;
-            }
-            String next = path.remove().getString();
-            key = first ? next : key + ":" + next;
-            value = modelObj.getFieldValue(key);
-            first = false;
-        }
-        return value;
-    }
+	private Object getValue(JsonNode node) {
+		if (node.isNumber()) {
+			return node.numberValue();
+		} else if (node.isTextual()) {
+			return node.textValue();
+		} else if (node.isBoolean()) {
+			return node.booleanValue();
+		} else if (node.isNull()) {
+			return null;
+		} else {
+			throw new IllegalArgumentException("Non-value JSON node got through value node filter");
+		}
+	}
 }

--- a/kaizen-openapi-parser/src/test/java/com/reprezen/swaggerparser/test/ExamplesTest.java
+++ b/kaizen-openapi-parser/src/test/java/com/reprezen/swaggerparser/test/ExamplesTest.java
@@ -36,62 +36,60 @@ import com.reprezen.kaizen.oasparser.val.ValidationResults.ValidationItem;
 @RunWith(Parameterized.class)
 public class ExamplesTest extends Assert {
 
-    private static final String SPEC_REPO = "RepreZen/KaiZen-OpenAPI-Editor";
-    private static final String EXAMPLES_BRANCH = "master";
-    private static final String EXAMPLES_ROOT = "com.reprezen.swagedit.openapi3.tests/resources/spec_examples/v3.0";
+	private static final String SPEC_REPO = "RepreZen/KaiZen-OpenAPI-Editor";
+	private static final String EXAMPLES_BRANCH = "master";
+	private static final String EXAMPLES_ROOT = "com.reprezen.swagedit.openapi3.tests/resources/spec_examples/v3.0";
 
-    private static ObjectMapper mapper = new ObjectMapper();
+	private static ObjectMapper mapper = new ObjectMapper();
 
-    @Parameters(name = "{index}: {1}")
-    public static Collection<Object[]> findExamples() throws IOException {
-        Collection<Object[]> examples = Lists.newArrayList();
-        Deque<URL> dirs = Queues.newArrayDeque();
-        String auth = System.getenv("GITHUB_AUTH") != null ? System.getenv("GITHUB_AUTH") + "@" : "";
-        String request = String.format("https://%sapi.github.com/repos/%s/contents/%s?ref=%s", auth, SPEC_REPO,
-                EXAMPLES_ROOT, EXAMPLES_BRANCH);
-        dirs.add(new URL(request));
-        while (!dirs.isEmpty()) {
-            URL url = dirs.remove();
-            String json = IOUtils.toString(url, Charsets.UTF_8);
-            JsonNode tree = mapper.readTree(json);
-            for (JsonNode result : iterable(tree.elements())) {
-                String type = result.get("type").asText();
-                String path = result.get("path").asText();
-                String resultUrl = result.get("url").asText();
-                if (type.equals("dir")) {
-                    dirs.add(new URL(resultUrl));
-                } else if (type.equals("file") && (path.endsWith(".yaml") || path.endsWith(".json"))) {
-                    String downloadUrl = result.get("download_url").asText();
-                    examples.add(new Object[]{new URL(downloadUrl), result.get("name").asText()});
-                }
-            }
-        }
-        return examples;
-    }
+	@Parameters(name = "{index}: {1}")
+	public static Collection<Object[]> findExamples() throws IOException {
+		Collection<Object[]> examples = Lists.newArrayList();
+		Deque<URL> dirs = Queues.newArrayDeque();
+		String auth = System.getenv("GITHUB_AUTH") != null ? System.getenv("GITHUB_AUTH") + "@" : "";
+		String request = String.format("https://%sapi.github.com/repos/%s/contents/%s?ref=%s", auth, SPEC_REPO,
+				EXAMPLES_ROOT, EXAMPLES_BRANCH);
+		dirs.add(new URL(request));
+		while (!dirs.isEmpty()) {
+			URL url = dirs.remove();
+			String json = IOUtils.toString(url, Charsets.UTF_8);
+			JsonNode tree = mapper.readTree(json);
+			for (JsonNode result : iterable(tree.elements())) {
+				String type = result.get("type").asText();
+				String path = result.get("path").asText();
+				String resultUrl = result.get("url").asText();
+				if (type.equals("dir")) {
+					dirs.add(new URL(resultUrl));
+				} else if (type.equals("file") && (path.endsWith(".yaml") || path.endsWith(".json"))) {
+					String downloadUrl = result.get("download_url").asText();
+					examples.add(new Object[] { new URL(downloadUrl), result.get("name").asText() });
+				}
+			}
+		}
+		return examples;
+	}
 
-    @Parameter
-    public URL exampleUrl;
-    
-    @Parameter(1)
-    public String fileName;
+	@Parameter
+	public URL exampleUrl;
 
-    @Test
-    public void exampleCanBeParsed() throws IOException {
-        OpenApi3 model = (OpenApi3) new OpenApiParser().parse(exampleUrl);
-        System.out.println(model.isValid());
-        System.out.println(IOUtils.toString(exampleUrl, Charsets.UTF_8));
-        for (ValidationItem item : model.getValidationItems()) {
-            System.out.println(item);
-        }
-        assertTrue(model.isValid());
-    }
+	@Parameter(1)
+	public String fileName;
 
-    private static <T> Iterable<T> iterable(final Iterator<T> iterator) {
-        return new Iterable<T>() {
-            @Override
-            public Iterator<T> iterator() {
-                return iterator;
-            }
-        };
-    }
+	@Test
+	public void exampleCanBeParsed() throws IOException {
+		OpenApi3 model = (OpenApi3) new OpenApiParser().parse(exampleUrl);
+		for (ValidationItem item : model.getValidationItems()) {
+			System.out.println(item);
+		}
+		assertTrue("Example was not valid: " + exampleUrl, model.isValid());
+	}
+
+	private static <T> Iterable<T> iterable(final Iterator<T> iterator) {
+		return new Iterable<T>() {
+			@Override
+			public Iterator<T> iterator() {
+				return iterator;
+			}
+		};
+	}
 }

--- a/kaizen-openapi-parser/src/test/java/com/reprezen/swaggerparser/test/JsonTreeWalker.java
+++ b/kaizen-openapi-parser/src/test/java/com/reprezen/swaggerparser/test/JsonTreeWalker.java
@@ -10,123 +10,78 @@
  *******************************************************************************/
 package com.reprezen.swaggerparser.test;
 
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Deque;
 import java.util.Iterator;
 import java.util.Map.Entry;
 
+import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Predicate;
 import com.google.common.base.Predicates;
-import com.google.common.collect.Queues;
 
 public class JsonTreeWalker {
 
-    public static void walkTree(JsonNode tree, Predicate<JsonNode> nodeFilter, WalkMethod walkMethod) {
-        if (nodeFilter == null) {
-            nodeFilter = Predicates.alwaysTrue();
-        }
-        new JsonTreeWalker(nodeFilter, walkMethod).walk(tree, Queues.<PathKey> newArrayDeque());
-    }
+	public static void walkTree(JsonNode tree, Predicate<JsonNode> nodeFilter, WalkMethod walkMethod) {
+		if (nodeFilter == null) {
+			nodeFilter = Predicates.alwaysTrue();
+		}
+		new JsonTreeWalker(nodeFilter, walkMethod).walk(tree, JsonPointer.compile(""));
+	}
 
-    private Predicate<JsonNode> nodeFilter;
-    private WalkMethod walkMethod;
+	private Predicate<JsonNode> nodeFilter;
+	private WalkMethod walkMethod;
 
-    public JsonTreeWalker(Predicate<JsonNode> nodeFilter, WalkMethod walkMethod) {
-        this.nodeFilter = nodeFilter;
-        this.walkMethod = walkMethod;
-    }
+	public JsonTreeWalker(Predicate<JsonNode> nodeFilter, WalkMethod walkMethod) {
+		this.nodeFilter = nodeFilter;
+		this.walkMethod = walkMethod;
+	}
 
-    private void walk(JsonNode node, Deque<PathKey> path) {
-        if (nodeFilter.apply(node)) {
-            visit(node, path);
-        }
-        walkChildren(node, path);
-    }
+	private void walk(JsonNode node, JsonPointer path) {
+		if (nodeFilter.apply(node)) {
+			visit(node, path);
+		}
+		walkChildren(node, path);
+	}
 
-    private void visit(JsonNode node, Deque<PathKey> path) {
-        walkMethod.run(node, Collections.unmodifiableCollection(path));
-    }
+	private void visit(JsonNode node, JsonPointer path) {
+		walkMethod.run(node, path);
+	}
 
-    private void walkChildren(JsonNode node, Deque<PathKey> path) {
-        if (node instanceof ObjectNode) {
-            for (Entry<String, JsonNode> field : iterable(node.fields())) {
-                path.add(PathKey.of(field.getKey()));
-                walk(field.getValue(), path);
-                path.removeLast();
-            }
-        } else if (node instanceof ArrayNode) {
-            for (int i = 0; i < node.size(); i++) {
-                path.add(PathKey.of(i));
-                walk(node.get(i), path);
-                path.removeLast();
-            }
-        }
-    }
+	private void walkChildren(JsonNode node, JsonPointer path) {
+		if (node instanceof ObjectNode) {
+			for (Entry<String, JsonNode> field : iterable(node.fields())) {
+				walk(field.getValue(), childPointer(path, field.getKey()));
+			}
+		} else if (node instanceof ArrayNode) {
+			for (int i = 0; i < node.size(); i++) {
+				walk(node.get(i), childPointer(path, i));
+			}
+		}
+	}
 
-    public static interface WalkMethod {
-        void run(JsonNode node, Collection<PathKey> path);
-    }
+	private JsonPointer childPointer(JsonPointer path, String childKey) {
+		return JsonPointer.compile(path + "/" + quote(childKey));
+	}
 
-    private <T> Iterable<T> iterable(final Iterator<T> iterator) {
-        return new Iterable<T>() {
-            @Override
-            public Iterator<T> iterator() {
-                return iterator;
-            }
-        };
-    }
+	private JsonPointer childPointer(JsonPointer path, int index) {
+		return childPointer(path, Integer.toString(index));
+	}
 
-    public static class PathKey {
-        private String key = null;
-        private Integer index = null;
+	public String quote(String key) {
+		return key.replaceAll("~", "~0").replaceAll("/", "~1");
+	}
 
-        public PathKey(String key) {
-            this.key = key;
-        }
+	public static interface WalkMethod {
+		void run(JsonNode node, JsonPointer path);
+	}
 
-        public static PathKey of(String key) {
-            return new PathKey(key);
-        }
-
-        public PathKey(int index) {
-            this.index = index;
-        }
-
-        public static PathKey of(int index) {
-            return new PathKey(index);
-        }
-
-        public String getString() {
-            if (key != null) {
-                return key;
-            } else {
-                throw new UnsupportedOperationException();
-            }
-        }
-
-        public int getIndex() {
-            if (index != null) {
-                return index;
-            } else {
-                throw new UnsupportedOperationException();
-            }
-        }
-
-        public boolean isString() {
-            return key != null;
-        }
-
-        public boolean isIndex() {
-            return index != null;
-        }
-
-        @Override
-        public String toString() {
-            return key != null ? key : "[" + index + "]";
-        }
-    }
+	private <T> Iterable<T> iterable(final Iterator<T> iterator) {
+		return new Iterable<T>() {
+			@Override
+			public Iterator<T> iterator() {
+				return iterator;
+			}
+		};
+	}
 }

--- a/kaizen-openapi-parser/src/test/java/com/reprezen/swaggerparser/test/SimpleSerializationTest.java
+++ b/kaizen-openapi-parser/src/test/java/com/reprezen/swaggerparser/test/SimpleSerializationTest.java
@@ -41,6 +41,7 @@ import com.reprezen.kaizen.oasparser.OpenApiParser;
 import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
 import com.reprezen.kaizen.oasparser.model3.OpenApi3;
 import com.reprezen.kaizen.oasparser.model3.OpenApiObject;
+import com.reprezen.kaizen.oasparser.model3.Schema;
 import com.reprezen.kaizen.oasparser.ovl3.OpenApi3Impl;
 
 @RunWith(Enclosed.class)
@@ -114,6 +115,14 @@ public class SimpleSerializationTest extends Assert {
 			assertEquals("changed title", model.toJson().at("/info/title").asText());
 			// verify that cached JSON now has new value
 			assertEquals("changed title", getCachedJson(model).at("/info/title").asText());
+		}
+
+		@Test
+		public void toJsonFollowsRefs() {
+			OpenApi3 model = parseLocalModel("simpleTest");
+			Schema xSchema = model.getSchema("X");
+			assertEquals("#/components/schemas/Y", xSchema.toJson().at("/properties/y/$ref").asText());
+			assertEquals("integer", xSchema.toJson(true).at("/properties/y/type").asText());
 		}
 	}
 

--- a/kaizen-openapi-parser/src/test/java/com/reprezen/swaggerparser/test/SimpleSerializationTest.java
+++ b/kaizen-openapi-parser/src/test/java/com/reprezen/swaggerparser/test/SimpleSerializationTest.java
@@ -1,0 +1,170 @@
+/*******************************************************************************
+ *  Copyright (c) 2017 ModelSolv, Inc. and others.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  Contributors:
+ *     ModelSolv, Inc. - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package com.reprezen.swaggerparser.test;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Collection;
+import java.util.Deque;
+import java.util.Iterator;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
+import com.google.common.base.Charsets;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Queues;
+import com.reprezen.kaizen.oasparser.OpenApiParser;
+import com.reprezen.kaizen.oasparser.model3.OpenApi3;
+import com.reprezen.kaizen.oasparser.ovl3.OpenApi3Impl;
+
+@RunWith(Parameterized.class)
+public class SimpleSerializationTest extends Assert {
+
+	private static final String SPEC_REPO = "RepreZen/KaiZen-OpenAPI-Editor";
+	private static final String EXAMPLES_BRANCH = "master";
+	private static final String EXAMPLES_ROOT = "com.reprezen.swagedit.openapi3.tests/resources/spec_examples/v3.0";
+
+	private static ObjectMapper mapper = new ObjectMapper();
+	private static ObjectMapper yamlMapper = new YAMLMapper();
+
+	@Parameters(name = "{index}: {1}")
+	public static Collection<Object[]> findExamples() throws IOException {
+		Collection<Object[]> examples = Lists.newArrayList();
+		Deque<URL> dirs = Queues.newArrayDeque();
+		String auth = System.getenv("GITHUB_AUTH") != null ? System.getenv("GITHUB_AUTH") + "@" : "";
+		String request = String.format("https://%sapi.github.com/repos/%s/contents/%s?ref=%s", auth, SPEC_REPO,
+				EXAMPLES_ROOT, EXAMPLES_BRANCH);
+		dirs.add(new URL(request));
+		while (!dirs.isEmpty()) {
+			URL url = dirs.remove();
+			String json = IOUtils.toString(url, Charsets.UTF_8);
+			JsonNode tree = mapper.readTree(json);
+			for (JsonNode result : iterable(tree.elements())) {
+				String type = result.get("type").asText();
+				String path = result.get("path").asText();
+				String resultUrl = result.get("url").asText();
+				if (type.equals("dir")) {
+					dirs.add(new URL(resultUrl));
+				} else if (type.equals("file") && (path.endsWith(".yaml") || path.endsWith(".json"))) {
+					String downloadUrl = result.get("download_url").asText();
+					examples.add(new Object[] { new URL(downloadUrl), result.get("name").asText() });
+				}
+			}
+		}
+		return examples;
+	}
+
+	@Parameter
+	public URL exampleUrl;
+
+	@Parameter(1)
+	public String fileName;
+
+	@Test
+	public void serializeExample() throws IOException {
+		OpenApi3 model = (OpenApi3) new OpenApiParser().parse(exampleUrl);
+		JsonNode serialized = ((OpenApi3Impl) model).createJson();
+		JsonNode expected = yamlMapper.readTree(exampleUrl);
+		assertTrue(treeEquals(expected, serialized, "[root]"));
+	}
+
+	private boolean treeEquals(JsonNode x, JsonNode y, String path) {
+		System.out.printf("Comparing at %s\n", path);
+		if ((x == null || x.isMissingNode()) == (y == null || y.isMissingNode())) {
+			return true;
+		} else if (x.getClass() != y.getClass()) {
+			System.out.printf("Different classes: %s <> %s\n", x.getClass(), y.getClass());
+			return false;
+		} else {
+			switch (x.getNodeType()) {
+			case ARRAY:
+				if (x.size() != y.size()) {
+					System.out.printf("Different array sizes: %s <> %s\n", x.size(), y.size());
+					return false;
+				}
+				for (int i = 0; i < x.size(); i++) {
+					if (!treeEquals(x.get(i), y.get(i), path + "/" + i)) {
+						System.out.printf("Differences at array position %s\n", i);
+						return false;
+					}
+				}
+				return true;
+			case BOOLEAN:
+				if (x.asBoolean() != y.asBoolean()) {
+					System.out.printf("Different boolean values: %s <> %s\n", x.asBoolean(), y.asBoolean());
+				}
+				return x.asBoolean() == y.asBoolean();
+			case NULL:
+				return true;
+			case NUMBER:
+				Number xn = null, yn = null;
+				if (x.isDouble()) {
+					xn = x.doubleValue();
+					yn = y.doubleValue();
+				} else if (x.isFloat()) {
+					xn = x.floatValue();
+					yn = y.floatValue();
+				} else if (x.isInt()) {
+					xn = x.intValue();
+					yn = y.intValue();
+				} else if (x.isLong()) {
+					xn = x.longValue();
+					yn = y.longValue();
+				} else if (x.isShort()) {
+					xn = x.shortValue();
+					yn = y.shortValue();
+				}
+				if (!xn.equals(yn)) {
+					System.out.printf("Different numeric values: %s <> %s\n", xn, yn);
+				}
+			case OBJECT:
+				if (x.size() != y.size()) {
+					System.out.printf("Different object sizes: %s <> %s\n", x.size(), y.size());
+					return false;
+				}
+				for (Iterator<String> iter = x.fieldNames(); iter.hasNext();) {
+					String propName = iter.next();
+					if (!treeEquals(x.get(propName), y.get(propName), path + "/" + propName)) {
+						System.out.printf("Different values for property '%s'\n", propName);
+						return false;
+					}
+				}
+				return true;
+			case STRING:
+				if (!x.asText().equals(y.asText())) {
+					System.out.printf("Different string values: '%s' <> '%s'\n", x.asText(), y.asText());
+				}
+				return x.asText().equals(y.asText());
+			default:
+				System.out.printf("Unexpected JsonNode type: %s\n", x.getClass());
+				return false;
+			}
+		}
+	}
+
+	private static <T> Iterable<T> iterable(final Iterator<T> iterator) {
+		return new Iterable<T>() {
+			@Override
+			public Iterator<T> iterator() {
+				return iterator;
+			}
+		};
+	}
+}

--- a/kaizen-openapi-parser/src/test/java/com/reprezen/swaggerparser/test/SimpleSerializationTest.java
+++ b/kaizen-openapi-parser/src/test/java/com/reprezen/swaggerparser/test/SimpleSerializationTest.java
@@ -17,14 +17,16 @@ import java.util.Deque;
 import java.util.Iterator;
 
 import org.apache.commons.io.IOUtils;
+import org.json.JSONException;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.skyscreamer.jsonassert.JSONCompareMode;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
@@ -79,72 +81,11 @@ public class SimpleSerializationTest extends Assert {
 	public String fileName;
 
 	@Test
-	public void serializeExample() throws IOException {
+	public void serializeExample() throws IOException, JSONException {
 		OpenApi3 model = (OpenApi3) new OpenApiParser().parse(exampleUrl);
-		JsonNode serialized = ((OpenApi3Impl) model).createJson();
-		JsonNode expected = yamlMapper.readTree(exampleUrl);
-		assertTrue(treeEquals(expected, serialized, "[root]"));
-	}
-
-	private boolean treeEquals(JsonNode x, JsonNode y, String path) throws JsonProcessingException {
-		if ((x == null || x.isMissingNode()) != (y == null || y.isMissingNode())) {
-			return false;
-		} else if (x.getClass() != y.getClass()) {
-			return false;
-		} else {
-			switch (x.getNodeType()) {
-			case ARRAY:
-				if (x.size() != y.size()) {
-					return false;
-				}
-				for (int i = 0; i < x.size(); i++) {
-					if (!treeEquals(x.get(i), y.get(i), path + "/" + i)) {
-						System.out.printf("Trees differed at path %s/%s\n%s\n%s\n", path, i, mapper.writeValueAsString(x), mapper.writeValueAsString(y));
-						return false;
-					}
-				}
-				return true;
-			case BOOLEAN:
-				return x.asBoolean() == y.asBoolean();
-			case NULL:
-				return true;
-			case NUMBER:
-				Number xn = null, yn = null;
-				if (x.isDouble()) {
-					xn = x.doubleValue();
-					yn = y.doubleValue();
-				} else if (x.isFloat()) {
-					xn = x.floatValue();
-					yn = y.floatValue();
-				} else if (x.isInt()) {
-					xn = x.intValue();
-					yn = y.intValue();
-				} else if (x.isLong()) {
-					xn = x.longValue();
-					yn = y.longValue();
-				} else if (x.isShort()) {
-					xn = x.shortValue();
-					yn = y.shortValue();
-				}
-				return xn.equals(yn);
-			case OBJECT:
-				if (x.size() != y.size()) {
-					return false;
-				}
-				for (Iterator<String> iter = x.fieldNames(); iter.hasNext();) {
-					String propName = iter.next();
-					if (!treeEquals(x.get(propName), y.get(propName), path + "/" + propName)) {
-						System.out.printf("Trees differed at path %s/%s\n%s\n%s\n", path, propName, mapper.writeValueAsString(x), mapper.writeValueAsString(y));
-						return false;
-					}
-				}
-				return true;
-			case STRING:
-				return x.asText().equals(y.asText());
-			default:
-				return false;
-			}
-		}
+		String serialized = mapper.writeValueAsString(((OpenApi3Impl) model).createJson());
+		String expected = mapper.writeValueAsString(yamlMapper.readTree(exampleUrl));
+		JSONAssert.assertEquals(expected, serialized, JSONCompareMode.STRICT);
 	}
 
 	private static <T> Iterable<T> iterable(final Iterator<T> iterator) {

--- a/kaizen-openapi-parser/src/test/resources/models/parseTest.yaml
+++ b/kaizen-openapi-parser/src/test/resources/models/parseTest.yaml
@@ -118,7 +118,7 @@ paths:
                 title: title
           links:
             name:
-              href: href
+              operationRef: operationRef
               operationId: operationId
               parameters: 
                 param1: xxxx
@@ -329,9 +329,9 @@ components:
       x-foo: foo
   links: 
     link1: 
-      href: href
+      operationRef: operationRef
     link2:
-      href: href
+      operationRef: operationRef
   callbacks:
     cb1:
       expr1: 

--- a/kaizen-openapi-parser/src/test/resources/models/simpleTest.yaml
+++ b/kaizen-openapi-parser/src/test/resources/models/simpleTest.yaml
@@ -1,0 +1,5 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: simple model
+paths: {}

--- a/kaizen-openapi-parser/src/test/resources/models/simpleTest.yaml
+++ b/kaizen-openapi-parser/src/test/resources/models/simpleTest.yaml
@@ -3,3 +3,14 @@ info:
   version: 1.0.0
   title: simple model
 paths: {}
+components:
+  schemas:
+    X:
+      type: object
+      properties:
+        x:
+          type: string
+        y:
+          $ref: "#/components/schemas/Y"
+    Y:
+      type: integer


### PR DESCRIPTION
All objects in a model (including the model itself) now support `toJson()` and `toJson(boolean followRefs)` methods.

These methods create a `JsonNode` structure reflecting the current model. Behind the scenes, the last computed (or parsed) JSON is cached in each overlay object, and the mutation API methods mark affected overlay objects as being out-of-date. In that case, `toJson` will refresh the cached JSON by recomputing it.

Unlike the general API, the cached JSON always reflects references, rather than invisibly following them. However, the `toJson(true)` will construct a JSON structure by following references. There is currently no protection against recursive references, so stack overflow will result in that case. (Actually that will happen during parsing until #64 is addressed.)

Note that this serializer does not currently preserve as-parsed ordering of object properties; map and list ordering is preserved.

A more advanced, separate serializer is anticipated, with various options related to reference following and related behaviors.