### PR TITLE
A json object key can have nearly any value

### DIFF
--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/SchemaValidator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/SchemaValidator.java
@@ -56,7 +56,7 @@ public class SchemaValidator extends ObjectValidatorBase<Schema> {
         if (schema.getItemsSchema(false) != null && schema.getItemsSchema(false).isPresent()) {
             validate(schema.getItemsSchema(false), results, "items");
         }
-        validateMap(schema.getProperties(false), results, false, "properties", Regexes.NOEXT_NAME_REGEX, this);
+        validateMap(schema.getProperties(false), results, false, "properties", null, this);
         validateFormat(schema.getFormat(false), schema.getType(false), results, "format");
         validateDefault(schema.getDefault(false), schema.getType(false), results, "default");
         checkDiscriminator(schema, results, "discriminator");


### PR DESCRIPTION
The previous validation was to limited an only allowed for very specific object key names.

This fixes #96