### PR TITLE
Task/10 Do not generate members that are present in non-generated form

### DIFF
--- a/kaizen-openapi-parser/.classpath
+++ b/kaizen-openapi-parser/.classpath
@@ -22,16 +22,12 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
-	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7">
-		<attributes>
-			<attribute name="maven.pomderived" value="true"/>
-		</attributes>
-	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
 	<classpathentry excluding="**" kind="src" output="target/classes" path="src/main/resources">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/kaizen-openapi-parser/.settings/org.eclipse.jdt.core.prefs
+++ b/kaizen-openapi-parser/.settings/org.eclipse.jdt.core.prefs
@@ -1,5 +1,2 @@
 eclipse.preferences.version=1
-org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.7
-org.eclipse.jdt.core.compiler.compliance=1.7
 org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
-org.eclipse.jdt.core.compiler.source=1.7

--- a/kaizen-openapi-parser/pom.xml
+++ b/kaizen-openapi-parser/pom.xml
@@ -49,16 +49,6 @@
     </scm>
     <dependencies>
 	<dependency>
-	    <groupId>com.github.javaparser</groupId>
-	    <artifactId>javaparser-core</artifactId>
-	    <version>2.5.1</version>
-	</dependency>
-	<dependency>
-	    <groupId>com.google.guava</groupId>
-	    <artifactId>guava</artifactId>
-	    <version>15.0</version>
-	</dependency>
-	<dependency>
 	    <groupId>junit</groupId>
 	    <artifactId>junit</artifactId>
 	    <version>4.12</version>
@@ -108,6 +98,11 @@
 		<artifactId>jsonassert</artifactId>
 		<version>1.5.0</version>
 		<scope>test</scope>
+	</dependency>
+	<dependency>
+		<groupId>com.github.javaparser</groupId>
+		<artifactId>javaparser-core</artifactId>
+		<version>3.5.7</version>
 	</dependency>
     </dependencies>
     <profiles>
@@ -252,8 +247,8 @@
 	</plugins>
     </build>
     <properties>
-	<maven.compiler.source>1.7</maven.compiler.source>
-	<maven.compiler.target>1.7</maven.compiler.target>
+	<maven.compiler.source>1.8</maven.compiler.source>
+	<maven.compiler.target>1.8</maven.compiler.target>
 	<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	<nexus.autorelease>false</nexus.autorelease>
 	<nexus.autodrop>true</nexus.autodrop>

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/gen/ImplGenerator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/gen/ImplGenerator.java
@@ -16,8 +16,6 @@ import java.io.File;
 import java.util.Collection;
 import java.util.Map;
 
-import org.apache.commons.lang3.StringUtils;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.google.common.base.Function;
@@ -31,7 +29,9 @@ import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.OverlayFactory;
 import com.reprezen.kaizen.oasparser.jsonoverlay.Reference;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ReferenceRegistry;
+import com.reprezen.kaizen.oasparser.jsonoverlay.gen.SimpleJavaGenerator.FieldMember;
 import com.reprezen.kaizen.oasparser.jsonoverlay.gen.SimpleJavaGenerator.Member;
+import com.reprezen.kaizen.oasparser.jsonoverlay.gen.SimpleJavaGenerator.MethodMember;
 import com.reprezen.kaizen.oasparser.jsonoverlay.gen.TypeData.Field;
 import com.reprezen.kaizen.oasparser.jsonoverlay.gen.TypeData.Type;
 import com.reprezen.kaizen.oasparser.model3.OpenApi3;
@@ -55,7 +55,7 @@ public class ImplGenerator extends TypeGenerator {
 
 	@Override
 	public Members getOtherMembers(Type type) {
-		Members members = new Members();
+		Members members = new Members(type);
 		members.add(getElaborateChildrenMethod(type));
 		members.add(getFactoryMethod(type));
 		return members;
@@ -81,12 +81,18 @@ public class ImplGenerator extends TypeGenerator {
 
 	@Override
 	protected Members getConstructors(Type type) {
-		Members members = new Members();
-		members.add(t("public ${implName}(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg)", type), //
-				code("super(json, parent, refReg);", "super.maybeElaborateChildrenAtCreation();"));
+		Members members = new Members(type);
+		members.addConstructor("${implName}", //
+				"JsonNode", "json", "JsonOverlay<?>", "parent", "ReferenceRegistry", "refReg") //
+				.code( //
+						"super(json, parent, refReg);", //
+						"super.maybeElaborateChildrenAtCreation();");
 		requireTypes(JsonNode.class, JsonOverlay.class);
-		members.add(t("public ${implName}(${name} ${lcName}, JsonOverlay<?> parent, ReferenceRegistry refReg)", type), //
-				code(t("super(${lcName}, parent, refReg);", type), "super.maybeElaborateChildrenAtCreation();"));
+		members.addConstructor("${implName}", //
+				"${name}", "${lcName}", "JsonOverlay<?>", "parent", "ReferenceRegistry", "refReg") //
+				.code( //
+						"super(${lcName}, parent, refReg);", //
+						"super.maybeElaborateChildrenAtCreation();");
 		return members;
 	}
 
@@ -98,8 +104,8 @@ public class ImplGenerator extends TypeGenerator {
 	@Override
 	protected Members getFieldMembers(Field field) {
 		requireTypes(field.getType(), field.getImplType());
-		Members members = new Members();
-		members.add(t("private ${propType} ${propName} = null", field));
+		Members members = new Members(field);
+		members.addField("${propType}", "${propName}", "null");
 		switch (field.getStructure()) {
 		case scalar:
 			requireTypes(ChildOverlay.class);
@@ -117,7 +123,7 @@ public class ImplGenerator extends TypeGenerator {
 
 	@Override
 	protected Members getFieldMethods(Field field) {
-		Members methods = new Members();
+		Members methods = new Members(field);
 		boolean first = true;
 		String typeComment = field.getName();
 		if (field.isRefable()) {
@@ -147,76 +153,67 @@ public class ImplGenerator extends TypeGenerator {
 	}
 
 	private Members getScalarMethods(Field field) {
-		Members methods = new Members();
-		String getDecl = t("public ${type} get${name}()", field);
-		String getBoolDecl = t("public ${type} get${name}(boolean elaborate)", field);
-		String setDecl = t("public void set${name}(${type} ${lcName})", field);
+		Members methods = new Members(field);
 		// T getFoo() => return foo.get()
-		methods.add(getDecl, code(field, "return ${lcName}.get();"));
+		methods.addMethod("${type}", "get${name}").code("return ${lcName}.get();");
 		// T getFoo(boolean elaborate) => return foo.get(elaborate)
-		methods.add(getBoolDecl, code(field, "return ${lcName}.get(elaborate);"));
+		methods.addMethod("${type}", "get${name}", "boolean", "elaborate").code("return ${lcName}.get(elaborate);");
 		if (field.isBoolean()) {
 			// boolean isFoo() => foo.get() != null ? foo.get() : boolDefault
-			methods.add(t("public boolean is${name}()", field),
-					code(field, "return ${lcName}.get() != null ? ${lcName}.get() : ${boolDefault};"));
+			methods.addMethod("boolean", "is${name}")
+					.code("return ${lcName}.get() != null ? ${lcName}.get() : ${boolDefault};");
 		}
 		// void setFoo(T foo) => foo = this.foo.set(foo)
-		methods.add(setDecl, code(field, "this.${lcName}.set(${lcName});"));
+		methods.addMethod("void", "set${name}", "${type}", "${lcName}").code("this.${lcName}.set(${lcName});");
 		if (field.isRefable()) {
 			// boolean isFooReference() => foo.isReference()
-			methods.add(t("public boolean is${name}Reference()", field),
-					code(field, "return ${lcName} != null ? ${lcName}.isReference() : false;"));
+			methods.addMethod("boolean", "is${name}Reference")
+					.code("return ${lcName} != null ? ${lcName}.isReference() : false;");
 			// Reference getFooReference() => foo.getReference()
-			methods.add(t("public Reference get${name}Reference()", field),
-					code(field, "return ${lcName} != null ? ${lcName}.getReference() : null;"));
+			methods.addMethod("Reference", "get${name}Reference")
+					.code("return ${lcName} != null ? ${lcName}.getReference() : null;");
 		}
 		return methods;
 	}
 
 	private Members getCollectionMethods(Field field) {
-		Members methods = new Members();
-		String getDecl = t("public Collection<${collType}> get${plural}()", field);
-		String getBoolDecl = t("public Collection<${collType}> get${plural}(boolean elaborate)", field);
-		String hasDecl = t("public boolean has${plural}()", field);
-		String iGetDecl = t("public ${type} get${name}(int index)", field);
-		String setDecl = t("public void set${plural}(Collection<${collType}> ${lcPlural})", field);
-		String iSetDecl = t("public void set${name}(int index, ${type} ${lcName})", field);
-		String addDecl = t("public void add${name}(${type} ${lcName})", field);
-		String insDecl = t("public void insert${name}(int index, ${type} ${lcName})", field);
-		String remDecl = t("public void remove${name}(int index)", field);
+		Members methods = new Members(field);
 
 		// Collection<T> getFoos(boolean) => foos.get()
-		methods.add(getDecl, code(field, "return ${lcPlural}.get();"));
+		methods.addMethod("Collection<${collType}>", "get${plural}").code("return ${lcPlural}.get();");
 		// Collection<T> getFoos(boolean elaborate) => foos.get(elaborate)
-		methods.add(getBoolDecl, code(field, "return ${lcPlural}.get(elaborate);"));
+		methods.addMethod("Collection<${collType}>", "get${plural}", "boolean", "elaborate")
+				.code("return ${lcPlural}.get(elaborate);");
 		// boolean hasFoos() => foos.isPresent()
-		methods.add(hasDecl, code(field, "return ${lcPlural}.isPresent();"));
+		methods.addMethod("boolean", "has${plural}").code("return ${lcPlural}.isPresent();");
 		// T getFoo(int index) => foos.get(index)
-		methods.add(iGetDecl, code(field, "return ${lcPlural}.get(index);"));
+		methods.addMethod("${type}", "get${name}", "int", "index").code("return ${lcPlural}.get(index);");
 		// void setFoos(Collection<T> foos) => this.foos.set((TImpl) foos)
-		methods.add(setDecl, code(field, "this.${lcPlural}.set((Collection<${collType}>) ${lcPlural});"));
+		methods.addMethod("void", "set${plural}", "Collection<${collType}>", "${lcPlural}")
+				.code("this.${lcPlural}.set((Collection<${collType}>) ${lcPlural});");
 		// void setFoo(int index, T foo) => foos.set(index, foo)
-		methods.add(iSetDecl, code(field, "${lcPlural}.set(index, ${lcName});"));
+		methods.addMethod("void", "set${name}", "int", "index", "${type}", "${lcName}")
+				.code("${lcPlural}.set(index, ${lcName});");
 		// void addFoo(Foo foo) => foos.add(foo)
-		methods.add(addDecl, code(field, "${lcPlural}.add(${lcName});"));
+		methods.addMethod("void", "add${name}", "${type}", "${lcName}").code("${lcPlural}.add(${lcName});");
 		// void insertFoo(int index, Foo foo) => foos.insertOveraly(index, foo)
-		methods.add(insDecl, code(field, "${lcPlural}.insert(index, ${lcName});"));
+		methods.addMethod("void", "insert${name}", "int", "index", "${type}", "${lcName}")
+				.code("${lcPlural}.insert(index, ${lcName});");
 		// void removeFoo(int index) => foos.remove(index)
-		methods.add(remDecl, code(field, "${lcPlural}.remove(index);"));
+		methods.addMethod("void", "remove${name}", "int", "index").code("${lcPlural}.remove(index);");
 		// methods.addAll(getKeyedCollectionMethods(field));
 		if (field.isRefable()) {
 			// boolean isFooReference(int index) => foos.getChild(index).isReference()
-			methods.add(t("public boolean is${name}Reference(int index)", field),
-					code(field, "return ${lcPlural}.getChild(index).isReference();"));
+			methods.addMethod("boolean", "is${name}Reference", "int", "index")
+					.code("return ${lcPlural}.getChild(index).isReference();");
 			// Reference getFooReference(int index) => foos.getChild(index).getReference()
-			methods.add(t("public Reference get${name}Reference(int index)", field),
-					code(field, "return ${lcPlural}.getChild(index).getReference();"));
+			methods.addMethod("Reference", "get${name}Reference", "int", "index")
+					.code("return ${lcPlural}.getChild(index).getReference();");
 		}
 		return methods;
 	}
 
 	private Member getElaborateChildrenMethod(Type type) {
-		String decl = "protected void elaborateChildren()";
 		Collection<String> code = Lists.newArrayList();
 		for (Field field : type.getFields().values()) {
 			if (!field.isNoImpl()) {
@@ -226,13 +223,12 @@ public class ImplGenerator extends TypeGenerator {
 				}
 			}
 		}
-		return new Member(decl, code).override();
+		return new MethodMember(null, "void", "elaborateChildren").override().code(code);
 	}
 
 	private Member getFactoryMethod(Type type) {
 		requireTypes(OverlayFactory.class, JsonNode.class, ReferenceRegistry.class);
-		Collection<String> decl = t(type,
-				"public static OverlayFactory<${name}, ${implName}> factory = new OverlayFactory<${name}, ${implName}>() {", //
+		String initializer = String.join("\n", t(type, "new OverlayFactory<${name}, ${implName}>() {", //
 				"    @Override", //
 				"    protected Class<? super ${implName}> getOverlayClass() {", //
 				"         return ${implName}.class;", //
@@ -247,48 +243,42 @@ public class ImplGenerator extends TypeGenerator {
 				"    public ${implName} _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {", //
 				"        return new ${implName}(json, parent, refReg);", //
 				"    }", //
-				"}");
-		return new Member(StringUtils.join(decl, "\n"), null);
+				"}"));
+		return new FieldMember(null, t("OverlayFactory<${name}, ${implName}>", type), "factory", initializer)
+				._static(true)._public(true);
 	}
 
 	private Members getMapMethods(Field field) {
-		Members methods = new Members();
+		Members methods = new Members(field);
 		// Map<String, ? extends T> getFoos() => foos.get()
-		methods.add(t("public Map<String, ${collType}> get${plural}()", field),
-				code(field, "return ${lcPlural}.get();"));
+		methods.addMethod("Map<String, ${collType}>", "get${plural}").code("return ${lcPlural}.get();");
 		// Map<String, ? extends T> getFoos(boolean elaborate) => foos.get(elaborate)
-		methods.add(t("public Map<String, ${collType}> get${plural}(boolean elaborate)", field),
-				code(field, "return ${lcPlural}.get(elaborate);"));
+		methods.addMethod("Map<String, ${collType}>", "get${plural}", "boolean", "elaborate")
+				.code("return ${lcPlural}.get(elaborate);");
 		// boolean hasFoo(String key) => foos.containsKey(key)
-		methods.add(t("public boolean has${name}(String ${keyName})", field),
-				code(field, "return ${lcPlural}.containsKey(${keyName});"));
+		methods.addMethod("boolean", "has${name}", "String", "${keyName}")
+				.code("return ${lcPlural}.containsKey(${keyName});");
 		// T getFoo(String key) => foos.get(key)
-		methods.add(t("public ${type} get${name}(String ${keyName})", field),
-				code(field, "return ${lcPlural}.get(${keyName});"));
+		methods.addMethod("${type}", "get${name}", "String", "${keyName}").code("return ${lcPlural}.get(${keyName});");
 		// void setFoos(Map<String, T> foos) => this.foos.set(foos)
-		methods.add(t("public void set${plural}(Map<String, ${type}> ${lcPlural})", field),
-				code(field, "this.${lcPlural}.set(${lcPlural});"));
+		methods.addMethod("void", "set${plural}", "Map<String, ${type}>", "${lcPlural}")
+				.code("this.${lcPlural}.set(${lcPlural});");
 		// void setFoo(String key, Foo foo) => foos.set(key, foo)
-		methods.add(t("public void set${name}(String ${keyName}, ${type} ${lcName})", field),
-				code(field, "${lcPlural}.set(${keyName}, ${lcName});"));
+		methods.addMethod("void", "set${name}", "String", "${keyName}", "${type}", "${lcName}")
+				.code("${lcPlural}.set(${keyName}, ${lcName});");
 		// void removeFoo(String key) => foos.remove(key)
-		methods.add(t("public void remove${name}(String ${keyName})", field),
-				code(field, "${lcPlural}.remove(${keyName});"));
+		methods.addMethod("void", "remove${name}", "String", "${keyName}").code("${lcPlural}.remove(${keyName});");
 		if (field.isRefable()) {
 			// boolean isFooReference(String key) => foos.getChild(key).isReference()
-			methods.add(t("public boolean is${name}Reference(String key)", field),
-					code(field, "ChildOverlay<${type}, ${implType}> child = ${lcPlural}.getChild(key);",
-							"return child != null ? child.isReference() : false;"));
+			methods.addMethod("boolean", "is${name}Reference", "String", "key").code(
+					"ChildOverlay<${type}, ${implType}> child = ${lcPlural}.getChild(key);",
+					"return child != null ? child.isReference() : false;");
 			// Reference getFooReference(String key) => foos.getChild(key).getReference()
-			methods.add(t("public Reference get${name}Reference(String key)", field),
-					code(field, "ChildOverlay<${type}, ${implType}> child = ${lcPlural}.getChild(key);",
-							"return child != null ? child.getReference() : null;"));
+			methods.addMethod("Reference", "get${name}Reference", "String", "key").code(
+					"ChildOverlay<${type}, ${implType}> child = ${lcPlural}.getChild(key);",
+					"return child != null ? child.getReference() : null;");
 		}
 		return methods;
-	}
-
-	private Collection<String> code(String... lines) {
-		return Lists.newArrayList(lines);
 	}
 
 	private Collection<String> code(final Field field, String... lines) {

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/gen/ImplGenerator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/gen/ImplGenerator.java
@@ -223,7 +223,7 @@ public class ImplGenerator extends TypeGenerator {
 				}
 			}
 		}
-		return new MethodMember(null, "void", "elaborateChildren").override().code(code);
+		return new MethodMember(null, "void", "elaborateChildren").override().protectedAccess().code(code);
 	}
 
 	private Member getFactoryMethod(Type type) {
@@ -245,7 +245,7 @@ public class ImplGenerator extends TypeGenerator {
 				"    }", //
 				"}"));
 		return new FieldMember(null, t("OverlayFactory<${name}, ${implName}>", type), "factory", initializer)
-				._static(true)._public(true);
+				._static(true).publicAccess();
 	}
 
 	private Members getMapMethods(Field field) {

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/gen/ImplGenerator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/gen/ImplGenerator.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.google.common.base.Function;
 import com.google.common.collect.Lists;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ChildListOverlay;
@@ -61,10 +62,16 @@ public class ImplGenerator extends TypeGenerator {
 	}
 
 	@Override
-	public String getTypeDeclaration(Type type, String suffix) {
+	public ClassOrInterfaceDeclaration getTypeDeclaration(Type type, String suffix) {
 		requireTypes(OpenApiObjectImpl.class, OpenApi3.class);
 		requireTypes(type);
-		return t("public class ${name}${0} extends ${1} implements ${name}", type, suffix, getSuperType(type));
+		ClassOrInterfaceDeclaration decl = new ClassOrInterfaceDeclaration();
+		decl.setInterface(false);
+		decl.setPublic(true);
+		decl.setName(type.getName() + suffix);
+		decl.addExtendedType(getSuperType(type));
+		decl.addImplementedType(type.getName());
+		return decl;
 	}
 
 	private String getSuperType(Type type) {

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/gen/InterfaceGenerator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/gen/InterfaceGenerator.java
@@ -17,8 +17,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.lang3.StringUtils;
-
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.google.common.collect.Lists;
 import com.reprezen.kaizen.oasparser.jsonoverlay.Reference;
 import com.reprezen.kaizen.oasparser.jsonoverlay.gen.SimpleJavaGenerator.Member;
@@ -37,13 +36,20 @@ public class InterfaceGenerator extends TypeGenerator {
 	}
 
 	@Override
-	protected String getTypeDeclaration(Type type, String suffix) {
+	protected ClassOrInterfaceDeclaration getTypeDeclaration(Type type, String suffix) {
 		String superType = getSuperType(type);
 		requireTypes(superType);
 		requireTypes(type.getExtendInterfaces());
+		ClassOrInterfaceDeclaration decl = new ClassOrInterfaceDeclaration();
+		decl.setInterface(true);
+		decl.setName(type.getName());
+		decl.setPublic(true);
 		List<String> allTypes = Lists.newArrayList(superType);
 		allTypes.addAll(type.getExtendInterfaces());
-		return t("public interface ${name} extends ${0}", type, StringUtils.join(allTypes, ", "));
+		for (String extensionType : allTypes) {
+			decl.addExtendedType(extensionType);
+		}
+		return decl;
 	}
 
 	@Override

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/gen/InterfaceGenerator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/gen/InterfaceGenerator.java
@@ -64,7 +64,7 @@ public class InterfaceGenerator extends TypeGenerator {
 
 	@Override
 	protected Members getFieldMethods(Field field) {
-		Members methods = new Members();
+		Members methods = new Members(field);
 		requireTypes(field.getType());
 		boolean first = true;
 		String typeComment = field.getName();
@@ -97,76 +97,76 @@ public class InterfaceGenerator extends TypeGenerator {
 	}
 
 	private Members getScalarMethods(Field field) {
-		Members methods = new Members();
+		Members methods = new Members(field);
 		// T getFoo()
-		methods.add(t("${type} get${name}()", field));
+		methods.addMethod("${type}", "get${name}");
 		// T getFoo(boolean elaborate)
-		methods.add(t("${type} get${name}(boolean elaborate)", field));
+		methods.addMethod("${type}", "get${name}", "boolean", "elaborate");
 		if (field.getType().equals("Boolean")) {
 			// boolean isFoo()
-			methods.add(t("boolean is${name}()", field));
+			methods.addMethod("boolean", "is${name}");
 		}
 		// void setFoo(T foo)
-		methods.add(t("void set${name}(${type} ${lcName})", field));
+		methods.addMethod("void", "set${name}", "${type}", "${lcName}");
 		if (field.isRefable()) {
 			// boolean isFooReference()
-			methods.add(t("boolean is${name}Reference()", field));
+			methods.addMethod("boolean", "is${name}Reference");
 			// Reference getFooReference()
-			methods.add(t("Reference get${name}Reference()", field));
+			methods.addMethod("Reference", "get${name}Reference");
 		}
 		return methods;
 	}
 
 	private Members getCollectionMethods(Field field) {
-		Members methods = new Members();
+		Members methods = new Members(field);
 		// Collection<? extends T> getFoos()
-		methods.add(t("Collection<${collType}> get${plural}()", field));
+		methods.addMethod("Collection<${collType}>", "get${plural}");
 		// Collection<? extends T> getFoos(boolean elaborate)
-		methods.add(t("Collection<${collType}> get${plural}(boolean elaborate)", field));
+		methods.addMethod(t("Collection<${collType}>", field), t("get${plural}", field), "boolean", "elaborate");
 		// boolean hasFoos()
-		methods.add(t("boolean has${plural}()", field));
+		methods.addMethod("boolean", t("has${plural}", field));
 		// T getFoo(int index)
-		methods.add(t("${type} get${name}(int index)", field));
+		methods.addMethod(t("${type}", field), t("get${name}", field), "int", "index");
 		// void setFoos(Collection<? extends T> foos)
-		methods.add(t("void set${plural}(Collection<${collType}> ${lcPlural})", field));
+		methods.addMethod("void", "set${plural}", "Collection<${collType}>", "${lcPlural}");
 		// void setFoo(int index, Foo foo)
-		methods.add(t("void set${name}(int index, ${type} ${lcName})", field));
+		methods.addMethod("void", "set${name}", "int", "index", "${type}", "${lcName}");
 		// void addFoo(Foo foo)
-		methods.add(t("void add${name}(${type} ${lcName})", field));
+		methods.addMethod("void", "add${name}", "${type}", "${lcName}");
 		// void insertFoo(int index, Foo foo)
-		methods.add(t("void insert${name}(int index, ${type} ${lcName})", field));
+		methods.addMethod("void", "insert${name}", "int", "index", "${type}", "${lcName}");
 		// void removeFoo(int index)
-		methods.add(t("void remove${name}(int index)", field));
+		methods.addMethod("void", "remove${name}", "int", "index");
 		if (field.isRefable()) {
 			// boolean isFooReference(int index)
-			methods.add(t("boolean is${name}Reference(int index)", field));
+			methods.addMethod("boolean", "is${name}Reference", "int", "index");
 			// ReferencegetFooReference(int index)
-			methods.add(t("Reference get${name}Reference(int index)", field));
+			methods.addMethod("Reference", "get${name}Reference", "int", "index");
 		}
 		return methods;
 	}
 
 	private Members getMapMethods(Field field) {
-		Members methods = new Members();
+		Members methods = new Members(field);
 		// Map<String, ? extends T> getFoos()
-		methods.add(t("Map<String, ${collType}> get${plural}()", field));
+		methods.addMethod("Map<String, ${collType}>", "get${plural}");
 		// Map<String, ? extends T> getFoos(boolean elaborate)
-		methods.add(t("Map<String, ${collType}> get${plural}(boolean elaborate)", field));
+		methods.addMethod("Map<String, ${collType}>", "get${plural}", "boolean", "elaborate");
 		// boolean hasFoo(String name)
-		methods.add(t("boolean has${name}(String ${keyName})", field));
+		methods.addMethod("boolean", "has${name}", "String", "${keyName}");
 		// Foo getFoo(String name)
-		methods.add(t("${type} get${name}(String ${keyName})", field));
+		methods.addMethod("${type}", "get${name}", "String", "${keyName}");
 		// void setFoos(Map<String, ? extends T> foos)
-		methods.add(t("void set${plural}(Map<String, ${collType}> ${lcPlural})", field));
+		methods.addMethod("void", "set${plural}", "Map<String, ${collType}>", "${lcPlural}");
 		// void setFoo(String name, Foo foo)
-		methods.add(t("void set${name}(String ${keyName}, ${type} ${lcName})", field));
+		methods.addMethod("void", "set${name}", "String", "${keyName}", "${type}", "${lcName}");
 		// void removeFoo(String name)
-		methods.add(t("void remove${name}(String ${keyName})", field));
+		methods.addMethod("void", "remove${name}", "String", "${keyName}");
 		if (field.isRefable()) {
 			// boolean isFooReference(String key)
-			methods.add(t("boolean is${name}Reference(String key)", field));
+			methods.addMethod("boolean", "is${name}Reference", "String", "key");
 			// ReferencegetFooReference(int index)
-			methods.add(t("Reference get${name}Reference(String key)", field));
+			methods.addMethod("Reference", "get${name}Reference", "String", "key");
 		}
 		return methods;
 	}

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/gen/InterfaceGenerator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/gen/InterfaceGenerator.java
@@ -93,6 +93,9 @@ public class InterfaceGenerator extends TypeGenerator {
 			}
 			break;
 		}
+		for (Member method: methods) {
+			method.packageAccess();
+		}
 		return methods;
 	}
 

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/gen/SimpleJavaGenerator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/gen/SimpleJavaGenerator.java
@@ -258,6 +258,13 @@ public class SimpleJavaGenerator {
 		public String format() {
 			return declaration.toString();
 		}
+
+		public String getName() {
+			return null;
+		}
+
+		public void setName(String name) {
+		}
 	}
 
 	public static class ConstructorMember extends Member {
@@ -289,7 +296,6 @@ public class SimpleJavaGenerator {
 		protected void setAccess(Modifier mod) {
 			cons.setModifiers(setAccessModifier(cons.getModifiers(), mod));
 		}
-
 	}
 
 	private static ConstructorDeclaration constructorDecl(
@@ -354,6 +360,15 @@ public class SimpleJavaGenerator {
 			meth.setModifiers(setAccessModifier(meth.getModifiers(), mod));
 		}
 
+		@Override
+		public String getName() {
+			return meth.getNameAsString();
+		}
+
+		@Override
+		public void setName(String name) {
+			meth.setName(name);
+		}
 	}
 
 	public static class FieldMember extends Member {
@@ -392,6 +407,15 @@ public class SimpleJavaGenerator {
 			fld.setModifiers(setAccessModifier(fld.getModifiers(), mod));
 		}
 
+		@Override
+		public String getName() {
+			return fld.getVariable(0).getNameAsString();
+		}
+
+		@Override
+		public void setName(String name) {
+			fld.getVariable(0).setName(name);
+		}
 	}
 
 	private static List<String> expandStrings(Field field, Collection<String> strings) {

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/gen/SimpleJavaGenerator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/gen/SimpleJavaGenerator.java
@@ -17,6 +17,14 @@ import java.util.Set;
 
 import org.apache.commons.lang3.StringUtils;
 
+import com.github.javaparser.JavaParser;
+import com.github.javaparser.ParseStart;
+import com.github.javaparser.ParserConfiguration;
+import com.github.javaparser.StringProvider;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+import com.github.javaparser.ast.comments.JavadocComment;
+import com.github.javaparser.ast.validator.Java8Validator;
 import com.google.common.base.Function;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.Lists;
@@ -24,154 +32,161 @@ import com.google.common.collect.Sets;
 
 public class SimpleJavaGenerator {
 
-    private String pkg;
-    private Set<String> imports = Sets.newHashSet();
-    private String declaration;
-    private List<Member> members = Lists.newArrayList();
-    private String fileComment;
+	private String pkg;
+	private Set<String> imports = Sets.newHashSet();
+	private ClassOrInterfaceDeclaration type;
+	private List<Member> members = Lists.newArrayList();
+	private String fileComment;
+	private JavaParser parser = new JavaParser(new ParserConfiguration().setValidator(new Java8Validator()));
+	private static int indentation = 4;
 
-    private static int indentation = 4;
+	public SimpleJavaGenerator(String pkg, ClassOrInterfaceDeclaration type) {
+		this.pkg = pkg;
+		this.type = type;
+	}
 
-    public SimpleJavaGenerator(String pkg, String declaration) {
-        this.pkg = pkg;
-        this.declaration = declaration;
-    }
+	public String getPackage() {
+		return pkg;
+	}
 
-    public String getPackage() {
-        return pkg;
-    }
+	public void setPackage(String pkg) {
+		this.pkg = pkg;
+	}
 
-    public void setPackage(String pkg) {
-        this.pkg = pkg;
-    }
+	public int getIndentation() {
+		return indentation;
+	}
 
-    public int getIndentation() {
-        return indentation;
-    }
+	public void setIndentation(int indentation) {
+		SimpleJavaGenerator.indentation = indentation;
+	}
 
-    public void setIndentation(int indentation) {
-        SimpleJavaGenerator.indentation = indentation;
-    }
+	public Collection<Member> getMembers() {
+		return members;
+	}
 
-    public Collection<Member> getMembers() {
-        return members;
-    }
+	public void addMember(Member member) {
+		members.add(member);
+	}
 
-    public void addMember(Member member) {
-        members.add(member);
-    }
+	public void addMembers(Collection<Member> members) {
+		this.members.addAll(members);
+	}
 
-    public void addMembers(Collection<Member> members) {
-        this.members.addAll(members);
-    }
+	public void addGeneratedMembers(Collection<Member> members) {
+		for (Member member : members) {
+			this.members.add(member.generated(true));
+		}
+	}
 
-    public void addGeneratedMembers(Collection<Member> members) {
-        for (Member member : members) {
-            this.members.add(member.generated(true));
-        }
-    }
+	public void setFileComment(String fileComment) {
+		this.fileComment = fileComment;
+	}
 
-    public void setFileComment(String fileComment) {
-        this.fileComment = fileComment;
-    }
+	public void addImport(String imp) {
+		if (imp != null) {
+			imports.add(imp);
+		}
+	}
 
-    public void addImport(String imp) {
-        if (imp != null) {
-            imports.add(imp);
-        }
-    }
+	public String format() {
+		CompilationUnit cu = new CompilationUnit();
+		if (fileComment != null) {
+			cu.addOrphanComment(new JavadocComment(fileComment));
+		}
+		cu.setPackageDeclaration(pkg);
+		for (String imp : imports) {
+			cu.addImport(imp);
+		}
+		cu.addType(type);
+		for (Member method : members) {
+			type.addMember(parser.parse(ParseStart.CLASS_BODY, new StringProvider(method.format())).getResult().get());
+		}
+		return cu.toString();
+	}
 
-    public String format() {
-        String result = String.format("%spackage %s;\n\n%s\n\n%s {\n\n", fileComment != null ? fileComment : "", pkg,
-                getImports(), declaration);
-        for (Member method : members) {
-            result += method.format() + "\n";
-        }
-        return result + "}\n";
+	private static String indent(int n) {
+		return StringUtils.repeat(" ", indentation * n);
+	}
 
-    }
+	private static String indent(int n, String text) {
+		String[] lines = StringUtils.split(text, "\n");
+		String result = "";
+		for (String line : lines) {
+			result += indent(n) + line + "\n";
+		}
+		return result;
+	}
 
-    private static String indent(int n) {
-        return StringUtils.repeat(" ", indentation * n);
-    }
+	public String getImports() {
+		List<String> importsList = Lists.newArrayList(imports);
+		Collections.sort(importsList);
+		return StringUtils.join(Collections2.transform(importsList, new Function<String, String>() {
+			@Override
+			public String apply(String imp) {
+				return "import " + imp + ";";
+			}
+		}), "\n");
+	}
 
-    private static String indent(int n, String text) {
-        String[] lines = StringUtils.split(text, "\n");
-        String result = "";
-        for (String line : lines) {
-            result += indent(n) + line + "\n";
-        }
-        return result;
-    }
+	public static class Member {
+		private String declaration;
+		private Collection<String> code;
+		private String comment;
+		private boolean override;
+		private boolean generated;
+		private boolean complete;
 
-    public String getImports() {
-        List<String> importsList = Lists.newArrayList(imports);
-        Collections.sort(importsList);
-        return StringUtils.join(Collections2.transform(importsList, new Function<String, String>() {
-            @Override
-            public String apply(String imp) {
-                return "import " + imp + ";";
-            }
-        }), "\n");
-    }
+		public Member(String declaration, Collection<String> code) {
+			this.declaration = declaration;
+			this.code = code;
+		}
 
-    public static class Member {
-        private String declaration;
-        private Collection<String> code;
-        private String comment;
-        private boolean override;
-        private boolean generated;
-        private boolean complete;
+		public String getDeclaration() {
+			return declaration;
+		}
 
-        public Member(String declaration, Collection<String> code) {
-            this.declaration = declaration;
-            this.code = code;
-        }
+		public Collection<String> getCode() {
+			return code;
+		}
 
-        public String getDeclaration() {
-            return declaration;
-        }
+		public Member override() {
+			this.override = true;
+			return this;
+		}
 
-        public Collection<String> getCode() {
-            return code;
-        }
+		public Member comment(String comment) {
+			this.comment = comment;
+			return this;
+		}
 
-        public Member override() {
-            this.override = true;
-            return this;
-        }
+		public Member generated(boolean generated) {
+			this.generated = generated;
+			return this;
+		}
 
-        public Member comment(String comment) {
-            this.comment = comment;
-            return this;
-        }
+		public Member complete(boolean complete) {
+			this.complete = complete;
+			return this;
+		}
 
-        public Member generated(boolean generated) {
-            this.generated = generated;
-            return this;
-        }
+		public String format() {
+			if (this.complete) {
+				return indent(1, declaration);
+			} else {
+				String override = this.override ? indent(1) + "@Override\n" : "";
+				String gen = this.generated
+						? indent(1) + String.format("@Generated(\"%s\")\n", CodeGenerator.class.getName())
+						: "";
+				String comment = this.comment != null ? indent(1) + "// " + this.comment + "\n" : "";
+				String header = comment + override + gen + indent(1) + declaration;
+				return code == null || code.isEmpty() ? header + ";\n"
+						: header + " {\n" + formatCode() + "\n" + indent(1) + "}\n";
+			}
+		}
 
-        public Member complete(boolean complete) {
-            this.complete = complete;
-            return this;
-        }
-
-        public String format() {
-            if (this.complete) {
-                return indent(1, declaration);
-            } else {
-                String override = this.override ? indent(1) + "@Override\n" : "";
-                String gen = this.generated
-                        ? indent(1) + String.format("@Generated(\"%s\")\n", CodeGenerator.class.getName()) : "";
-                String comment = this.comment != null ? indent(1) + "// " + this.comment + "\n" : "";
-                String header = comment + override + gen + indent(1) + declaration;
-                return code == null || code.isEmpty() ? header + ";\n"
-                        : header + " {\n" + formatCode() + "\n" + indent(1) + "}\n";
-            }
-        }
-
-        private String formatCode() {
-            return (indent(2) + StringUtils.join(code, "\n" + indent(3)));
-        }
-    }
+		private String formatCode() {
+			return (indent(2) + StringUtils.join(code, "\n" + indent(3)));
+		}
+	}
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/gen/SimpleJavaGenerator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/gen/SimpleJavaGenerator.java
@@ -99,23 +99,10 @@ public class SimpleJavaGenerator {
 			cu.addImport(imp);
 		}
 		cu.addType(type);
-		for (Member method : members) {
-			type.addMember(parser.parse(ParseStart.CLASS_BODY, new StringProvider(method.format())).getResult().get());
+		for (Member member : members) {
+			type.addMember(parser.parse(ParseStart.CLASS_BODY, new StringProvider(member.format())).getResult().get());
 		}
 		return cu.toString();
-	}
-
-	private static String indent(int n) {
-		return StringUtils.repeat(" ", indentation * n);
-	}
-
-	private static String indent(int n, String text) {
-		String[] lines = StringUtils.split(text, "\n");
-		String result = "";
-		for (String line : lines) {
-			result += indent(n) + line + "\n";
-		}
-		return result;
 	}
 
 	public String getImports() {
@@ -172,21 +159,18 @@ public class SimpleJavaGenerator {
 
 		public String format() {
 			if (this.complete) {
-				return indent(1, declaration);
+				return declaration;
 			} else {
-				String override = this.override ? indent(1) + "@Override\n" : "";
-				String gen = this.generated
-						? indent(1) + String.format("@Generated(\"%s\")\n", CodeGenerator.class.getName())
-						: "";
-				String comment = this.comment != null ? indent(1) + "// " + this.comment + "\n" : "";
-				String header = comment + override + gen + indent(1) + declaration;
-				return code == null || code.isEmpty() ? header + ";\n"
-						: header + " {\n" + formatCode() + "\n" + indent(1) + "}\n";
+				String override = this.override ? "@Override\n" : "";
+				String gen = this.generated ? String.format("@Generated(\"%s\")\n", CodeGenerator.class.getName()) : "";
+				String comment = this.comment != null ? "// " + this.comment + "\n" : "";
+				String header = comment + override + gen + declaration;
+				return code == null || code.isEmpty() ? header + ";\n" : header + " {\n" + formatCode() + "\n" + "}\n";
 			}
 		}
 
 		private String formatCode() {
-			return (indent(2) + StringUtils.join(code, "\n" + indent(3)));
+			return StringUtils.join(code, "\n");
 		}
 	}
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/gen/TypeData.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/gen/TypeData.java
@@ -83,6 +83,7 @@ public class TypeData {
 		private Map<String, Collection<String>> imports = Maps.newHashMap();
 		private boolean noGen = false;
 		private String extensionOf;
+		private Map<String, String> renames = Maps.newHashMap();
 
 		private TypeData typeData;
 
@@ -152,6 +153,10 @@ public class TypeData {
 
 		public String getExtensionOf() {
 			return extensionOf;
+		}
+
+		public Map<String, String> getRenames() {
+			return renames;
 		}
 
 		public String getImplType() {
@@ -349,7 +354,7 @@ public class TypeData {
 		public String getTypeInCollection() {
 			return isScalarType() ? type : t("? extends ${type}", this);
 		}
-		
+
 		public boolean isRefable() {
 			return refable;
 		}

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/gen/TypeGenerator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/gen/TypeGenerator.java
@@ -239,18 +239,30 @@ public abstract class TypeGenerator {
 	}
 
 	protected void addGeneratedMembers(Type type, SimpleJavaGenerator gen) {
-		gen.addGeneratedMembers(getConstructors(type));
+		Members members = new Members(type);
+		members.addAll(getConstructors(type));
 		for (Field field : type.getFields().values()) {
 			if (!skipField(field)) {
-				gen.addGeneratedMembers(getFieldMembers(field));
+				members.addAll(getFieldMembers(field));
 			}
 		}
 		for (Field field : type.getFields().values()) {
 			if (!skipField(field)) {
-				gen.addGeneratedMembers(getFieldMethods(field));
+				members.addAll(getFieldMethods(field));
 			}
 		}
-		gen.addGeneratedMembers(getOtherMembers(type));
+		members.addAll(getOtherMembers(type));
+		for (Member member : members) {
+			maybeRename(member, type.getRenames());
+		}
+		gen.addGeneratedMembers(members);
+	}
+
+	private void maybeRename(Member member, Map<String, String> renames) {
+		String name = member.getName();
+		if (name != null && renames.containsKey(name)) {
+			member.setName(renames.get(name));
+		}
 	}
 
 	protected boolean skipField(Field field) {

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Callback.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Callback.java
@@ -1,9 +1,9 @@
 package com.reprezen.kaizen.oasparser.model3;
 
-import com.reprezen.kaizen.oasparser.model3.OpenApiObject;
+import javax.annotation.Generated;
 import com.reprezen.kaizen.oasparser.model3.Path;
 import java.util.Map;
-import javax.annotation.Generated;
+import com.reprezen.kaizen.oasparser.model3.OpenApiObject;
 
 public interface Callback extends OpenApiObject<OpenApi3, Callback> {
 
@@ -50,5 +50,4 @@ public interface Callback extends OpenApiObject<OpenApi3, Callback> {
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     void removeExtension(String name);
-
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Contact.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Contact.java
@@ -1,8 +1,8 @@
 package com.reprezen.kaizen.oasparser.model3;
 
-import com.reprezen.kaizen.oasparser.model3.OpenApiObject;
-import java.util.Map;
 import javax.annotation.Generated;
+import java.util.Map;
+import com.reprezen.kaizen.oasparser.model3.OpenApiObject;
 
 public interface Contact extends OpenApiObject<OpenApi3, Contact> {
 
@@ -57,5 +57,4 @@ public interface Contact extends OpenApiObject<OpenApi3, Contact> {
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     void removeExtension(String name);
-
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/EncodingProperty.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/EncodingProperty.java
@@ -1,9 +1,9 @@
 package com.reprezen.kaizen.oasparser.model3;
 
-import com.reprezen.kaizen.oasparser.jsonoverlay.Reference;
-import com.reprezen.kaizen.oasparser.model3.OpenApiObject;
-import java.util.Map;
 import javax.annotation.Generated;
+import java.util.Map;
+import com.reprezen.kaizen.oasparser.model3.OpenApiObject;
+import com.reprezen.kaizen.oasparser.jsonoverlay.Reference;
 
 public interface EncodingProperty extends OpenApiObject<OpenApi3, EncodingProperty> {
 
@@ -89,5 +89,4 @@ public interface EncodingProperty extends OpenApiObject<OpenApi3, EncodingProper
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     void removeExtension(String name);
-
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Example.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Example.java
@@ -1,8 +1,8 @@
 package com.reprezen.kaizen.oasparser.model3;
 
-import com.reprezen.kaizen.oasparser.model3.OpenApiObject;
-import java.util.Map;
 import javax.annotation.Generated;
+import java.util.Map;
+import com.reprezen.kaizen.oasparser.model3.OpenApiObject;
 
 public interface Example extends OpenApiObject<OpenApi3, Example> {
 
@@ -67,5 +67,4 @@ public interface Example extends OpenApiObject<OpenApi3, Example> {
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     void removeExtension(String name);
-
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/ExternalDocs.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/ExternalDocs.java
@@ -1,8 +1,8 @@
 package com.reprezen.kaizen.oasparser.model3;
 
-import com.reprezen.kaizen.oasparser.model3.OpenApiObject;
-import java.util.Map;
 import javax.annotation.Generated;
+import java.util.Map;
+import com.reprezen.kaizen.oasparser.model3.OpenApiObject;
 
 public interface ExternalDocs extends OpenApiObject<OpenApi3, ExternalDocs> {
 
@@ -47,5 +47,4 @@ public interface ExternalDocs extends OpenApiObject<OpenApi3, ExternalDocs> {
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     void removeExtension(String name);
-
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Header.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Header.java
@@ -1,12 +1,12 @@
 package com.reprezen.kaizen.oasparser.model3;
 
-import com.reprezen.kaizen.oasparser.jsonoverlay.Reference;
-import com.reprezen.kaizen.oasparser.model3.Example;
-import com.reprezen.kaizen.oasparser.model3.MediaType;
-import com.reprezen.kaizen.oasparser.model3.OpenApiObject;
 import com.reprezen.kaizen.oasparser.model3.Schema;
-import java.util.Map;
 import javax.annotation.Generated;
+import com.reprezen.kaizen.oasparser.model3.MediaType;
+import com.reprezen.kaizen.oasparser.model3.Example;
+import java.util.Map;
+import com.reprezen.kaizen.oasparser.model3.OpenApiObject;
+import com.reprezen.kaizen.oasparser.jsonoverlay.Reference;
 
 public interface Header extends OpenApiObject<OpenApi3, Header> {
 
@@ -212,5 +212,4 @@ public interface Header extends OpenApiObject<OpenApi3, Header> {
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     void removeExtension(String name);
-
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Info.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Info.java
@@ -1,10 +1,10 @@
 package com.reprezen.kaizen.oasparser.model3;
 
-import com.reprezen.kaizen.oasparser.model3.Contact;
-import com.reprezen.kaizen.oasparser.model3.License;
-import com.reprezen.kaizen.oasparser.model3.OpenApiObject;
-import java.util.Map;
 import javax.annotation.Generated;
+import com.reprezen.kaizen.oasparser.model3.License;
+import java.util.Map;
+import com.reprezen.kaizen.oasparser.model3.OpenApiObject;
+import com.reprezen.kaizen.oasparser.model3.Contact;
 
 public interface Info extends OpenApiObject<OpenApi3, Info> {
 
@@ -89,5 +89,4 @@ public interface Info extends OpenApiObject<OpenApi3, Info> {
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     void removeExtension(String name);
-
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/License.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/License.java
@@ -1,8 +1,8 @@
 package com.reprezen.kaizen.oasparser.model3;
 
-import com.reprezen.kaizen.oasparser.model3.OpenApiObject;
-import java.util.Map;
 import javax.annotation.Generated;
+import java.util.Map;
+import com.reprezen.kaizen.oasparser.model3.OpenApiObject;
 
 public interface License extends OpenApiObject<OpenApi3, License> {
 
@@ -47,5 +47,4 @@ public interface License extends OpenApiObject<OpenApi3, License> {
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     void removeExtension(String name);
-
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Link.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Link.java
@@ -1,10 +1,10 @@
 package com.reprezen.kaizen.oasparser.model3;
 
+import com.reprezen.kaizen.oasparser.model3.Server;
+import javax.annotation.Generated;
+import java.util.Map;
 import com.reprezen.kaizen.oasparser.model3.Header;
 import com.reprezen.kaizen.oasparser.model3.OpenApiObject;
-import com.reprezen.kaizen.oasparser.model3.Server;
-import java.util.Map;
-import javax.annotation.Generated;
 
 public interface Link extends OpenApiObject<OpenApi3, Link> {
 
@@ -113,5 +113,4 @@ public interface Link extends OpenApiObject<OpenApi3, Link> {
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     void removeExtension(String name);
-
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/MediaType.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/MediaType.java
@@ -1,12 +1,12 @@
 package com.reprezen.kaizen.oasparser.model3;
 
-import com.reprezen.kaizen.oasparser.jsonoverlay.Reference;
-import com.reprezen.kaizen.oasparser.model3.EncodingProperty;
-import com.reprezen.kaizen.oasparser.model3.Example;
-import com.reprezen.kaizen.oasparser.model3.OpenApiObject;
 import com.reprezen.kaizen.oasparser.model3.Schema;
-import java.util.Map;
 import javax.annotation.Generated;
+import com.reprezen.kaizen.oasparser.model3.Example;
+import java.util.Map;
+import com.reprezen.kaizen.oasparser.model3.EncodingProperty;
+import com.reprezen.kaizen.oasparser.model3.OpenApiObject;
+import com.reprezen.kaizen.oasparser.jsonoverlay.Reference;
 
 public interface MediaType extends OpenApiObject<OpenApi3, MediaType> {
 
@@ -107,5 +107,4 @@ public interface MediaType extends OpenApiObject<OpenApi3, MediaType> {
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     void removeExtension(String name);
-
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/OAuthFlow.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/OAuthFlow.java
@@ -1,8 +1,8 @@
 package com.reprezen.kaizen.oasparser.model3;
 
-import com.reprezen.kaizen.oasparser.model3.OpenApiObject;
-import java.util.Map;
 import javax.annotation.Generated;
+import java.util.Map;
+import com.reprezen.kaizen.oasparser.model3.OpenApiObject;
 
 public interface OAuthFlow extends OpenApiObject<OpenApi3, OAuthFlow> {
 
@@ -101,5 +101,4 @@ public interface OAuthFlow extends OpenApiObject<OpenApi3, OAuthFlow> {
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     void removeExtension(String name);
-
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/OpenApi3.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/OpenApi3.java
@@ -1,27 +1,27 @@
 package com.reprezen.kaizen.oasparser.model3;
 
-import com.reprezen.kaizen.oasparser.OpenApi;
-import com.reprezen.kaizen.oasparser.jsonoverlay.Reference;
-import com.reprezen.kaizen.oasparser.model3.Callback;
-import com.reprezen.kaizen.oasparser.model3.Example;
-import com.reprezen.kaizen.oasparser.model3.ExternalDocs;
-import com.reprezen.kaizen.oasparser.model3.Header;
-import com.reprezen.kaizen.oasparser.model3.Info;
-import com.reprezen.kaizen.oasparser.model3.Link;
-import com.reprezen.kaizen.oasparser.model3.OpenApiObject;
-import com.reprezen.kaizen.oasparser.model3.Parameter;
-import com.reprezen.kaizen.oasparser.model3.Path;
-import com.reprezen.kaizen.oasparser.model3.RequestBody;
-import com.reprezen.kaizen.oasparser.model3.Response;
 import com.reprezen.kaizen.oasparser.model3.Schema;
-import com.reprezen.kaizen.oasparser.model3.SecurityRequirement;
-import com.reprezen.kaizen.oasparser.model3.SecurityScheme;
 import com.reprezen.kaizen.oasparser.model3.Server;
-import com.reprezen.kaizen.oasparser.model3.Tag;
-import com.reprezen.kaizen.oasparser.val.ValidationResults;
+import com.reprezen.kaizen.oasparser.model3.Path;
+import com.reprezen.kaizen.oasparser.model3.SecurityRequirement;
 import java.util.Collection;
-import java.util.Map;
+import com.reprezen.kaizen.oasparser.model3.Header;
+import com.reprezen.kaizen.oasparser.jsonoverlay.Reference;
+import com.reprezen.kaizen.oasparser.model3.Link;
+import com.reprezen.kaizen.oasparser.model3.Callback;
+import com.reprezen.kaizen.oasparser.OpenApi;
 import javax.annotation.Generated;
+import com.reprezen.kaizen.oasparser.model3.Response;
+import com.reprezen.kaizen.oasparser.model3.Tag;
+import com.reprezen.kaizen.oasparser.model3.RequestBody;
+import com.reprezen.kaizen.oasparser.model3.Parameter;
+import com.reprezen.kaizen.oasparser.val.ValidationResults;
+import com.reprezen.kaizen.oasparser.model3.Example;
+import java.util.Map;
+import com.reprezen.kaizen.oasparser.model3.Info;
+import com.reprezen.kaizen.oasparser.model3.SecurityScheme;
+import com.reprezen.kaizen.oasparser.model3.OpenApiObject;
+import com.reprezen.kaizen.oasparser.model3.ExternalDocs;
 
 public interface OpenApi3 extends OpenApiObject<OpenApi3, OpenApi3>, OpenApi<OpenApi3> {
 
@@ -492,5 +492,4 @@ public interface OpenApi3 extends OpenApiObject<OpenApi3, OpenApi3>, OpenApi<Ope
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     void removeExtension(String name);
-
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Operation.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Operation.java
@@ -1,17 +1,17 @@
 package com.reprezen.kaizen.oasparser.model3;
 
-import com.reprezen.kaizen.oasparser.jsonoverlay.Reference;
-import com.reprezen.kaizen.oasparser.model3.Callback;
-import com.reprezen.kaizen.oasparser.model3.ExternalDocs;
-import com.reprezen.kaizen.oasparser.model3.OpenApiObject;
-import com.reprezen.kaizen.oasparser.model3.Parameter;
-import com.reprezen.kaizen.oasparser.model3.RequestBody;
-import com.reprezen.kaizen.oasparser.model3.Response;
-import com.reprezen.kaizen.oasparser.model3.SecurityRequirement;
 import com.reprezen.kaizen.oasparser.model3.Server;
+import com.reprezen.kaizen.oasparser.model3.Callback;
+import javax.annotation.Generated;
+import com.reprezen.kaizen.oasparser.model3.Response;
+import com.reprezen.kaizen.oasparser.model3.RequestBody;
+import com.reprezen.kaizen.oasparser.model3.SecurityRequirement;
+import com.reprezen.kaizen.oasparser.model3.Parameter;
 import java.util.Collection;
 import java.util.Map;
-import javax.annotation.Generated;
+import com.reprezen.kaizen.oasparser.model3.OpenApiObject;
+import com.reprezen.kaizen.oasparser.jsonoverlay.Reference;
+import com.reprezen.kaizen.oasparser.model3.ExternalDocs;
 
 public interface Operation extends OpenApiObject<OpenApi3, Operation> {
 
@@ -323,5 +323,4 @@ public interface Operation extends OpenApiObject<OpenApi3, Operation> {
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     void removeExtension(String name);
-
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Parameter.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Parameter.java
@@ -1,12 +1,12 @@
 package com.reprezen.kaizen.oasparser.model3;
 
-import com.reprezen.kaizen.oasparser.jsonoverlay.Reference;
-import com.reprezen.kaizen.oasparser.model3.Example;
-import com.reprezen.kaizen.oasparser.model3.MediaType;
-import com.reprezen.kaizen.oasparser.model3.OpenApiObject;
 import com.reprezen.kaizen.oasparser.model3.Schema;
-import java.util.Map;
 import javax.annotation.Generated;
+import com.reprezen.kaizen.oasparser.model3.MediaType;
+import com.reprezen.kaizen.oasparser.model3.Example;
+import java.util.Map;
+import com.reprezen.kaizen.oasparser.model3.OpenApiObject;
+import com.reprezen.kaizen.oasparser.jsonoverlay.Reference;
 
 public interface Parameter extends OpenApiObject<OpenApi3, Parameter> {
 
@@ -212,5 +212,4 @@ public interface Parameter extends OpenApiObject<OpenApi3, Parameter> {
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     void removeExtension(String name);
-
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Path.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Path.java
@@ -1,13 +1,13 @@
 package com.reprezen.kaizen.oasparser.model3;
 
-import com.reprezen.kaizen.oasparser.jsonoverlay.Reference;
-import com.reprezen.kaizen.oasparser.model3.OpenApiObject;
+import com.reprezen.kaizen.oasparser.model3.Server;
+import javax.annotation.Generated;
 import com.reprezen.kaizen.oasparser.model3.Operation;
 import com.reprezen.kaizen.oasparser.model3.Parameter;
-import com.reprezen.kaizen.oasparser.model3.Server;
 import java.util.Collection;
 import java.util.Map;
-import javax.annotation.Generated;
+import com.reprezen.kaizen.oasparser.model3.OpenApiObject;
+import com.reprezen.kaizen.oasparser.jsonoverlay.Reference;
 
 public interface Path extends OpenApiObject<OpenApi3, Path> {
 
@@ -216,5 +216,4 @@ public interface Path extends OpenApiObject<OpenApi3, Path> {
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     void removeExtension(String name);
-
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/RequestBody.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/RequestBody.java
@@ -1,9 +1,9 @@
 package com.reprezen.kaizen.oasparser.model3;
 
-import com.reprezen.kaizen.oasparser.model3.MediaType;
-import com.reprezen.kaizen.oasparser.model3.OpenApiObject;
-import java.util.Map;
 import javax.annotation.Generated;
+import com.reprezen.kaizen.oasparser.model3.MediaType;
+import java.util.Map;
+import com.reprezen.kaizen.oasparser.model3.OpenApiObject;
 
 public interface RequestBody extends OpenApiObject<OpenApi3, RequestBody> {
 
@@ -73,5 +73,4 @@ public interface RequestBody extends OpenApiObject<OpenApi3, RequestBody> {
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     void removeExtension(String name);
-
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Response.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Response.java
@@ -1,12 +1,12 @@
 package com.reprezen.kaizen.oasparser.model3;
 
-import com.reprezen.kaizen.oasparser.jsonoverlay.Reference;
-import com.reprezen.kaizen.oasparser.model3.Header;
-import com.reprezen.kaizen.oasparser.model3.Link;
-import com.reprezen.kaizen.oasparser.model3.MediaType;
-import com.reprezen.kaizen.oasparser.model3.OpenApiObject;
-import java.util.Map;
 import javax.annotation.Generated;
+import com.reprezen.kaizen.oasparser.model3.MediaType;
+import java.util.Map;
+import com.reprezen.kaizen.oasparser.model3.Header;
+import com.reprezen.kaizen.oasparser.model3.OpenApiObject;
+import com.reprezen.kaizen.oasparser.jsonoverlay.Reference;
+import com.reprezen.kaizen.oasparser.model3.Link;
 
 public interface Response extends OpenApiObject<OpenApi3, Response> {
 
@@ -119,5 +119,4 @@ public interface Response extends OpenApiObject<OpenApi3, Response> {
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     void removeExtension(String name);
-
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Schema.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Schema.java
@@ -1,14 +1,14 @@
 package com.reprezen.kaizen.oasparser.model3;
 
-import com.reprezen.kaizen.oasparser.jsonoverlay.Reference;
-import com.reprezen.kaizen.oasparser.model3.Example;
-import com.reprezen.kaizen.oasparser.model3.ExternalDocs;
-import com.reprezen.kaizen.oasparser.model3.OpenApiObject;
 import com.reprezen.kaizen.oasparser.model3.Schema;
 import com.reprezen.kaizen.oasparser.model3.Xml;
+import javax.annotation.Generated;
+import com.reprezen.kaizen.oasparser.model3.Example;
 import java.util.Collection;
 import java.util.Map;
-import javax.annotation.Generated;
+import com.reprezen.kaizen.oasparser.model3.OpenApiObject;
+import com.reprezen.kaizen.oasparser.jsonoverlay.Reference;
+import com.reprezen.kaizen.oasparser.model3.ExternalDocs;
 
 public interface Schema extends OpenApiObject<OpenApi3, Schema> {
 
@@ -583,5 +583,4 @@ public interface Schema extends OpenApiObject<OpenApi3, Schema> {
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     void removeExtension(String name);
-
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/SecurityParameter.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/SecurityParameter.java
@@ -1,8 +1,8 @@
 package com.reprezen.kaizen.oasparser.model3;
 
-import com.reprezen.kaizen.oasparser.model3.OpenApiObject;
-import java.util.Collection;
 import javax.annotation.Generated;
+import java.util.Collection;
+import com.reprezen.kaizen.oasparser.model3.OpenApiObject;
 
 public interface SecurityParameter extends OpenApiObject<OpenApi3, SecurityParameter> {
 
@@ -33,5 +33,4 @@ public interface SecurityParameter extends OpenApiObject<OpenApi3, SecurityParam
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     void removeParameter(int index);
-
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/SecurityRequirement.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/SecurityRequirement.java
@@ -1,9 +1,9 @@
 package com.reprezen.kaizen.oasparser.model3;
 
+import javax.annotation.Generated;
+import java.util.Map;
 import com.reprezen.kaizen.oasparser.model3.OpenApiObject;
 import com.reprezen.kaizen.oasparser.model3.SecurityParameter;
-import java.util.Map;
-import javax.annotation.Generated;
 
 public interface SecurityRequirement extends OpenApiObject<OpenApi3, SecurityRequirement> {
 
@@ -28,5 +28,4 @@ public interface SecurityRequirement extends OpenApiObject<OpenApi3, SecurityReq
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     void removeRequirement(String name);
-
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/SecurityScheme.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/SecurityScheme.java
@@ -1,9 +1,9 @@
 package com.reprezen.kaizen.oasparser.model3;
 
+import javax.annotation.Generated;
+import java.util.Map;
 import com.reprezen.kaizen.oasparser.model3.OAuthFlow;
 import com.reprezen.kaizen.oasparser.model3.OpenApiObject;
-import java.util.Map;
-import javax.annotation.Generated;
 
 public interface SecurityScheme extends OpenApiObject<OpenApi3, SecurityScheme> {
 
@@ -160,5 +160,4 @@ public interface SecurityScheme extends OpenApiObject<OpenApi3, SecurityScheme> 
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     void removeExtension(String name);
-
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Server.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Server.java
@@ -1,9 +1,9 @@
 package com.reprezen.kaizen.oasparser.model3;
 
-import com.reprezen.kaizen.oasparser.model3.OpenApiObject;
-import com.reprezen.kaizen.oasparser.model3.ServerVariable;
-import java.util.Map;
 import javax.annotation.Generated;
+import java.util.Map;
+import com.reprezen.kaizen.oasparser.model3.ServerVariable;
+import com.reprezen.kaizen.oasparser.model3.OpenApiObject;
 
 public interface Server extends OpenApiObject<OpenApi3, Server> {
 
@@ -92,5 +92,4 @@ public interface Server extends OpenApiObject<OpenApi3, Server> {
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     void removeExtension(String name);
-
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/ServerVariable.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/ServerVariable.java
@@ -1,9 +1,9 @@
 package com.reprezen.kaizen.oasparser.model3;
 
-import com.reprezen.kaizen.oasparser.model3.OpenApiObject;
+import javax.annotation.Generated;
 import java.util.Collection;
 import java.util.Map;
-import javax.annotation.Generated;
+import com.reprezen.kaizen.oasparser.model3.OpenApiObject;
 
 public interface ServerVariable extends OpenApiObject<OpenApi3, ServerVariable> {
 
@@ -76,5 +76,4 @@ public interface ServerVariable extends OpenApiObject<OpenApi3, ServerVariable> 
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     void removeExtension(String name);
-
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Tag.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Tag.java
@@ -1,9 +1,9 @@
 package com.reprezen.kaizen.oasparser.model3;
 
-import com.reprezen.kaizen.oasparser.model3.ExternalDocs;
-import com.reprezen.kaizen.oasparser.model3.OpenApiObject;
-import java.util.Map;
 import javax.annotation.Generated;
+import java.util.Map;
+import com.reprezen.kaizen.oasparser.model3.OpenApiObject;
+import com.reprezen.kaizen.oasparser.model3.ExternalDocs;
 
 public interface Tag extends OpenApiObject<OpenApi3, Tag> {
 
@@ -58,5 +58,4 @@ public interface Tag extends OpenApiObject<OpenApi3, Tag> {
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     void removeExtension(String name);
-
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Xml.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Xml.java
@@ -1,8 +1,8 @@
 package com.reprezen.kaizen.oasparser.model3;
 
-import com.reprezen.kaizen.oasparser.model3.OpenApiObject;
-import java.util.Map;
 import javax.annotation.Generated;
+import java.util.Map;
+import com.reprezen.kaizen.oasparser.model3.OpenApiObject;
 
 public interface Xml extends OpenApiObject<OpenApi3, Xml> {
 
@@ -83,5 +83,4 @@ public interface Xml extends OpenApiObject<OpenApi3, Xml> {
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     void removeExtension(String name);
-
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/CallbackImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/CallbackImpl.java
@@ -1,32 +1,32 @@
 package com.reprezen.kaizen.oasparser.ovl3;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ChildMapOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ObjectOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.OverlayFactory;
+import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ChildMapOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ReferenceRegistry;
-import com.reprezen.kaizen.oasparser.model3.Callback;
-import com.reprezen.kaizen.oasparser.model3.OpenApi3;
 import com.reprezen.kaizen.oasparser.model3.Path;
-import com.reprezen.kaizen.oasparser.ovl3.OpenApiObjectImpl;
+import com.reprezen.kaizen.oasparser.model3.OpenApi3;
 import com.reprezen.kaizen.oasparser.ovl3.PathImpl;
-import java.util.Map;
+import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
+import com.reprezen.kaizen.oasparser.model3.Callback;
 import javax.annotation.Generated;
+import com.reprezen.kaizen.oasparser.ovl3.OpenApiObjectImpl;
+import java.util.Map;
+import com.reprezen.kaizen.oasparser.jsonoverlay.OverlayFactory;
+import com.fasterxml.jackson.databind.JsonNode;
 
 public class CallbackImpl extends OpenApiObjectImpl<OpenApi3, Callback> implements Callback {
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public CallbackImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
         super(json, parent, refReg);
-            super.maybeElaborateChildrenAtCreation();
+        super.maybeElaborateChildrenAtCreation();
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public CallbackImpl(Callback callback, JsonOverlay<?> parent, ReferenceRegistry refReg) {
         super(callback, parent, refReg);
-            super.maybeElaborateChildrenAtCreation();
+        super.maybeElaborateChildrenAtCreation();
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
@@ -125,25 +125,25 @@ public class CallbackImpl extends OpenApiObjectImpl<OpenApi3, Callback> implemen
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     protected void elaborateChildren() {
         callbackPaths = createChildMap("", this, PathImpl.factory, "(?!x-).*");
-            extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
+        extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public static OverlayFactory<Callback, CallbackImpl> factory = new OverlayFactory<Callback, CallbackImpl>() {
-    @Override
-    protected Class<? super CallbackImpl> getOverlayClass() {
-         return CallbackImpl.class;
-    }
 
-    @Override
-    public CallbackImpl _create(Callback callback, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        return new CallbackImpl(callback, parent, refReg);
-    }
+        @Override
+        protected Class<? super CallbackImpl> getOverlayClass() {
+            return CallbackImpl.class;
+        }
 
-    @Override
-    public CallbackImpl _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        return new CallbackImpl(json, parent, refReg);
-    }
-};
+        @Override
+        public CallbackImpl _create(Callback callback, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+            return new CallbackImpl(callback, parent, refReg);
+        }
 
+        @Override
+        public CallbackImpl _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+            return new CallbackImpl(json, parent, refReg);
+        }
+    };
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ContactImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ContactImpl.java
@@ -1,35 +1,35 @@
 package com.reprezen.kaizen.oasparser.ovl3;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ChildListOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ChildMapOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ChildOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ListOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ObjectOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.OverlayFactory;
+import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ChildMapOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ChildListOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ReferenceRegistry;
-import com.reprezen.kaizen.oasparser.jsonoverlay.StringOverlay;
-import com.reprezen.kaizen.oasparser.model3.Contact;
-import com.reprezen.kaizen.oasparser.model3.OpenApi3;
-import com.reprezen.kaizen.oasparser.ovl3.OpenApiObjectImpl;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ListOverlay;
 import java.util.Collection;
-import java.util.Map;
+import com.reprezen.kaizen.oasparser.model3.OpenApi3;
+import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ChildOverlay;
 import javax.annotation.Generated;
+import com.reprezen.kaizen.oasparser.ovl3.OpenApiObjectImpl;
+import java.util.Map;
+import com.reprezen.kaizen.oasparser.jsonoverlay.OverlayFactory;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.reprezen.kaizen.oasparser.model3.Contact;
+import com.reprezen.kaizen.oasparser.jsonoverlay.StringOverlay;
 
 public class ContactImpl extends OpenApiObjectImpl<OpenApi3, Contact> implements Contact {
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public ContactImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
         super(json, parent, refReg);
-            super.maybeElaborateChildrenAtCreation();
+        super.maybeElaborateChildrenAtCreation();
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public ContactImpl(Contact contact, JsonOverlay<?> parent, ReferenceRegistry refReg) {
         super(contact, parent, refReg);
-            super.maybeElaborateChildrenAtCreation();
+        super.maybeElaborateChildrenAtCreation();
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
@@ -148,27 +148,27 @@ public class ContactImpl extends OpenApiObjectImpl<OpenApi3, Contact> implements
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     protected void elaborateChildren() {
         name = createChild("name", this, StringOverlay.factory);
-            url = createChild("url", this, StringOverlay.factory);
-            email = createChild("email", this, StringOverlay.factory);
-            extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
+        url = createChild("url", this, StringOverlay.factory);
+        email = createChild("email", this, StringOverlay.factory);
+        extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public static OverlayFactory<Contact, ContactImpl> factory = new OverlayFactory<Contact, ContactImpl>() {
-    @Override
-    protected Class<? super ContactImpl> getOverlayClass() {
-         return ContactImpl.class;
-    }
 
-    @Override
-    public ContactImpl _create(Contact contact, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        return new ContactImpl(contact, parent, refReg);
-    }
+        @Override
+        protected Class<? super ContactImpl> getOverlayClass() {
+            return ContactImpl.class;
+        }
 
-    @Override
-    public ContactImpl _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        return new ContactImpl(json, parent, refReg);
-    }
-};
+        @Override
+        public ContactImpl _create(Contact contact, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+            return new ContactImpl(contact, parent, refReg);
+        }
 
+        @Override
+        public ContactImpl _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+            return new ContactImpl(json, parent, refReg);
+        }
+    };
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/EncodingPropertyImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/EncodingPropertyImpl.java
@@ -1,37 +1,37 @@
 package com.reprezen.kaizen.oasparser.ovl3;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.reprezen.kaizen.oasparser.jsonoverlay.BooleanOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ChildListOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ChildMapOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ChildOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ListOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ObjectOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.OverlayFactory;
-import com.reprezen.kaizen.oasparser.jsonoverlay.Reference;
+import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ChildMapOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ChildListOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ReferenceRegistry;
-import com.reprezen.kaizen.oasparser.jsonoverlay.StringOverlay;
-import com.reprezen.kaizen.oasparser.model3.EncodingProperty;
-import com.reprezen.kaizen.oasparser.model3.OpenApi3;
-import com.reprezen.kaizen.oasparser.ovl3.OpenApiObjectImpl;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ListOverlay;
 import java.util.Collection;
-import java.util.Map;
+import com.reprezen.kaizen.oasparser.model3.OpenApi3;
+import com.reprezen.kaizen.oasparser.jsonoverlay.Reference;
+import com.reprezen.kaizen.oasparser.jsonoverlay.BooleanOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ChildOverlay;
 import javax.annotation.Generated;
+import com.reprezen.kaizen.oasparser.ovl3.OpenApiObjectImpl;
+import java.util.Map;
+import com.reprezen.kaizen.oasparser.jsonoverlay.OverlayFactory;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.reprezen.kaizen.oasparser.model3.EncodingProperty;
+import com.reprezen.kaizen.oasparser.jsonoverlay.StringOverlay;
 
 public class EncodingPropertyImpl extends OpenApiObjectImpl<OpenApi3, EncodingProperty> implements EncodingProperty {
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public EncodingPropertyImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
         super(json, parent, refReg);
-            super.maybeElaborateChildrenAtCreation();
+        super.maybeElaborateChildrenAtCreation();
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public EncodingPropertyImpl(EncodingProperty encodingProperty, JsonOverlay<?> parent, ReferenceRegistry refReg) {
         super(encodingProperty, parent, refReg);
-            super.maybeElaborateChildrenAtCreation();
+        super.maybeElaborateChildrenAtCreation();
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
@@ -115,14 +115,14 @@ public class EncodingPropertyImpl extends OpenApiObjectImpl<OpenApi3, EncodingPr
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public boolean isHeaderReference(String key) {
         ChildOverlay<String, StringOverlay> child = headers.getChild(key);
-            return child != null ? child.isReference() : false;
+        return child != null ? child.isReference() : false;
     }
 
     @Override
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public Reference getHeaderReference(String key) {
         ChildOverlay<String, StringOverlay> child = headers.getChild(key);
-            return child != null ? child.getReference() : null;
+        return child != null ? child.getReference() : null;
     }
 
     // Style
@@ -216,29 +216,29 @@ public class EncodingPropertyImpl extends OpenApiObjectImpl<OpenApi3, EncodingPr
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     protected void elaborateChildren() {
         contentType = createChild("contentType", this, StringOverlay.factory);
-            headers = createChildMap("headers", this, StringOverlay.factory, null);
-            refables.put("headers", headers);
-            style = createChild("style", this, StringOverlay.factory);
-            explode = createChild("explode", this, BooleanOverlay.factory);
-            extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
+        headers = createChildMap("headers", this, StringOverlay.factory, null);
+        refables.put("headers", headers);
+        style = createChild("style", this, StringOverlay.factory);
+        explode = createChild("explode", this, BooleanOverlay.factory);
+        extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public static OverlayFactory<EncodingProperty, EncodingPropertyImpl> factory = new OverlayFactory<EncodingProperty, EncodingPropertyImpl>() {
-    @Override
-    protected Class<? super EncodingPropertyImpl> getOverlayClass() {
-         return EncodingPropertyImpl.class;
-    }
 
-    @Override
-    public EncodingPropertyImpl _create(EncodingProperty encodingProperty, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        return new EncodingPropertyImpl(encodingProperty, parent, refReg);
-    }
+        @Override
+        protected Class<? super EncodingPropertyImpl> getOverlayClass() {
+            return EncodingPropertyImpl.class;
+        }
 
-    @Override
-    public EncodingPropertyImpl _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        return new EncodingPropertyImpl(json, parent, refReg);
-    }
-};
+        @Override
+        public EncodingPropertyImpl _create(EncodingProperty encodingProperty, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+            return new EncodingPropertyImpl(encodingProperty, parent, refReg);
+        }
 
+        @Override
+        public EncodingPropertyImpl _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+            return new EncodingPropertyImpl(json, parent, refReg);
+        }
+    };
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ExampleImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ExampleImpl.java
@@ -1,35 +1,35 @@
 package com.reprezen.kaizen.oasparser.ovl3;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ChildListOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ChildMapOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ChildOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ListOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ObjectOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.OverlayFactory;
+import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ChildMapOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ChildListOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ReferenceRegistry;
-import com.reprezen.kaizen.oasparser.jsonoverlay.StringOverlay;
-import com.reprezen.kaizen.oasparser.model3.Example;
-import com.reprezen.kaizen.oasparser.model3.OpenApi3;
-import com.reprezen.kaizen.oasparser.ovl3.OpenApiObjectImpl;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ListOverlay;
 import java.util.Collection;
-import java.util.Map;
+import com.reprezen.kaizen.oasparser.model3.OpenApi3;
+import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ChildOverlay;
 import javax.annotation.Generated;
+import com.reprezen.kaizen.oasparser.ovl3.OpenApiObjectImpl;
+import com.reprezen.kaizen.oasparser.model3.Example;
+import java.util.Map;
+import com.reprezen.kaizen.oasparser.jsonoverlay.OverlayFactory;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.reprezen.kaizen.oasparser.jsonoverlay.StringOverlay;
 
 public class ExampleImpl extends OpenApiObjectImpl<OpenApi3, Example> implements Example {
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public ExampleImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
         super(json, parent, refReg);
-            super.maybeElaborateChildrenAtCreation();
+        super.maybeElaborateChildrenAtCreation();
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public ExampleImpl(Example example, JsonOverlay<?> parent, ReferenceRegistry refReg) {
         super(example, parent, refReg);
-            super.maybeElaborateChildrenAtCreation();
+        super.maybeElaborateChildrenAtCreation();
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
@@ -170,28 +170,28 @@ public class ExampleImpl extends OpenApiObjectImpl<OpenApi3, Example> implements
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     protected void elaborateChildren() {
         summary = createChild("summary", this, StringOverlay.factory);
-            description = createChild("description", this, StringOverlay.factory);
-            value = createChild("value", this, ObjectOverlay.factory);
-            externalValue = createChild("externalValue", this, StringOverlay.factory);
-            extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
+        description = createChild("description", this, StringOverlay.factory);
+        value = createChild("value", this, ObjectOverlay.factory);
+        externalValue = createChild("externalValue", this, StringOverlay.factory);
+        extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public static OverlayFactory<Example, ExampleImpl> factory = new OverlayFactory<Example, ExampleImpl>() {
-    @Override
-    protected Class<? super ExampleImpl> getOverlayClass() {
-         return ExampleImpl.class;
-    }
 
-    @Override
-    public ExampleImpl _create(Example example, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        return new ExampleImpl(example, parent, refReg);
-    }
+        @Override
+        protected Class<? super ExampleImpl> getOverlayClass() {
+            return ExampleImpl.class;
+        }
 
-    @Override
-    public ExampleImpl _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        return new ExampleImpl(json, parent, refReg);
-    }
-};
+        @Override
+        public ExampleImpl _create(Example example, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+            return new ExampleImpl(example, parent, refReg);
+        }
 
+        @Override
+        public ExampleImpl _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+            return new ExampleImpl(json, parent, refReg);
+        }
+    };
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ExternalDocsImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ExternalDocsImpl.java
@@ -1,35 +1,35 @@
 package com.reprezen.kaizen.oasparser.ovl3;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ChildListOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ChildMapOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ChildOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ListOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ObjectOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.OverlayFactory;
+import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ChildMapOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ChildListOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ReferenceRegistry;
-import com.reprezen.kaizen.oasparser.jsonoverlay.StringOverlay;
-import com.reprezen.kaizen.oasparser.model3.ExternalDocs;
-import com.reprezen.kaizen.oasparser.model3.OpenApi3;
-import com.reprezen.kaizen.oasparser.ovl3.OpenApiObjectImpl;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ListOverlay;
 import java.util.Collection;
-import java.util.Map;
+import com.reprezen.kaizen.oasparser.model3.OpenApi3;
+import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ChildOverlay;
 import javax.annotation.Generated;
+import com.reprezen.kaizen.oasparser.ovl3.OpenApiObjectImpl;
+import java.util.Map;
+import com.reprezen.kaizen.oasparser.jsonoverlay.OverlayFactory;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.reprezen.kaizen.oasparser.model3.ExternalDocs;
+import com.reprezen.kaizen.oasparser.jsonoverlay.StringOverlay;
 
 public class ExternalDocsImpl extends OpenApiObjectImpl<OpenApi3, ExternalDocs> implements ExternalDocs {
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public ExternalDocsImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
         super(json, parent, refReg);
-            super.maybeElaborateChildrenAtCreation();
+        super.maybeElaborateChildrenAtCreation();
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public ExternalDocsImpl(ExternalDocs externalDocs, JsonOverlay<?> parent, ReferenceRegistry refReg) {
         super(externalDocs, parent, refReg);
-            super.maybeElaborateChildrenAtCreation();
+        super.maybeElaborateChildrenAtCreation();
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
@@ -126,26 +126,26 @@ public class ExternalDocsImpl extends OpenApiObjectImpl<OpenApi3, ExternalDocs> 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     protected void elaborateChildren() {
         description = createChild("description", this, StringOverlay.factory);
-            url = createChild("url", this, StringOverlay.factory);
-            extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
+        url = createChild("url", this, StringOverlay.factory);
+        extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public static OverlayFactory<ExternalDocs, ExternalDocsImpl> factory = new OverlayFactory<ExternalDocs, ExternalDocsImpl>() {
-    @Override
-    protected Class<? super ExternalDocsImpl> getOverlayClass() {
-         return ExternalDocsImpl.class;
-    }
 
-    @Override
-    public ExternalDocsImpl _create(ExternalDocs externalDocs, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        return new ExternalDocsImpl(externalDocs, parent, refReg);
-    }
+        @Override
+        protected Class<? super ExternalDocsImpl> getOverlayClass() {
+            return ExternalDocsImpl.class;
+        }
 
-    @Override
-    public ExternalDocsImpl _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        return new ExternalDocsImpl(json, parent, refReg);
-    }
-};
+        @Override
+        public ExternalDocsImpl _create(ExternalDocs externalDocs, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+            return new ExternalDocsImpl(externalDocs, parent, refReg);
+        }
 
+        @Override
+        public ExternalDocsImpl _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+            return new ExternalDocsImpl(json, parent, refReg);
+        }
+    };
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/HeaderImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/HeaderImpl.java
@@ -1,43 +1,43 @@
 package com.reprezen.kaizen.oasparser.ovl3;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.reprezen.kaizen.oasparser.jsonoverlay.BooleanOverlay;
+import com.reprezen.kaizen.oasparser.model3.Schema;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ChildListOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ChildMapOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ChildOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ListOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ObjectOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.OverlayFactory;
-import com.reprezen.kaizen.oasparser.jsonoverlay.Reference;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ReferenceRegistry;
-import com.reprezen.kaizen.oasparser.jsonoverlay.StringOverlay;
-import com.reprezen.kaizen.oasparser.model3.Example;
-import com.reprezen.kaizen.oasparser.model3.Header;
-import com.reprezen.kaizen.oasparser.model3.MediaType;
 import com.reprezen.kaizen.oasparser.model3.OpenApi3;
-import com.reprezen.kaizen.oasparser.model3.Schema;
-import com.reprezen.kaizen.oasparser.ovl3.ExampleImpl;
-import com.reprezen.kaizen.oasparser.ovl3.MediaTypeImpl;
-import com.reprezen.kaizen.oasparser.ovl3.OpenApiObjectImpl;
-import com.reprezen.kaizen.oasparser.ovl3.SchemaImpl;
-import java.util.Collection;
-import java.util.Map;
+import com.reprezen.kaizen.oasparser.jsonoverlay.BooleanOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
 import javax.annotation.Generated;
+import com.reprezen.kaizen.oasparser.ovl3.SchemaImpl;
+import com.reprezen.kaizen.oasparser.model3.Example;
+import java.util.Map;
+import com.reprezen.kaizen.oasparser.jsonoverlay.OverlayFactory;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ObjectOverlay;
+import com.reprezen.kaizen.oasparser.ovl3.MediaTypeImpl;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ListOverlay;
+import com.reprezen.kaizen.oasparser.ovl3.ExampleImpl;
+import java.util.Collection;
+import com.reprezen.kaizen.oasparser.model3.Header;
+import com.reprezen.kaizen.oasparser.jsonoverlay.Reference;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ChildOverlay;
+import com.reprezen.kaizen.oasparser.model3.MediaType;
+import com.reprezen.kaizen.oasparser.ovl3.OpenApiObjectImpl;
+import com.reprezen.kaizen.oasparser.jsonoverlay.StringOverlay;
 
 public class HeaderImpl extends OpenApiObjectImpl<OpenApi3, Header> implements Header {
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public HeaderImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
         super(json, parent, refReg);
-            super.maybeElaborateChildrenAtCreation();
+        super.maybeElaborateChildrenAtCreation();
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public HeaderImpl(Header header, JsonOverlay<?> parent, ReferenceRegistry refReg) {
         super(header, parent, refReg);
-            super.maybeElaborateChildrenAtCreation();
+        super.maybeElaborateChildrenAtCreation();
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
@@ -380,14 +380,14 @@ public class HeaderImpl extends OpenApiObjectImpl<OpenApi3, Header> implements H
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public boolean isExampleReference(String key) {
         ChildOverlay<Example, ExampleImpl> child = examples.getChild(key);
-            return child != null ? child.isReference() : false;
+        return child != null ? child.isReference() : false;
     }
 
     @Override
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public Reference getExampleReference(String key) {
         ChildOverlay<Example, ExampleImpl> child = examples.getChild(key);
-            return child != null ? child.getReference() : null;
+        return child != null ? child.getReference() : null;
     }
 
     // ContentMediaType
@@ -480,39 +480,39 @@ public class HeaderImpl extends OpenApiObjectImpl<OpenApi3, Header> implements H
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     protected void elaborateChildren() {
         name = createChild("name", this, StringOverlay.factory);
-            in = createChild("in", this, StringOverlay.factory);
-            description = createChild("description", this, StringOverlay.factory);
-            required = createChild("required", this, BooleanOverlay.factory);
-            deprecated = createChild("deprecated", this, BooleanOverlay.factory);
-            allowEmptyValue = createChild("allowEmptyValue", this, BooleanOverlay.factory);
-            style = createChild("style", this, StringOverlay.factory);
-            explode = createChild("explode", this, BooleanOverlay.factory);
-            allowReserved = createChild("allowReserved", this, BooleanOverlay.factory);
-            schema = createChild("schema", this, SchemaImpl.factory);
-            refables.put("schema", schema);
-            example = createChild("example", this, ObjectOverlay.factory);
-            examples = createChildMap("examples", this, ExampleImpl.factory, "[a-zA-Z0-9\\._-]+");
-            refables.put("examples", examples);
-            contentMediaTypes = createChildMap("content", this, MediaTypeImpl.factory, null);
-            extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
+        in = createChild("in", this, StringOverlay.factory);
+        description = createChild("description", this, StringOverlay.factory);
+        required = createChild("required", this, BooleanOverlay.factory);
+        deprecated = createChild("deprecated", this, BooleanOverlay.factory);
+        allowEmptyValue = createChild("allowEmptyValue", this, BooleanOverlay.factory);
+        style = createChild("style", this, StringOverlay.factory);
+        explode = createChild("explode", this, BooleanOverlay.factory);
+        allowReserved = createChild("allowReserved", this, BooleanOverlay.factory);
+        schema = createChild("schema", this, SchemaImpl.factory);
+        refables.put("schema", schema);
+        example = createChild("example", this, ObjectOverlay.factory);
+        examples = createChildMap("examples", this, ExampleImpl.factory, "[a-zA-Z0-9\\._-]+");
+        refables.put("examples", examples);
+        contentMediaTypes = createChildMap("content", this, MediaTypeImpl.factory, null);
+        extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public static OverlayFactory<Header, HeaderImpl> factory = new OverlayFactory<Header, HeaderImpl>() {
-    @Override
-    protected Class<? super HeaderImpl> getOverlayClass() {
-         return HeaderImpl.class;
-    }
 
-    @Override
-    public HeaderImpl _create(Header header, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        return new HeaderImpl(header, parent, refReg);
-    }
+        @Override
+        protected Class<? super HeaderImpl> getOverlayClass() {
+            return HeaderImpl.class;
+        }
 
-    @Override
-    public HeaderImpl _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        return new HeaderImpl(json, parent, refReg);
-    }
-};
+        @Override
+        public HeaderImpl _create(Header header, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+            return new HeaderImpl(header, parent, refReg);
+        }
 
+        @Override
+        public HeaderImpl _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+            return new HeaderImpl(json, parent, refReg);
+        }
+    };
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/InfoImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/InfoImpl.java
@@ -1,39 +1,39 @@
 package com.reprezen.kaizen.oasparser.ovl3;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ChildListOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ChildMapOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ChildOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ListOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ObjectOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.OverlayFactory;
+import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ChildMapOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ChildListOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ReferenceRegistry;
-import com.reprezen.kaizen.oasparser.jsonoverlay.StringOverlay;
-import com.reprezen.kaizen.oasparser.model3.Contact;
-import com.reprezen.kaizen.oasparser.model3.Info;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ListOverlay;
 import com.reprezen.kaizen.oasparser.model3.License;
-import com.reprezen.kaizen.oasparser.model3.OpenApi3;
-import com.reprezen.kaizen.oasparser.ovl3.ContactImpl;
-import com.reprezen.kaizen.oasparser.ovl3.LicenseImpl;
-import com.reprezen.kaizen.oasparser.ovl3.OpenApiObjectImpl;
 import java.util.Collection;
-import java.util.Map;
+import com.reprezen.kaizen.oasparser.model3.OpenApi3;
+import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ChildOverlay;
 import javax.annotation.Generated;
+import com.reprezen.kaizen.oasparser.ovl3.ContactImpl;
+import com.reprezen.kaizen.oasparser.ovl3.OpenApiObjectImpl;
+import java.util.Map;
+import com.reprezen.kaizen.oasparser.jsonoverlay.OverlayFactory;
+import com.reprezen.kaizen.oasparser.model3.Info;
+import com.reprezen.kaizen.oasparser.ovl3.LicenseImpl;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.reprezen.kaizen.oasparser.model3.Contact;
+import com.reprezen.kaizen.oasparser.jsonoverlay.StringOverlay;
 
 public class InfoImpl extends OpenApiObjectImpl<OpenApi3, Info> implements Info {
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public InfoImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
         super(json, parent, refReg);
-            super.maybeElaborateChildrenAtCreation();
+        super.maybeElaborateChildrenAtCreation();
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public InfoImpl(Info info, JsonOverlay<?> parent, ReferenceRegistry refReg) {
         super(info, parent, refReg);
-            super.maybeElaborateChildrenAtCreation();
+        super.maybeElaborateChildrenAtCreation();
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
@@ -218,30 +218,30 @@ public class InfoImpl extends OpenApiObjectImpl<OpenApi3, Info> implements Info 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     protected void elaborateChildren() {
         title = createChild("title", this, StringOverlay.factory);
-            description = createChild("description", this, StringOverlay.factory);
-            termsOfService = createChild("termsOfService", this, StringOverlay.factory);
-            contact = createChild("contact", this, ContactImpl.factory);
-            license = createChild("license", this, LicenseImpl.factory);
-            version = createChild("version", this, StringOverlay.factory);
-            extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
+        description = createChild("description", this, StringOverlay.factory);
+        termsOfService = createChild("termsOfService", this, StringOverlay.factory);
+        contact = createChild("contact", this, ContactImpl.factory);
+        license = createChild("license", this, LicenseImpl.factory);
+        version = createChild("version", this, StringOverlay.factory);
+        extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public static OverlayFactory<Info, InfoImpl> factory = new OverlayFactory<Info, InfoImpl>() {
-    @Override
-    protected Class<? super InfoImpl> getOverlayClass() {
-         return InfoImpl.class;
-    }
 
-    @Override
-    public InfoImpl _create(Info info, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        return new InfoImpl(info, parent, refReg);
-    }
+        @Override
+        protected Class<? super InfoImpl> getOverlayClass() {
+            return InfoImpl.class;
+        }
 
-    @Override
-    public InfoImpl _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        return new InfoImpl(json, parent, refReg);
-    }
-};
+        @Override
+        public InfoImpl _create(Info info, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+            return new InfoImpl(info, parent, refReg);
+        }
 
+        @Override
+        public InfoImpl _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+            return new InfoImpl(json, parent, refReg);
+        }
+    };
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/LicenseImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/LicenseImpl.java
@@ -1,22 +1,22 @@
 package com.reprezen.kaizen.oasparser.ovl3;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ChildListOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ChildMapOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ChildOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ListOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ObjectOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.OverlayFactory;
+import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ChildMapOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ChildListOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ReferenceRegistry;
-import com.reprezen.kaizen.oasparser.jsonoverlay.StringOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ListOverlay;
 import com.reprezen.kaizen.oasparser.model3.License;
-import com.reprezen.kaizen.oasparser.model3.OpenApi3;
-import com.reprezen.kaizen.oasparser.ovl3.OpenApiObjectImpl;
 import java.util.Collection;
-import java.util.Map;
+import com.reprezen.kaizen.oasparser.model3.OpenApi3;
+import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ChildOverlay;
 import javax.annotation.Generated;
+import com.reprezen.kaizen.oasparser.ovl3.OpenApiObjectImpl;
+import java.util.Map;
+import com.reprezen.kaizen.oasparser.jsonoverlay.OverlayFactory;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.reprezen.kaizen.oasparser.jsonoverlay.StringOverlay;
 
 public class LicenseImpl extends OpenApiObjectImpl<OpenApi3, License> implements License {
 
@@ -25,13 +25,13 @@ public class LicenseImpl extends OpenApiObjectImpl<OpenApi3, License> implements
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public LicenseImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
         super(json, parent, refReg);
-            super.maybeElaborateChildrenAtCreation();
+        super.maybeElaborateChildrenAtCreation();
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public LicenseImpl(License license, JsonOverlay<?> parent, ReferenceRegistry refReg) {
         super(license, parent, refReg);
-            super.maybeElaborateChildrenAtCreation();
+        super.maybeElaborateChildrenAtCreation();
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
@@ -128,26 +128,26 @@ public class LicenseImpl extends OpenApiObjectImpl<OpenApi3, License> implements
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     protected void elaborateChildren() {
         name = createChild("name", this, StringOverlay.factory);
-            url = createChild("url", this, StringOverlay.factory);
-            extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
+        url = createChild("url", this, StringOverlay.factory);
+        extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public static OverlayFactory<License, LicenseImpl> factory = new OverlayFactory<License, LicenseImpl>() {
-    @Override
-    protected Class<? super LicenseImpl> getOverlayClass() {
-         return LicenseImpl.class;
-    }
 
-    @Override
-    public LicenseImpl _create(License license, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        return new LicenseImpl(license, parent, refReg);
-    }
+        @Override
+        protected Class<? super LicenseImpl> getOverlayClass() {
+            return LicenseImpl.class;
+        }
 
-    @Override
-    public LicenseImpl _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        return new LicenseImpl(json, parent, refReg);
-    }
-};
+        @Override
+        public LicenseImpl _create(License license, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+            return new LicenseImpl(license, parent, refReg);
+        }
 
+        @Override
+        public LicenseImpl _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+            return new LicenseImpl(json, parent, refReg);
+        }
+    };
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/LinkImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/LinkImpl.java
@@ -1,39 +1,39 @@
 package com.reprezen.kaizen.oasparser.ovl3;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ChildListOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ChildMapOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ChildOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ListOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ObjectOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.OverlayFactory;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ReferenceRegistry;
-import com.reprezen.kaizen.oasparser.jsonoverlay.StringOverlay;
-import com.reprezen.kaizen.oasparser.model3.Header;
-import com.reprezen.kaizen.oasparser.model3.Link;
-import com.reprezen.kaizen.oasparser.model3.OpenApi3;
+import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
 import com.reprezen.kaizen.oasparser.model3.Server;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ChildMapOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ChildListOverlay;
 import com.reprezen.kaizen.oasparser.ovl3.HeaderImpl;
-import com.reprezen.kaizen.oasparser.ovl3.OpenApiObjectImpl;
-import com.reprezen.kaizen.oasparser.ovl3.ServerImpl;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ReferenceRegistry;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ListOverlay;
 import java.util.Collection;
-import java.util.Map;
+import com.reprezen.kaizen.oasparser.model3.Header;
+import com.reprezen.kaizen.oasparser.model3.OpenApi3;
+import com.reprezen.kaizen.oasparser.model3.Link;
+import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ChildOverlay;
 import javax.annotation.Generated;
+import com.reprezen.kaizen.oasparser.ovl3.OpenApiObjectImpl;
+import java.util.Map;
+import com.reprezen.kaizen.oasparser.jsonoverlay.OverlayFactory;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.reprezen.kaizen.oasparser.ovl3.ServerImpl;
+import com.reprezen.kaizen.oasparser.jsonoverlay.StringOverlay;
 
 public class LinkImpl extends OpenApiObjectImpl<OpenApi3, Link> implements Link {
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public LinkImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
         super(json, parent, refReg);
-            super.maybeElaborateChildrenAtCreation();
+        super.maybeElaborateChildrenAtCreation();
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public LinkImpl(Link link, JsonOverlay<?> parent, ReferenceRegistry refReg) {
         super(link, parent, refReg);
-            super.maybeElaborateChildrenAtCreation();
+        super.maybeElaborateChildrenAtCreation();
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
@@ -266,30 +266,30 @@ public class LinkImpl extends OpenApiObjectImpl<OpenApi3, Link> implements Link 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     protected void elaborateChildren() {
         operationId = createChild("operationId", this, StringOverlay.factory);
-            operationRef = createChild("operationRef", this, StringOverlay.factory);
-            parameters = createChildMap("parameters", this, StringOverlay.factory, null);
-            headers = createChildMap("headers", this, HeaderImpl.factory, null);
-            description = createChild("description", this, StringOverlay.factory);
-            server = createChild("server", this, ServerImpl.factory);
-            extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
+        operationRef = createChild("operationRef", this, StringOverlay.factory);
+        parameters = createChildMap("parameters", this, StringOverlay.factory, null);
+        headers = createChildMap("headers", this, HeaderImpl.factory, null);
+        description = createChild("description", this, StringOverlay.factory);
+        server = createChild("server", this, ServerImpl.factory);
+        extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public static OverlayFactory<Link, LinkImpl> factory = new OverlayFactory<Link, LinkImpl>() {
-    @Override
-    protected Class<? super LinkImpl> getOverlayClass() {
-         return LinkImpl.class;
-    }
 
-    @Override
-    public LinkImpl _create(Link link, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        return new LinkImpl(link, parent, refReg);
-    }
+        @Override
+        protected Class<? super LinkImpl> getOverlayClass() {
+            return LinkImpl.class;
+        }
 
-    @Override
-    public LinkImpl _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        return new LinkImpl(json, parent, refReg);
-    }
-};
+        @Override
+        public LinkImpl _create(Link link, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+            return new LinkImpl(link, parent, refReg);
+        }
 
+        @Override
+        public LinkImpl _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+            return new LinkImpl(json, parent, refReg);
+        }
+    };
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/MediaTypeImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/MediaTypeImpl.java
@@ -1,41 +1,41 @@
 package com.reprezen.kaizen.oasparser.ovl3;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ChildListOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ChildMapOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ChildOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ListOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ObjectOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.OverlayFactory;
-import com.reprezen.kaizen.oasparser.jsonoverlay.Reference;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ReferenceRegistry;
-import com.reprezen.kaizen.oasparser.model3.EncodingProperty;
-import com.reprezen.kaizen.oasparser.model3.Example;
-import com.reprezen.kaizen.oasparser.model3.MediaType;
-import com.reprezen.kaizen.oasparser.model3.OpenApi3;
 import com.reprezen.kaizen.oasparser.model3.Schema;
-import com.reprezen.kaizen.oasparser.ovl3.EncodingPropertyImpl;
-import com.reprezen.kaizen.oasparser.ovl3.ExampleImpl;
-import com.reprezen.kaizen.oasparser.ovl3.OpenApiObjectImpl;
-import com.reprezen.kaizen.oasparser.ovl3.SchemaImpl;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ObjectOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ChildMapOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ChildListOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ReferenceRegistry;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ListOverlay;
 import java.util.Collection;
-import java.util.Map;
+import com.reprezen.kaizen.oasparser.ovl3.ExampleImpl;
+import com.reprezen.kaizen.oasparser.model3.OpenApi3;
+import com.reprezen.kaizen.oasparser.jsonoverlay.Reference;
+import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
+import com.reprezen.kaizen.oasparser.ovl3.EncodingPropertyImpl;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ChildOverlay;
 import javax.annotation.Generated;
+import com.reprezen.kaizen.oasparser.ovl3.SchemaImpl;
+import com.reprezen.kaizen.oasparser.model3.MediaType;
+import com.reprezen.kaizen.oasparser.ovl3.OpenApiObjectImpl;
+import com.reprezen.kaizen.oasparser.model3.Example;
+import java.util.Map;
+import com.reprezen.kaizen.oasparser.jsonoverlay.OverlayFactory;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.reprezen.kaizen.oasparser.model3.EncodingProperty;
 
 public class MediaTypeImpl extends OpenApiObjectImpl<OpenApi3, MediaType> implements MediaType {
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public MediaTypeImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
         super(json, parent, refReg);
-            super.maybeElaborateChildrenAtCreation();
+        super.maybeElaborateChildrenAtCreation();
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public MediaTypeImpl(MediaType mediaType, JsonOverlay<?> parent, ReferenceRegistry refReg) {
         super(mediaType, parent, refReg);
-            super.maybeElaborateChildrenAtCreation();
+        super.maybeElaborateChildrenAtCreation();
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
@@ -131,14 +131,14 @@ public class MediaTypeImpl extends OpenApiObjectImpl<OpenApi3, MediaType> implem
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public boolean isExampleReference(String key) {
         ChildOverlay<Example, ExampleImpl> child = examples.getChild(key);
-            return child != null ? child.isReference() : false;
+        return child != null ? child.isReference() : false;
     }
 
     @Override
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public Reference getExampleReference(String key) {
         ChildOverlay<Example, ExampleImpl> child = examples.getChild(key);
-            return child != null ? child.getReference() : null;
+        return child != null ? child.getReference() : null;
     }
 
     // Example
@@ -250,30 +250,30 @@ public class MediaTypeImpl extends OpenApiObjectImpl<OpenApi3, MediaType> implem
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     protected void elaborateChildren() {
         schema = createChild("schema", this, SchemaImpl.factory);
-            refables.put("schema", schema);
-            examples = createChildMap("examples", this, ExampleImpl.factory, "[a-zA-Z0-9\\._-]+");
-            refables.put("examples", examples);
-            example = createChild("example", this, ObjectOverlay.factory);
-            encodingProperties = createChildMap("encoding", this, EncodingPropertyImpl.factory, null);
-            extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
+        refables.put("schema", schema);
+        examples = createChildMap("examples", this, ExampleImpl.factory, "[a-zA-Z0-9\\._-]+");
+        refables.put("examples", examples);
+        example = createChild("example", this, ObjectOverlay.factory);
+        encodingProperties = createChildMap("encoding", this, EncodingPropertyImpl.factory, null);
+        extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public static OverlayFactory<MediaType, MediaTypeImpl> factory = new OverlayFactory<MediaType, MediaTypeImpl>() {
-    @Override
-    protected Class<? super MediaTypeImpl> getOverlayClass() {
-         return MediaTypeImpl.class;
-    }
 
-    @Override
-    public MediaTypeImpl _create(MediaType mediaType, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        return new MediaTypeImpl(mediaType, parent, refReg);
-    }
+        @Override
+        protected Class<? super MediaTypeImpl> getOverlayClass() {
+            return MediaTypeImpl.class;
+        }
 
-    @Override
-    public MediaTypeImpl _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        return new MediaTypeImpl(json, parent, refReg);
-    }
-};
+        @Override
+        public MediaTypeImpl _create(MediaType mediaType, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+            return new MediaTypeImpl(mediaType, parent, refReg);
+        }
 
+        @Override
+        public MediaTypeImpl _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+            return new MediaTypeImpl(json, parent, refReg);
+        }
+    };
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/OAuthFlowImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/OAuthFlowImpl.java
@@ -1,35 +1,35 @@
 package com.reprezen.kaizen.oasparser.ovl3;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ChildListOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ChildMapOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ChildOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ListOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ObjectOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.OverlayFactory;
+import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ChildMapOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ChildListOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ReferenceRegistry;
-import com.reprezen.kaizen.oasparser.jsonoverlay.StringOverlay;
-import com.reprezen.kaizen.oasparser.model3.OAuthFlow;
-import com.reprezen.kaizen.oasparser.model3.OpenApi3;
-import com.reprezen.kaizen.oasparser.ovl3.OpenApiObjectImpl;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ListOverlay;
 import java.util.Collection;
-import java.util.Map;
+import com.reprezen.kaizen.oasparser.model3.OpenApi3;
+import com.reprezen.kaizen.oasparser.model3.OAuthFlow;
+import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ChildOverlay;
 import javax.annotation.Generated;
+import com.reprezen.kaizen.oasparser.ovl3.OpenApiObjectImpl;
+import java.util.Map;
+import com.reprezen.kaizen.oasparser.jsonoverlay.OverlayFactory;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.reprezen.kaizen.oasparser.jsonoverlay.StringOverlay;
 
 public class OAuthFlowImpl extends OpenApiObjectImpl<OpenApi3, OAuthFlow> implements OAuthFlow {
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public OAuthFlowImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
         super(json, parent, refReg);
-            super.maybeElaborateChildrenAtCreation();
+        super.maybeElaborateChildrenAtCreation();
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public OAuthFlowImpl(OAuthFlow oAuthFlow, JsonOverlay<?> parent, ReferenceRegistry refReg) {
         super(oAuthFlow, parent, refReg);
-            super.maybeElaborateChildrenAtCreation();
+        super.maybeElaborateChildrenAtCreation();
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
@@ -240,29 +240,29 @@ public class OAuthFlowImpl extends OpenApiObjectImpl<OpenApi3, OAuthFlow> implem
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     protected void elaborateChildren() {
         authorizationUrl = createChild("authorizationUrl", this, StringOverlay.factory);
-            tokenUrl = createChild("tokenUrl", this, StringOverlay.factory);
-            refreshUrl = createChild("refreshUrl", this, StringOverlay.factory);
-            scopes = createChildMap("scopes", this, StringOverlay.factory, "(?!x-).*");
-            scopesExtensions = createChildMap("scopes", this, ObjectOverlay.factory, "x-.+");
-            extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
+        tokenUrl = createChild("tokenUrl", this, StringOverlay.factory);
+        refreshUrl = createChild("refreshUrl", this, StringOverlay.factory);
+        scopes = createChildMap("scopes", this, StringOverlay.factory, "(?!x-).*");
+        scopesExtensions = createChildMap("scopes", this, ObjectOverlay.factory, "x-.+");
+        extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public static OverlayFactory<OAuthFlow, OAuthFlowImpl> factory = new OverlayFactory<OAuthFlow, OAuthFlowImpl>() {
-    @Override
-    protected Class<? super OAuthFlowImpl> getOverlayClass() {
-         return OAuthFlowImpl.class;
-    }
 
-    @Override
-    public OAuthFlowImpl _create(OAuthFlow oAuthFlow, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        return new OAuthFlowImpl(oAuthFlow, parent, refReg);
-    }
+        @Override
+        protected Class<? super OAuthFlowImpl> getOverlayClass() {
+            return OAuthFlowImpl.class;
+        }
 
-    @Override
-    public OAuthFlowImpl _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        return new OAuthFlowImpl(json, parent, refReg);
-    }
-};
+        @Override
+        public OAuthFlowImpl _create(OAuthFlow oAuthFlow, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+            return new OAuthFlowImpl(oAuthFlow, parent, refReg);
+        }
 
+        @Override
+        public OAuthFlowImpl _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+            return new OAuthFlowImpl(json, parent, refReg);
+        }
+    };
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/OpenApi3Impl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/OpenApi3Impl.java
@@ -1,59 +1,59 @@
 package com.reprezen.kaizen.oasparser.ovl3;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.inject.Inject;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ChildListOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ChildMapOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ChildOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ListOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ObjectOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.OverlayFactory;
-import com.reprezen.kaizen.oasparser.jsonoverlay.Reference;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ReferenceRegistry;
-import com.reprezen.kaizen.oasparser.jsonoverlay.StringOverlay;
-import com.reprezen.kaizen.oasparser.model3.Callback;
-import com.reprezen.kaizen.oasparser.model3.Example;
-import com.reprezen.kaizen.oasparser.model3.ExternalDocs;
-import com.reprezen.kaizen.oasparser.model3.Header;
-import com.reprezen.kaizen.oasparser.model3.Info;
-import com.reprezen.kaizen.oasparser.model3.Link;
-import com.reprezen.kaizen.oasparser.model3.OpenApi3;
-import com.reprezen.kaizen.oasparser.model3.Parameter;
-import com.reprezen.kaizen.oasparser.model3.Path;
-import com.reprezen.kaizen.oasparser.model3.RequestBody;
-import com.reprezen.kaizen.oasparser.model3.Response;
-import com.reprezen.kaizen.oasparser.model3.Schema;
-import com.reprezen.kaizen.oasparser.model3.SecurityRequirement;
-import com.reprezen.kaizen.oasparser.model3.SecurityScheme;
-import com.reprezen.kaizen.oasparser.model3.Server;
-import com.reprezen.kaizen.oasparser.model3.Tag;
-import com.reprezen.kaizen.oasparser.ovl3.CallbackImpl;
-import com.reprezen.kaizen.oasparser.ovl3.ExampleImpl;
-import com.reprezen.kaizen.oasparser.ovl3.ExternalDocsImpl;
 import com.reprezen.kaizen.oasparser.ovl3.HeaderImpl;
+import com.reprezen.kaizen.oasparser.ovl3.CallbackImpl;
+import com.google.inject.Inject;
+import com.reprezen.kaizen.oasparser.model3.OpenApi3;
+import com.reprezen.kaizen.oasparser.ovl3.SecuritySchemeImpl;
+import com.reprezen.kaizen.oasparser.ovl3.SecurityRequirementImpl;
+import javax.annotation.Generated;
+import com.reprezen.kaizen.oasparser.model3.Tag;
+import com.reprezen.kaizen.oasparser.model3.Parameter;
+import java.util.Map;
+import com.reprezen.kaizen.oasparser.jsonoverlay.OverlayFactory;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.reprezen.kaizen.oasparser.ovl3.ServerImpl;
+import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ObjectOverlay;
+import com.reprezen.kaizen.oasparser.val.ValidationResults.Severity;
+import java.util.Collection;
+import com.reprezen.kaizen.oasparser.ovl3.ResponseImpl;
+import com.reprezen.kaizen.oasparser.model3.Header;
+import com.reprezen.kaizen.oasparser.ovl3.ExternalDocsImpl;
+import com.reprezen.kaizen.oasparser.val3.OpenApi3Validator;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.reprezen.kaizen.oasparser.ovl3.RequestBodyImpl;
+import com.reprezen.kaizen.oasparser.model3.Schema;
+import com.reprezen.kaizen.oasparser.model3.Server;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ChildMapOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ChildListOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ReferenceRegistry;
 import com.reprezen.kaizen.oasparser.ovl3.InfoImpl;
-import com.reprezen.kaizen.oasparser.ovl3.LinkImpl;
-import com.reprezen.kaizen.oasparser.ovl3.OpenApiObjectImpl;
+import com.reprezen.kaizen.oasparser.ovl3.TagImpl;
 import com.reprezen.kaizen.oasparser.ovl3.ParameterImpl;
 import com.reprezen.kaizen.oasparser.ovl3.PathImpl;
-import com.reprezen.kaizen.oasparser.ovl3.RequestBodyImpl;
-import com.reprezen.kaizen.oasparser.ovl3.ResponseImpl;
-import com.reprezen.kaizen.oasparser.ovl3.SchemaImpl;
-import com.reprezen.kaizen.oasparser.ovl3.SecurityRequirementImpl;
-import com.reprezen.kaizen.oasparser.ovl3.SecuritySchemeImpl;
-import com.reprezen.kaizen.oasparser.ovl3.ServerImpl;
-import com.reprezen.kaizen.oasparser.ovl3.TagImpl;
-import com.reprezen.kaizen.oasparser.val.ValidationResults;
-import com.reprezen.kaizen.oasparser.val.ValidationResults.Severity;
+import com.reprezen.kaizen.oasparser.model3.Link;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
+import com.reprezen.kaizen.oasparser.model3.Callback;
 import com.reprezen.kaizen.oasparser.val.Validator;
-import com.reprezen.kaizen.oasparser.val3.OpenApi3Validator;
-import java.util.Collection;
-import java.util.Map;
-import javax.annotation.Generated;
+import com.reprezen.kaizen.oasparser.model3.Response;
+import com.reprezen.kaizen.oasparser.ovl3.SchemaImpl;
+import com.reprezen.kaizen.oasparser.model3.RequestBody;
+import com.reprezen.kaizen.oasparser.model3.Example;
+import com.reprezen.kaizen.oasparser.model3.Path;
+import com.reprezen.kaizen.oasparser.model3.SecurityRequirement;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ListOverlay;
+import com.reprezen.kaizen.oasparser.ovl3.ExampleImpl;
+import com.reprezen.kaizen.oasparser.jsonoverlay.Reference;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ChildOverlay;
+import com.reprezen.kaizen.oasparser.ovl3.OpenApiObjectImpl;
+import com.reprezen.kaizen.oasparser.val.ValidationResults;
+import com.reprezen.kaizen.oasparser.model3.SecurityScheme;
+import com.reprezen.kaizen.oasparser.model3.Info;
+import com.reprezen.kaizen.oasparser.ovl3.LinkImpl;
+import com.reprezen.kaizen.oasparser.model3.ExternalDocs;
+import com.reprezen.kaizen.oasparser.jsonoverlay.StringOverlay;
 
 public class OpenApi3Impl extends OpenApiObjectImpl<OpenApi3, OpenApi3> implements OpenApi3 {
 
@@ -102,13 +102,13 @@ public class OpenApi3Impl extends OpenApiObjectImpl<OpenApi3, OpenApi3> implemen
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public OpenApi3Impl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
         super(json, parent, refReg);
-            super.maybeElaborateChildrenAtCreation();
+        super.maybeElaborateChildrenAtCreation();
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public OpenApi3Impl(OpenApi3 openApi3, JsonOverlay<?> parent, ReferenceRegistry refReg) {
         super(openApi3, parent, refReg);
-            super.maybeElaborateChildrenAtCreation();
+        super.maybeElaborateChildrenAtCreation();
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
@@ -308,14 +308,14 @@ public class OpenApi3Impl extends OpenApiObjectImpl<OpenApi3, OpenApi3> implemen
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public boolean isPathReference(String key) {
         ChildOverlay<Path, PathImpl> child = paths.getChild(key);
-            return child != null ? child.isReference() : false;
+        return child != null ? child.isReference() : false;
     }
 
     @Override
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public Reference getPathReference(String key) {
         ChildOverlay<Path, PathImpl> child = paths.getChild(key);
-            return child != null ? child.getReference() : null;
+        return child != null ? child.getReference() : null;
     }
 
     // PathsExtension
@@ -408,14 +408,14 @@ public class OpenApi3Impl extends OpenApiObjectImpl<OpenApi3, OpenApi3> implemen
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public boolean isSchemaReference(String key) {
         ChildOverlay<Schema, SchemaImpl> child = schemas.getChild(key);
-            return child != null ? child.isReference() : false;
+        return child != null ? child.isReference() : false;
     }
 
     @Override
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public Reference getSchemaReference(String key) {
         ChildOverlay<Schema, SchemaImpl> child = schemas.getChild(key);
-            return child != null ? child.getReference() : null;
+        return child != null ? child.getReference() : null;
     }
 
     // Response
@@ -465,14 +465,14 @@ public class OpenApi3Impl extends OpenApiObjectImpl<OpenApi3, OpenApi3> implemen
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public boolean isResponseReference(String key) {
         ChildOverlay<Response, ResponseImpl> child = responses.getChild(key);
-            return child != null ? child.isReference() : false;
+        return child != null ? child.isReference() : false;
     }
 
     @Override
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public Reference getResponseReference(String key) {
         ChildOverlay<Response, ResponseImpl> child = responses.getChild(key);
-            return child != null ? child.getReference() : null;
+        return child != null ? child.getReference() : null;
     }
 
     // Parameter
@@ -522,14 +522,14 @@ public class OpenApi3Impl extends OpenApiObjectImpl<OpenApi3, OpenApi3> implemen
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public boolean isParameterReference(String key) {
         ChildOverlay<Parameter, ParameterImpl> child = parameters.getChild(key);
-            return child != null ? child.isReference() : false;
+        return child != null ? child.isReference() : false;
     }
 
     @Override
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public Reference getParameterReference(String key) {
         ChildOverlay<Parameter, ParameterImpl> child = parameters.getChild(key);
-            return child != null ? child.getReference() : null;
+        return child != null ? child.getReference() : null;
     }
 
     // Example
@@ -579,14 +579,14 @@ public class OpenApi3Impl extends OpenApiObjectImpl<OpenApi3, OpenApi3> implemen
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public boolean isExampleReference(String key) {
         ChildOverlay<Example, ExampleImpl> child = examples.getChild(key);
-            return child != null ? child.isReference() : false;
+        return child != null ? child.isReference() : false;
     }
 
     @Override
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public Reference getExampleReference(String key) {
         ChildOverlay<Example, ExampleImpl> child = examples.getChild(key);
-            return child != null ? child.getReference() : null;
+        return child != null ? child.getReference() : null;
     }
 
     // RequestBody
@@ -636,14 +636,14 @@ public class OpenApi3Impl extends OpenApiObjectImpl<OpenApi3, OpenApi3> implemen
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public boolean isRequestBodyReference(String key) {
         ChildOverlay<RequestBody, RequestBodyImpl> child = requestBodies.getChild(key);
-            return child != null ? child.isReference() : false;
+        return child != null ? child.isReference() : false;
     }
 
     @Override
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public Reference getRequestBodyReference(String key) {
         ChildOverlay<RequestBody, RequestBodyImpl> child = requestBodies.getChild(key);
-            return child != null ? child.getReference() : null;
+        return child != null ? child.getReference() : null;
     }
 
     // Header
@@ -693,14 +693,14 @@ public class OpenApi3Impl extends OpenApiObjectImpl<OpenApi3, OpenApi3> implemen
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public boolean isHeaderReference(String key) {
         ChildOverlay<Header, HeaderImpl> child = headers.getChild(key);
-            return child != null ? child.isReference() : false;
+        return child != null ? child.isReference() : false;
     }
 
     @Override
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public Reference getHeaderReference(String key) {
         ChildOverlay<Header, HeaderImpl> child = headers.getChild(key);
-            return child != null ? child.getReference() : null;
+        return child != null ? child.getReference() : null;
     }
 
     // SecurityScheme
@@ -750,14 +750,14 @@ public class OpenApi3Impl extends OpenApiObjectImpl<OpenApi3, OpenApi3> implemen
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public boolean isSecuritySchemeReference(String key) {
         ChildOverlay<SecurityScheme, SecuritySchemeImpl> child = securitySchemes.getChild(key);
-            return child != null ? child.isReference() : false;
+        return child != null ? child.isReference() : false;
     }
 
     @Override
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public Reference getSecuritySchemeReference(String key) {
         ChildOverlay<SecurityScheme, SecuritySchemeImpl> child = securitySchemes.getChild(key);
-            return child != null ? child.getReference() : null;
+        return child != null ? child.getReference() : null;
     }
 
     // Link
@@ -807,14 +807,14 @@ public class OpenApi3Impl extends OpenApiObjectImpl<OpenApi3, OpenApi3> implemen
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public boolean isLinkReference(String key) {
         ChildOverlay<Link, LinkImpl> child = links.getChild(key);
-            return child != null ? child.isReference() : false;
+        return child != null ? child.isReference() : false;
     }
 
     @Override
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public Reference getLinkReference(String key) {
         ChildOverlay<Link, LinkImpl> child = links.getChild(key);
-            return child != null ? child.getReference() : null;
+        return child != null ? child.getReference() : null;
     }
 
     // Callback
@@ -864,14 +864,14 @@ public class OpenApi3Impl extends OpenApiObjectImpl<OpenApi3, OpenApi3> implemen
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public boolean isCallbackReference(String key) {
         ChildOverlay<Callback, CallbackImpl> child = callbacks.getChild(key);
-            return child != null ? child.isReference() : false;
+        return child != null ? child.isReference() : false;
     }
 
     @Override
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public Reference getCallbackReference(String key) {
         ChildOverlay<Callback, CallbackImpl> child = callbacks.getChild(key);
-            return child != null ? child.getReference() : null;
+        return child != null ? child.getReference() : null;
     }
 
     // ComponentsExtension
@@ -1093,52 +1093,52 @@ public class OpenApi3Impl extends OpenApiObjectImpl<OpenApi3, OpenApi3> implemen
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     protected void elaborateChildren() {
         openApi = createChild("openapi", this, StringOverlay.factory);
-            info = createChild("info", this, InfoImpl.factory);
-            servers = createChildList("servers", this, ServerImpl.factory);
-            paths = createChildMap("paths", this, PathImpl.factory, "/.*");
-            refables.put("paths", paths);
-            pathsExtensions = createChildMap("paths", this, ObjectOverlay.factory, "x-.+");
-            schemas = createChildMap("components/schemas", this, SchemaImpl.factory, "[a-zA-Z0-9\\._-]+");
-            refables.put("components/schemas", schemas);
-            responses = createChildMap("components/responses", this, ResponseImpl.factory, "[a-zA-Z0-9\\._-]+");
-            refables.put("components/responses", responses);
-            parameters = createChildMap("components/parameters", this, ParameterImpl.factory, "[a-zA-Z0-9\\._-]+");
-            refables.put("components/parameters", parameters);
-            examples = createChildMap("components/examples", this, ExampleImpl.factory, "[a-zA-Z0-9\\._-]+");
-            refables.put("components/examples", examples);
-            requestBodies = createChildMap("components/requestBodies", this, RequestBodyImpl.factory, "[a-zA-Z0-9\\._-]+");
-            refables.put("components/requestBodies", requestBodies);
-            headers = createChildMap("components/headers", this, HeaderImpl.factory, "[a-zA-Z0-9\\._-]+");
-            refables.put("components/headers", headers);
-            securitySchemes = createChildMap("components/securitySchemes", this, SecuritySchemeImpl.factory, "[a-zA-Z0-9\\._-]+");
-            refables.put("components/securitySchemes", securitySchemes);
-            links = createChildMap("components/links", this, LinkImpl.factory, "[a-zA-Z0-9\\._-]+");
-            refables.put("components/links", links);
-            callbacks = createChildMap("components/callbacks", this, CallbackImpl.factory, "(?!x-)[a-zA-Z0-9\\._-]+");
-            refables.put("components/callbacks", callbacks);
-            componentsExtensions = createChildMap("components", this, ObjectOverlay.factory, "x-.+");
-            securityRequirements = createChildList("security", this, SecurityRequirementImpl.factory);
-            tags = createChildList("tags", this, TagImpl.factory);
-            externalDocs = createChild("externalDocs", this, ExternalDocsImpl.factory);
-            extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
+        info = createChild("info", this, InfoImpl.factory);
+        servers = createChildList("servers", this, ServerImpl.factory);
+        paths = createChildMap("paths", this, PathImpl.factory, "/.*");
+        refables.put("paths", paths);
+        pathsExtensions = createChildMap("paths", this, ObjectOverlay.factory, "x-.+");
+        schemas = createChildMap("components/schemas", this, SchemaImpl.factory, "[a-zA-Z0-9\\._-]+");
+        refables.put("components/schemas", schemas);
+        responses = createChildMap("components/responses", this, ResponseImpl.factory, "[a-zA-Z0-9\\._-]+");
+        refables.put("components/responses", responses);
+        parameters = createChildMap("components/parameters", this, ParameterImpl.factory, "[a-zA-Z0-9\\._-]+");
+        refables.put("components/parameters", parameters);
+        examples = createChildMap("components/examples", this, ExampleImpl.factory, "[a-zA-Z0-9\\._-]+");
+        refables.put("components/examples", examples);
+        requestBodies = createChildMap("components/requestBodies", this, RequestBodyImpl.factory, "[a-zA-Z0-9\\._-]+");
+        refables.put("components/requestBodies", requestBodies);
+        headers = createChildMap("components/headers", this, HeaderImpl.factory, "[a-zA-Z0-9\\._-]+");
+        refables.put("components/headers", headers);
+        securitySchemes = createChildMap("components/securitySchemes", this, SecuritySchemeImpl.factory, "[a-zA-Z0-9\\._-]+");
+        refables.put("components/securitySchemes", securitySchemes);
+        links = createChildMap("components/links", this, LinkImpl.factory, "[a-zA-Z0-9\\._-]+");
+        refables.put("components/links", links);
+        callbacks = createChildMap("components/callbacks", this, CallbackImpl.factory, "(?!x-)[a-zA-Z0-9\\._-]+");
+        refables.put("components/callbacks", callbacks);
+        componentsExtensions = createChildMap("components", this, ObjectOverlay.factory, "x-.+");
+        securityRequirements = createChildList("security", this, SecurityRequirementImpl.factory);
+        tags = createChildList("tags", this, TagImpl.factory);
+        externalDocs = createChild("externalDocs", this, ExternalDocsImpl.factory);
+        extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public static OverlayFactory<OpenApi3, OpenApi3Impl> factory = new OverlayFactory<OpenApi3, OpenApi3Impl>() {
-    @Override
-    protected Class<? super OpenApi3Impl> getOverlayClass() {
-         return OpenApi3Impl.class;
-    }
 
-    @Override
-    public OpenApi3Impl _create(OpenApi3 openApi3, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        return new OpenApi3Impl(openApi3, parent, refReg);
-    }
+        @Override
+        protected Class<? super OpenApi3Impl> getOverlayClass() {
+            return OpenApi3Impl.class;
+        }
 
-    @Override
-    public OpenApi3Impl _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        return new OpenApi3Impl(json, parent, refReg);
-    }
-};
+        @Override
+        public OpenApi3Impl _create(OpenApi3 openApi3, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+            return new OpenApi3Impl(openApi3, parent, refReg);
+        }
 
+        @Override
+        public OpenApi3Impl _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+            return new OpenApi3Impl(json, parent, refReg);
+        }
+    };
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/OperationImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/OperationImpl.java
@@ -1,51 +1,51 @@
 package com.reprezen.kaizen.oasparser.ovl3;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.reprezen.kaizen.oasparser.jsonoverlay.BooleanOverlay;
+import com.reprezen.kaizen.oasparser.model3.Server;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ChildListOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ChildMapOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ChildOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ListOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ObjectOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.OverlayFactory;
-import com.reprezen.kaizen.oasparser.jsonoverlay.Reference;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ReferenceRegistry;
-import com.reprezen.kaizen.oasparser.jsonoverlay.StringOverlay;
-import com.reprezen.kaizen.oasparser.model3.Callback;
-import com.reprezen.kaizen.oasparser.model3.ExternalDocs;
-import com.reprezen.kaizen.oasparser.model3.OpenApi3;
-import com.reprezen.kaizen.oasparser.model3.Operation;
-import com.reprezen.kaizen.oasparser.model3.Parameter;
-import com.reprezen.kaizen.oasparser.model3.RequestBody;
-import com.reprezen.kaizen.oasparser.model3.Response;
-import com.reprezen.kaizen.oasparser.model3.SecurityRequirement;
-import com.reprezen.kaizen.oasparser.model3.Server;
 import com.reprezen.kaizen.oasparser.ovl3.CallbackImpl;
-import com.reprezen.kaizen.oasparser.ovl3.ExternalDocsImpl;
-import com.reprezen.kaizen.oasparser.ovl3.OpenApiObjectImpl;
+import com.reprezen.kaizen.oasparser.model3.OpenApi3;
 import com.reprezen.kaizen.oasparser.ovl3.ParameterImpl;
-import com.reprezen.kaizen.oasparser.ovl3.RequestBodyImpl;
-import com.reprezen.kaizen.oasparser.ovl3.ResponseImpl;
+import com.reprezen.kaizen.oasparser.jsonoverlay.BooleanOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
 import com.reprezen.kaizen.oasparser.ovl3.SecurityRequirementImpl;
-import com.reprezen.kaizen.oasparser.ovl3.ServerImpl;
-import java.util.Collection;
-import java.util.Map;
+import com.reprezen.kaizen.oasparser.model3.Callback;
 import javax.annotation.Generated;
+import com.reprezen.kaizen.oasparser.model3.Response;
+import com.reprezen.kaizen.oasparser.model3.RequestBody;
+import com.reprezen.kaizen.oasparser.model3.Parameter;
+import java.util.Map;
+import com.reprezen.kaizen.oasparser.jsonoverlay.OverlayFactory;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.reprezen.kaizen.oasparser.ovl3.ServerImpl;
+import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ObjectOverlay;
+import com.reprezen.kaizen.oasparser.model3.SecurityRequirement;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ListOverlay;
+import java.util.Collection;
+import com.reprezen.kaizen.oasparser.ovl3.ResponseImpl;
+import com.reprezen.kaizen.oasparser.jsonoverlay.Reference;
+import com.reprezen.kaizen.oasparser.ovl3.ExternalDocsImpl;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ChildOverlay;
+import com.reprezen.kaizen.oasparser.model3.Operation;
+import com.reprezen.kaizen.oasparser.ovl3.OpenApiObjectImpl;
+import com.reprezen.kaizen.oasparser.ovl3.RequestBodyImpl;
+import com.reprezen.kaizen.oasparser.model3.ExternalDocs;
+import com.reprezen.kaizen.oasparser.jsonoverlay.StringOverlay;
 
 public class OperationImpl extends OpenApiObjectImpl<OpenApi3, Operation> implements Operation {
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public OperationImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
         super(json, parent, refReg);
-            super.maybeElaborateChildrenAtCreation();
+        super.maybeElaborateChildrenAtCreation();
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public OperationImpl(Operation operation, JsonOverlay<?> parent, ReferenceRegistry refReg) {
         super(operation, parent, refReg);
-            super.maybeElaborateChildrenAtCreation();
+        super.maybeElaborateChildrenAtCreation();
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
@@ -369,14 +369,14 @@ public class OperationImpl extends OpenApiObjectImpl<OpenApi3, Operation> implem
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public boolean isResponseReference(String key) {
         ChildOverlay<Response, ResponseImpl> child = responses.getChild(key);
-            return child != null ? child.isReference() : false;
+        return child != null ? child.isReference() : false;
     }
 
     @Override
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public Reference getResponseReference(String key) {
         ChildOverlay<Response, ResponseImpl> child = responses.getChild(key);
-            return child != null ? child.getReference() : null;
+        return child != null ? child.getReference() : null;
     }
 
     // ResponsesExtension
@@ -469,14 +469,14 @@ public class OperationImpl extends OpenApiObjectImpl<OpenApi3, Operation> implem
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public boolean isCallbackReference(String key) {
         ChildOverlay<Callback, CallbackImpl> child = callbacks.getChild(key);
-            return child != null ? child.isReference() : false;
+        return child != null ? child.isReference() : false;
     }
 
     @Override
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public Reference getCallbackReference(String key) {
         ChildOverlay<Callback, CallbackImpl> child = callbacks.getChild(key);
-            return child != null ? child.getReference() : null;
+        return child != null ? child.getReference() : null;
     }
 
     // CallbacksExtension
@@ -704,42 +704,42 @@ public class OperationImpl extends OpenApiObjectImpl<OpenApi3, Operation> implem
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     protected void elaborateChildren() {
         tags = createChildList("tags", this, StringOverlay.factory);
-            summary = createChild("summary", this, StringOverlay.factory);
-            description = createChild("description", this, StringOverlay.factory);
-            externalDocs = createChild("externalDocs", this, ExternalDocsImpl.factory);
-            operationId = createChild("operationId", this, StringOverlay.factory);
-            parameters = createChildList("parameters", this, ParameterImpl.factory);
-            refables.put("parameters", parameters);
-            requestBody = createChild("requestBody", this, RequestBodyImpl.factory);
-            refables.put("requestBody", requestBody);
-            responses = createChildMap("responses", this, ResponseImpl.factory, "default|(\\d\\d\\d)");
-            refables.put("responses", responses);
-            responsesExtensions = createChildMap("responses", this, ObjectOverlay.factory, "x-.+");
-            callbacks = createChildMap("callbacks", this, CallbackImpl.factory, "(?!x-)[a-zA-Z0-9\\._-]+");
-            refables.put("callbacks", callbacks);
-            callbacksExtensions = createChildMap("callbacks", this, ObjectOverlay.factory, "x-.+");
-            deprecated = createChild("deprecated", this, BooleanOverlay.factory);
-            securityRequirements = createChildList("security", this, SecurityRequirementImpl.factory);
-            servers = createChildList("servers", this, ServerImpl.factory);
-            extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
+        summary = createChild("summary", this, StringOverlay.factory);
+        description = createChild("description", this, StringOverlay.factory);
+        externalDocs = createChild("externalDocs", this, ExternalDocsImpl.factory);
+        operationId = createChild("operationId", this, StringOverlay.factory);
+        parameters = createChildList("parameters", this, ParameterImpl.factory);
+        refables.put("parameters", parameters);
+        requestBody = createChild("requestBody", this, RequestBodyImpl.factory);
+        refables.put("requestBody", requestBody);
+        responses = createChildMap("responses", this, ResponseImpl.factory, "default|(\\d\\d\\d)");
+        refables.put("responses", responses);
+        responsesExtensions = createChildMap("responses", this, ObjectOverlay.factory, "x-.+");
+        callbacks = createChildMap("callbacks", this, CallbackImpl.factory, "(?!x-)[a-zA-Z0-9\\._-]+");
+        refables.put("callbacks", callbacks);
+        callbacksExtensions = createChildMap("callbacks", this, ObjectOverlay.factory, "x-.+");
+        deprecated = createChild("deprecated", this, BooleanOverlay.factory);
+        securityRequirements = createChildList("security", this, SecurityRequirementImpl.factory);
+        servers = createChildList("servers", this, ServerImpl.factory);
+        extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public static OverlayFactory<Operation, OperationImpl> factory = new OverlayFactory<Operation, OperationImpl>() {
-    @Override
-    protected Class<? super OperationImpl> getOverlayClass() {
-         return OperationImpl.class;
-    }
 
-    @Override
-    public OperationImpl _create(Operation operation, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        return new OperationImpl(operation, parent, refReg);
-    }
+        @Override
+        protected Class<? super OperationImpl> getOverlayClass() {
+            return OperationImpl.class;
+        }
 
-    @Override
-    public OperationImpl _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        return new OperationImpl(json, parent, refReg);
-    }
-};
+        @Override
+        public OperationImpl _create(Operation operation, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+            return new OperationImpl(operation, parent, refReg);
+        }
 
+        @Override
+        public OperationImpl _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+            return new OperationImpl(json, parent, refReg);
+        }
+    };
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ParameterImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ParameterImpl.java
@@ -1,43 +1,43 @@
 package com.reprezen.kaizen.oasparser.ovl3;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.reprezen.kaizen.oasparser.jsonoverlay.BooleanOverlay;
+import com.reprezen.kaizen.oasparser.model3.Schema;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ChildListOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ChildMapOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ChildOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ListOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ObjectOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.OverlayFactory;
-import com.reprezen.kaizen.oasparser.jsonoverlay.Reference;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ReferenceRegistry;
-import com.reprezen.kaizen.oasparser.jsonoverlay.StringOverlay;
-import com.reprezen.kaizen.oasparser.model3.Example;
-import com.reprezen.kaizen.oasparser.model3.MediaType;
 import com.reprezen.kaizen.oasparser.model3.OpenApi3;
-import com.reprezen.kaizen.oasparser.model3.Parameter;
-import com.reprezen.kaizen.oasparser.model3.Schema;
-import com.reprezen.kaizen.oasparser.ovl3.ExampleImpl;
-import com.reprezen.kaizen.oasparser.ovl3.MediaTypeImpl;
-import com.reprezen.kaizen.oasparser.ovl3.OpenApiObjectImpl;
-import com.reprezen.kaizen.oasparser.ovl3.SchemaImpl;
-import java.util.Collection;
-import java.util.Map;
+import com.reprezen.kaizen.oasparser.jsonoverlay.BooleanOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
 import javax.annotation.Generated;
+import com.reprezen.kaizen.oasparser.ovl3.SchemaImpl;
+import com.reprezen.kaizen.oasparser.model3.Parameter;
+import com.reprezen.kaizen.oasparser.model3.Example;
+import java.util.Map;
+import com.reprezen.kaizen.oasparser.jsonoverlay.OverlayFactory;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ObjectOverlay;
+import com.reprezen.kaizen.oasparser.ovl3.MediaTypeImpl;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ListOverlay;
+import com.reprezen.kaizen.oasparser.ovl3.ExampleImpl;
+import java.util.Collection;
+import com.reprezen.kaizen.oasparser.jsonoverlay.Reference;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ChildOverlay;
+import com.reprezen.kaizen.oasparser.model3.MediaType;
+import com.reprezen.kaizen.oasparser.ovl3.OpenApiObjectImpl;
+import com.reprezen.kaizen.oasparser.jsonoverlay.StringOverlay;
 
 public class ParameterImpl extends OpenApiObjectImpl<OpenApi3, Parameter> implements Parameter {
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public ParameterImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
         super(json, parent, refReg);
-            super.maybeElaborateChildrenAtCreation();
+        super.maybeElaborateChildrenAtCreation();
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public ParameterImpl(Parameter parameter, JsonOverlay<?> parent, ReferenceRegistry refReg) {
         super(parameter, parent, refReg);
-            super.maybeElaborateChildrenAtCreation();
+        super.maybeElaborateChildrenAtCreation();
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
@@ -380,14 +380,14 @@ public class ParameterImpl extends OpenApiObjectImpl<OpenApi3, Parameter> implem
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public boolean isExampleReference(String key) {
         ChildOverlay<Example, ExampleImpl> child = examples.getChild(key);
-            return child != null ? child.isReference() : false;
+        return child != null ? child.isReference() : false;
     }
 
     @Override
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public Reference getExampleReference(String key) {
         ChildOverlay<Example, ExampleImpl> child = examples.getChild(key);
-            return child != null ? child.getReference() : null;
+        return child != null ? child.getReference() : null;
     }
 
     // ContentMediaType
@@ -480,39 +480,39 @@ public class ParameterImpl extends OpenApiObjectImpl<OpenApi3, Parameter> implem
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     protected void elaborateChildren() {
         name = createChild("name", this, StringOverlay.factory);
-            in = createChild("in", this, StringOverlay.factory);
-            description = createChild("description", this, StringOverlay.factory);
-            required = createChild("required", this, BooleanOverlay.factory);
-            deprecated = createChild("deprecated", this, BooleanOverlay.factory);
-            allowEmptyValue = createChild("allowEmptyValue", this, BooleanOverlay.factory);
-            style = createChild("style", this, StringOverlay.factory);
-            explode = createChild("explode", this, BooleanOverlay.factory);
-            allowReserved = createChild("allowReserved", this, BooleanOverlay.factory);
-            schema = createChild("schema", this, SchemaImpl.factory);
-            refables.put("schema", schema);
-            example = createChild("example", this, ObjectOverlay.factory);
-            examples = createChildMap("examples", this, ExampleImpl.factory, "[a-zA-Z0-9\\._-]+");
-            refables.put("examples", examples);
-            contentMediaTypes = createChildMap("content", this, MediaTypeImpl.factory, null);
-            extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
+        in = createChild("in", this, StringOverlay.factory);
+        description = createChild("description", this, StringOverlay.factory);
+        required = createChild("required", this, BooleanOverlay.factory);
+        deprecated = createChild("deprecated", this, BooleanOverlay.factory);
+        allowEmptyValue = createChild("allowEmptyValue", this, BooleanOverlay.factory);
+        style = createChild("style", this, StringOverlay.factory);
+        explode = createChild("explode", this, BooleanOverlay.factory);
+        allowReserved = createChild("allowReserved", this, BooleanOverlay.factory);
+        schema = createChild("schema", this, SchemaImpl.factory);
+        refables.put("schema", schema);
+        example = createChild("example", this, ObjectOverlay.factory);
+        examples = createChildMap("examples", this, ExampleImpl.factory, "[a-zA-Z0-9\\._-]+");
+        refables.put("examples", examples);
+        contentMediaTypes = createChildMap("content", this, MediaTypeImpl.factory, null);
+        extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public static OverlayFactory<Parameter, ParameterImpl> factory = new OverlayFactory<Parameter, ParameterImpl>() {
-    @Override
-    protected Class<? super ParameterImpl> getOverlayClass() {
-         return ParameterImpl.class;
-    }
 
-    @Override
-    public ParameterImpl _create(Parameter parameter, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        return new ParameterImpl(parameter, parent, refReg);
-    }
+        @Override
+        protected Class<? super ParameterImpl> getOverlayClass() {
+            return ParameterImpl.class;
+        }
 
-    @Override
-    public ParameterImpl _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        return new ParameterImpl(json, parent, refReg);
-    }
-};
+        @Override
+        public ParameterImpl _create(Parameter parameter, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+            return new ParameterImpl(parameter, parent, refReg);
+        }
 
+        @Override
+        public ParameterImpl _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+            return new ParameterImpl(json, parent, refReg);
+        }
+    };
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/PathImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/PathImpl.java
@@ -1,29 +1,29 @@
 package com.reprezen.kaizen.oasparser.ovl3;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ObjectOverlay;
+import com.reprezen.kaizen.oasparser.model3.Server;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ChildListOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ChildMapOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ChildOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ListOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ObjectOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.OverlayFactory;
-import com.reprezen.kaizen.oasparser.jsonoverlay.Reference;
+import com.reprezen.kaizen.oasparser.ovl3.OperationImpl;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ReferenceRegistry;
-import com.reprezen.kaizen.oasparser.jsonoverlay.StringOverlay;
+import com.reprezen.kaizen.oasparser.model3.Path;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ListOverlay;
+import java.util.Collection;
 import com.reprezen.kaizen.oasparser.model3.OpenApi3;
+import com.reprezen.kaizen.oasparser.ovl3.ParameterImpl;
+import com.reprezen.kaizen.oasparser.jsonoverlay.Reference;
+import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ChildOverlay;
+import javax.annotation.Generated;
 import com.reprezen.kaizen.oasparser.model3.Operation;
 import com.reprezen.kaizen.oasparser.model3.Parameter;
-import com.reprezen.kaizen.oasparser.model3.Path;
-import com.reprezen.kaizen.oasparser.model3.Server;
 import com.reprezen.kaizen.oasparser.ovl3.OpenApiObjectImpl;
-import com.reprezen.kaizen.oasparser.ovl3.OperationImpl;
-import com.reprezen.kaizen.oasparser.ovl3.ParameterImpl;
-import com.reprezen.kaizen.oasparser.ovl3.ServerImpl;
-import java.util.Collection;
 import java.util.Map;
-import javax.annotation.Generated;
+import com.reprezen.kaizen.oasparser.jsonoverlay.OverlayFactory;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.reprezen.kaizen.oasparser.ovl3.ServerImpl;
+import com.reprezen.kaizen.oasparser.jsonoverlay.StringOverlay;
 
 public class PathImpl extends OpenApiObjectImpl<OpenApi3, Path> implements Path {
 
@@ -150,13 +150,13 @@ public class PathImpl extends OpenApiObjectImpl<OpenApi3, Path> implements Path 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public PathImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
         super(json, parent, refReg);
-            super.maybeElaborateChildrenAtCreation();
+        super.maybeElaborateChildrenAtCreation();
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public PathImpl(Path path, JsonOverlay<?> parent, ReferenceRegistry refReg) {
         super(path, parent, refReg);
-            super.maybeElaborateChildrenAtCreation();
+        super.maybeElaborateChildrenAtCreation();
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
@@ -427,30 +427,30 @@ public class PathImpl extends OpenApiObjectImpl<OpenApi3, Path> implements Path 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     protected void elaborateChildren() {
         summary = createChild("summary", this, StringOverlay.factory);
-            description = createChild("description", this, StringOverlay.factory);
-            operations = createChildMap("", this, OperationImpl.factory, "get|put|post|delete|options|head|patch|trace");
-            servers = createChildList("servers", this, ServerImpl.factory);
-            parameters = createChildList("parameters", this, ParameterImpl.factory);
-            refables.put("parameters", parameters);
-            extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
+        description = createChild("description", this, StringOverlay.factory);
+        operations = createChildMap("", this, OperationImpl.factory, "get|put|post|delete|options|head|patch|trace");
+        servers = createChildList("servers", this, ServerImpl.factory);
+        parameters = createChildList("parameters", this, ParameterImpl.factory);
+        refables.put("parameters", parameters);
+        extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public static OverlayFactory<Path, PathImpl> factory = new OverlayFactory<Path, PathImpl>() {
-    @Override
-    protected Class<? super PathImpl> getOverlayClass() {
-         return PathImpl.class;
-    }
 
-    @Override
-    public PathImpl _create(Path path, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        return new PathImpl(path, parent, refReg);
-    }
+        @Override
+        protected Class<? super PathImpl> getOverlayClass() {
+            return PathImpl.class;
+        }
 
-    @Override
-    public PathImpl _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        return new PathImpl(json, parent, refReg);
-    }
-};
+        @Override
+        public PathImpl _create(Path path, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+            return new PathImpl(path, parent, refReg);
+        }
 
+        @Override
+        public PathImpl _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+            return new PathImpl(json, parent, refReg);
+        }
+    };
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/RequestBodyImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/RequestBodyImpl.java
@@ -1,38 +1,38 @@
 package com.reprezen.kaizen.oasparser.ovl3;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.reprezen.kaizen.oasparser.jsonoverlay.BooleanOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ChildListOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ChildMapOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ChildOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ListOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ObjectOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.OverlayFactory;
+import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ChildMapOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ChildListOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ReferenceRegistry;
-import com.reprezen.kaizen.oasparser.jsonoverlay.StringOverlay;
-import com.reprezen.kaizen.oasparser.model3.MediaType;
-import com.reprezen.kaizen.oasparser.model3.OpenApi3;
-import com.reprezen.kaizen.oasparser.model3.RequestBody;
 import com.reprezen.kaizen.oasparser.ovl3.MediaTypeImpl;
-import com.reprezen.kaizen.oasparser.ovl3.OpenApiObjectImpl;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ListOverlay;
 import java.util.Collection;
-import java.util.Map;
+import com.reprezen.kaizen.oasparser.model3.OpenApi3;
+import com.reprezen.kaizen.oasparser.jsonoverlay.BooleanOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ChildOverlay;
 import javax.annotation.Generated;
+import com.reprezen.kaizen.oasparser.model3.MediaType;
+import com.reprezen.kaizen.oasparser.model3.RequestBody;
+import com.reprezen.kaizen.oasparser.ovl3.OpenApiObjectImpl;
+import java.util.Map;
+import com.reprezen.kaizen.oasparser.jsonoverlay.OverlayFactory;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.reprezen.kaizen.oasparser.jsonoverlay.StringOverlay;
 
 public class RequestBodyImpl extends OpenApiObjectImpl<OpenApi3, RequestBody> implements RequestBody {
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public RequestBodyImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
         super(json, parent, refReg);
-            super.maybeElaborateChildrenAtCreation();
+        super.maybeElaborateChildrenAtCreation();
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public RequestBodyImpl(RequestBody requestBody, JsonOverlay<?> parent, ReferenceRegistry refReg) {
         super(requestBody, parent, refReg);
-            super.maybeElaborateChildrenAtCreation();
+        super.maybeElaborateChildrenAtCreation();
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
@@ -181,27 +181,27 @@ public class RequestBodyImpl extends OpenApiObjectImpl<OpenApi3, RequestBody> im
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     protected void elaborateChildren() {
         description = createChild("description", this, StringOverlay.factory);
-            contentMediaTypes = createChildMap("content", this, MediaTypeImpl.factory, null);
-            required = createChild("required", this, BooleanOverlay.factory);
-            extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
+        contentMediaTypes = createChildMap("content", this, MediaTypeImpl.factory, null);
+        required = createChild("required", this, BooleanOverlay.factory);
+        extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public static OverlayFactory<RequestBody, RequestBodyImpl> factory = new OverlayFactory<RequestBody, RequestBodyImpl>() {
-    @Override
-    protected Class<? super RequestBodyImpl> getOverlayClass() {
-         return RequestBodyImpl.class;
-    }
 
-    @Override
-    public RequestBodyImpl _create(RequestBody requestBody, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        return new RequestBodyImpl(requestBody, parent, refReg);
-    }
+        @Override
+        protected Class<? super RequestBodyImpl> getOverlayClass() {
+            return RequestBodyImpl.class;
+        }
 
-    @Override
-    public RequestBodyImpl _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        return new RequestBodyImpl(json, parent, refReg);
-    }
-};
+        @Override
+        public RequestBodyImpl _create(RequestBody requestBody, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+            return new RequestBodyImpl(requestBody, parent, refReg);
+        }
 
+        @Override
+        public RequestBodyImpl _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+            return new RequestBodyImpl(json, parent, refReg);
+        }
+    };
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ResponseImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ResponseImpl.java
@@ -1,42 +1,42 @@
 package com.reprezen.kaizen.oasparser.ovl3;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ObjectOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ChildListOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ChildMapOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ChildOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ListOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ObjectOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.OverlayFactory;
-import com.reprezen.kaizen.oasparser.jsonoverlay.Reference;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ReferenceRegistry;
-import com.reprezen.kaizen.oasparser.jsonoverlay.StringOverlay;
-import com.reprezen.kaizen.oasparser.model3.Header;
-import com.reprezen.kaizen.oasparser.model3.Link;
-import com.reprezen.kaizen.oasparser.model3.MediaType;
-import com.reprezen.kaizen.oasparser.model3.OpenApi3;
-import com.reprezen.kaizen.oasparser.model3.Response;
 import com.reprezen.kaizen.oasparser.ovl3.HeaderImpl;
-import com.reprezen.kaizen.oasparser.ovl3.LinkImpl;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ReferenceRegistry;
 import com.reprezen.kaizen.oasparser.ovl3.MediaTypeImpl;
-import com.reprezen.kaizen.oasparser.ovl3.OpenApiObjectImpl;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ListOverlay;
 import java.util.Collection;
-import java.util.Map;
+import com.reprezen.kaizen.oasparser.model3.OpenApi3;
+import com.reprezen.kaizen.oasparser.model3.Header;
+import com.reprezen.kaizen.oasparser.jsonoverlay.Reference;
+import com.reprezen.kaizen.oasparser.model3.Link;
+import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ChildOverlay;
 import javax.annotation.Generated;
+import com.reprezen.kaizen.oasparser.model3.Response;
+import com.reprezen.kaizen.oasparser.model3.MediaType;
+import com.reprezen.kaizen.oasparser.ovl3.OpenApiObjectImpl;
+import java.util.Map;
+import com.reprezen.kaizen.oasparser.jsonoverlay.OverlayFactory;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.reprezen.kaizen.oasparser.ovl3.LinkImpl;
+import com.reprezen.kaizen.oasparser.jsonoverlay.StringOverlay;
 
 public class ResponseImpl extends OpenApiObjectImpl<OpenApi3, Response> implements Response {
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public ResponseImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
         super(json, parent, refReg);
-            super.maybeElaborateChildrenAtCreation();
+        super.maybeElaborateChildrenAtCreation();
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public ResponseImpl(Response response, JsonOverlay<?> parent, ReferenceRegistry refReg) {
         super(response, parent, refReg);
-            super.maybeElaborateChildrenAtCreation();
+        super.maybeElaborateChildrenAtCreation();
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
@@ -120,14 +120,14 @@ public class ResponseImpl extends OpenApiObjectImpl<OpenApi3, Response> implemen
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public boolean isHeaderReference(String key) {
         ChildOverlay<Header, HeaderImpl> child = headers.getChild(key);
-            return child != null ? child.isReference() : false;
+        return child != null ? child.isReference() : false;
     }
 
     @Override
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public Reference getHeaderReference(String key) {
         ChildOverlay<Header, HeaderImpl> child = headers.getChild(key);
-            return child != null ? child.getReference() : null;
+        return child != null ? child.getReference() : null;
     }
 
     // ContentMediaType
@@ -220,14 +220,14 @@ public class ResponseImpl extends OpenApiObjectImpl<OpenApi3, Response> implemen
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public boolean isLinkReference(String key) {
         ChildOverlay<Link, LinkImpl> child = links.getChild(key);
-            return child != null ? child.isReference() : false;
+        return child != null ? child.isReference() : false;
     }
 
     @Override
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public Reference getLinkReference(String key) {
         ChildOverlay<Link, LinkImpl> child = links.getChild(key);
-            return child != null ? child.getReference() : null;
+        return child != null ? child.getReference() : null;
     }
 
     // Extension
@@ -277,30 +277,30 @@ public class ResponseImpl extends OpenApiObjectImpl<OpenApi3, Response> implemen
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     protected void elaborateChildren() {
         description = createChild("description", this, StringOverlay.factory);
-            headers = createChildMap("headers", this, HeaderImpl.factory, null);
-            refables.put("headers", headers);
-            contentMediaTypes = createChildMap("content", this, MediaTypeImpl.factory, null);
-            links = createChildMap("links", this, LinkImpl.factory, null);
-            refables.put("links", links);
-            extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
+        headers = createChildMap("headers", this, HeaderImpl.factory, null);
+        refables.put("headers", headers);
+        contentMediaTypes = createChildMap("content", this, MediaTypeImpl.factory, null);
+        links = createChildMap("links", this, LinkImpl.factory, null);
+        refables.put("links", links);
+        extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public static OverlayFactory<Response, ResponseImpl> factory = new OverlayFactory<Response, ResponseImpl>() {
-    @Override
-    protected Class<? super ResponseImpl> getOverlayClass() {
-         return ResponseImpl.class;
-    }
 
-    @Override
-    public ResponseImpl _create(Response response, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        return new ResponseImpl(response, parent, refReg);
-    }
+        @Override
+        protected Class<? super ResponseImpl> getOverlayClass() {
+            return ResponseImpl.class;
+        }
 
-    @Override
-    public ResponseImpl _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        return new ResponseImpl(json, parent, refReg);
-    }
-};
+        @Override
+        public ResponseImpl _create(Response response, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+            return new ResponseImpl(response, parent, refReg);
+        }
 
+        @Override
+        public ResponseImpl _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+            return new ResponseImpl(json, parent, refReg);
+        }
+    };
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/SchemaImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/SchemaImpl.java
@@ -1,36 +1,36 @@
 package com.reprezen.kaizen.oasparser.ovl3;
 
-import com.fasterxml.jackson.core.JsonPointer;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.google.common.base.Optional;
-import com.reprezen.kaizen.oasparser.jsonoverlay.BooleanOverlay;
+import com.reprezen.kaizen.oasparser.model3.Schema;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ChildListOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ChildMapOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ChildOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.IJsonOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.IntegerOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ListOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.NumberOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ObjectOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.OverlayFactory;
-import com.reprezen.kaizen.oasparser.jsonoverlay.Reference;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ReferenceRegistry;
-import com.reprezen.kaizen.oasparser.jsonoverlay.StringOverlay;
-import com.reprezen.kaizen.oasparser.model3.Example;
-import com.reprezen.kaizen.oasparser.model3.ExternalDocs;
 import com.reprezen.kaizen.oasparser.model3.OpenApi3;
-import com.reprezen.kaizen.oasparser.model3.Schema;
+import com.reprezen.kaizen.oasparser.jsonoverlay.BooleanOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
 import com.reprezen.kaizen.oasparser.model3.Xml;
-import com.reprezen.kaizen.oasparser.ovl3.ExampleImpl;
-import com.reprezen.kaizen.oasparser.ovl3.ExternalDocsImpl;
-import com.reprezen.kaizen.oasparser.ovl3.OpenApiObjectImpl;
-import com.reprezen.kaizen.oasparser.ovl3.SchemaImpl;
-import com.reprezen.kaizen.oasparser.ovl3.XmlImpl;
-import java.util.Collection;
-import java.util.Map;
+import com.fasterxml.jackson.core.JsonPointer;
 import javax.annotation.Generated;
+import com.reprezen.kaizen.oasparser.ovl3.SchemaImpl;
+import com.reprezen.kaizen.oasparser.model3.Example;
+import java.util.Map;
+import com.reprezen.kaizen.oasparser.jsonoverlay.OverlayFactory;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.reprezen.kaizen.oasparser.jsonoverlay.IJsonOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ObjectOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ListOverlay;
+import com.reprezen.kaizen.oasparser.ovl3.ExampleImpl;
+import java.util.Collection;
+import com.reprezen.kaizen.oasparser.jsonoverlay.Reference;
+import com.reprezen.kaizen.oasparser.ovl3.ExternalDocsImpl;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ChildOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.NumberOverlay;
+import com.reprezen.kaizen.oasparser.ovl3.OpenApiObjectImpl;
+import java.util.Optional;
+import com.reprezen.kaizen.oasparser.jsonoverlay.IntegerOverlay;
+import com.reprezen.kaizen.oasparser.model3.ExternalDocs;
+import com.reprezen.kaizen.oasparser.ovl3.XmlImpl;
+import com.reprezen.kaizen.oasparser.jsonoverlay.StringOverlay;
 
 public class SchemaImpl extends OpenApiObjectImpl<OpenApi3, Schema> implements Schema {
 
@@ -46,13 +46,13 @@ public class SchemaImpl extends OpenApiObjectImpl<OpenApi3, Schema> implements S
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public SchemaImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
         super(json, parent, refReg);
-            super.maybeElaborateChildrenAtCreation();
+        super.maybeElaborateChildrenAtCreation();
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public SchemaImpl(Schema schema, JsonOverlay<?> parent, ReferenceRegistry refReg) {
         super(schema, parent, refReg);
-            super.maybeElaborateChildrenAtCreation();
+        super.maybeElaborateChildrenAtCreation();
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
@@ -892,14 +892,14 @@ public class SchemaImpl extends OpenApiObjectImpl<OpenApi3, Schema> implements S
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public boolean isPropertyReference(String key) {
         ChildOverlay<Schema, SchemaImpl> child = properties.getChild(key);
-            return child != null ? child.isReference() : false;
+        return child != null ? child.isReference() : false;
     }
 
     @Override
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public Reference getPropertyReference(String key) {
         ChildOverlay<Schema, SchemaImpl> child = properties.getChild(key);
-            return child != null ? child.getReference() : null;
+        return child != null ? child.getReference() : null;
     }
 
     // AdditionalPropertiesSchema
@@ -1281,68 +1281,68 @@ public class SchemaImpl extends OpenApiObjectImpl<OpenApi3, Schema> implements S
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     protected void elaborateChildren() {
         title = createChild("title", this, StringOverlay.factory);
-            multipleOf = createChild("multipleOf", this, NumberOverlay.factory);
-            maximum = createChild("maximum", this, NumberOverlay.factory);
-            exclusiveMaximum = createChild("exclusiveMaximum", this, BooleanOverlay.factory);
-            minimum = createChild("minimum", this, NumberOverlay.factory);
-            exclusiveMinimum = createChild("exclusiveMinimum", this, BooleanOverlay.factory);
-            maxLength = createChild("maxLength", this, IntegerOverlay.factory);
-            minLength = createChild("minLength", this, IntegerOverlay.factory);
-            pattern = createChild("pattern", this, StringOverlay.factory);
-            maxItems = createChild("maxItems", this, IntegerOverlay.factory);
-            minItems = createChild("minItems", this, IntegerOverlay.factory);
-            uniqueItems = createChild("uniqueItems", this, BooleanOverlay.factory);
-            maxProperties = createChild("maxProperties", this, IntegerOverlay.factory);
-            minProperties = createChild("minProperties", this, IntegerOverlay.factory);
-            requiredFields = createChildList("required", this, StringOverlay.factory);
-            enums = createChildList("enum", this, ObjectOverlay.factory);
-            type = createChild("type", this, StringOverlay.factory);
-            allOfSchemas = createChildList("allOf", this, SchemaImpl.factory);
-            refables.put("allOf", allOfSchemas);
-            oneOfSchemas = createChildList("oneOf", this, SchemaImpl.factory);
-            refables.put("oneOf", oneOfSchemas);
-            anyOfSchemas = createChildList("anyOf", this, SchemaImpl.factory);
-            refables.put("anyOf", anyOfSchemas);
-            notSchema = createChild("not", this, SchemaImpl.factory);
-            refables.put("not", notSchema);
-            itemsSchema = createChild("items", this, SchemaImpl.factory);
-            refables.put("items", itemsSchema);
-            properties = createChildMap("properties", this, SchemaImpl.factory, null);
-            refables.put("properties", properties);
-            additionalPropertiesSchema = createChild(json.at("/additionalProperties").isObject(), "additionalProperties", this, SchemaImpl.factory);
-            refables.put("additionalProperties", additionalPropertiesSchema);
-            additionalProperties = createChild(json.at("/additionalProperties").isBoolean(), "additionalProperties", this, BooleanOverlay.factory);
-            description = createChild("description", this, StringOverlay.factory);
-            format = createChild("format", this, StringOverlay.factory);
-            defaultValue = createChild("default", this, ObjectOverlay.factory);
-            nullable = createChild("nullable", this, BooleanOverlay.factory);
-            discriminator = createChild("discriminator", this, StringOverlay.factory);
-            readOnly = createChild("readOnly", this, BooleanOverlay.factory);
-            writeOnly = createChild("writeOnly", this, BooleanOverlay.factory);
-            xml = createChild("xml", this, XmlImpl.factory);
-            externalDocs = createChild("externalDocs", this, ExternalDocsImpl.factory);
-            examples = createChildMap("examples", this, ExampleImpl.factory, "[a-zA-Z0-9\\._-]+");
-            example = createChild("example", this, ObjectOverlay.factory);
-            deprecated = createChild("deprecated", this, BooleanOverlay.factory);
-            extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
+        multipleOf = createChild("multipleOf", this, NumberOverlay.factory);
+        maximum = createChild("maximum", this, NumberOverlay.factory);
+        exclusiveMaximum = createChild("exclusiveMaximum", this, BooleanOverlay.factory);
+        minimum = createChild("minimum", this, NumberOverlay.factory);
+        exclusiveMinimum = createChild("exclusiveMinimum", this, BooleanOverlay.factory);
+        maxLength = createChild("maxLength", this, IntegerOverlay.factory);
+        minLength = createChild("minLength", this, IntegerOverlay.factory);
+        pattern = createChild("pattern", this, StringOverlay.factory);
+        maxItems = createChild("maxItems", this, IntegerOverlay.factory);
+        minItems = createChild("minItems", this, IntegerOverlay.factory);
+        uniqueItems = createChild("uniqueItems", this, BooleanOverlay.factory);
+        maxProperties = createChild("maxProperties", this, IntegerOverlay.factory);
+        minProperties = createChild("minProperties", this, IntegerOverlay.factory);
+        requiredFields = createChildList("required", this, StringOverlay.factory);
+        enums = createChildList("enum", this, ObjectOverlay.factory);
+        type = createChild("type", this, StringOverlay.factory);
+        allOfSchemas = createChildList("allOf", this, SchemaImpl.factory);
+        refables.put("allOf", allOfSchemas);
+        oneOfSchemas = createChildList("oneOf", this, SchemaImpl.factory);
+        refables.put("oneOf", oneOfSchemas);
+        anyOfSchemas = createChildList("anyOf", this, SchemaImpl.factory);
+        refables.put("anyOf", anyOfSchemas);
+        notSchema = createChild("not", this, SchemaImpl.factory);
+        refables.put("not", notSchema);
+        itemsSchema = createChild("items", this, SchemaImpl.factory);
+        refables.put("items", itemsSchema);
+        properties = createChildMap("properties", this, SchemaImpl.factory, null);
+        refables.put("properties", properties);
+        additionalPropertiesSchema = createChild(json.at("/additionalProperties").isObject(), "additionalProperties", this, SchemaImpl.factory);
+        refables.put("additionalProperties", additionalPropertiesSchema);
+        additionalProperties = createChild(json.at("/additionalProperties").isBoolean(), "additionalProperties", this, BooleanOverlay.factory);
+        description = createChild("description", this, StringOverlay.factory);
+        format = createChild("format", this, StringOverlay.factory);
+        defaultValue = createChild("default", this, ObjectOverlay.factory);
+        nullable = createChild("nullable", this, BooleanOverlay.factory);
+        discriminator = createChild("discriminator", this, StringOverlay.factory);
+        readOnly = createChild("readOnly", this, BooleanOverlay.factory);
+        writeOnly = createChild("writeOnly", this, BooleanOverlay.factory);
+        xml = createChild("xml", this, XmlImpl.factory);
+        externalDocs = createChild("externalDocs", this, ExternalDocsImpl.factory);
+        examples = createChildMap("examples", this, ExampleImpl.factory, "[a-zA-Z0-9\\._-]+");
+        example = createChild("example", this, ObjectOverlay.factory);
+        deprecated = createChild("deprecated", this, BooleanOverlay.factory);
+        extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public static OverlayFactory<Schema, SchemaImpl> factory = new OverlayFactory<Schema, SchemaImpl>() {
-    @Override
-    protected Class<? super SchemaImpl> getOverlayClass() {
-         return SchemaImpl.class;
-    }
 
-    @Override
-    public SchemaImpl _create(Schema schema, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        return new SchemaImpl(schema, parent, refReg);
-    }
+        @Override
+        protected Class<? super SchemaImpl> getOverlayClass() {
+            return SchemaImpl.class;
+        }
 
-    @Override
-    public SchemaImpl _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        return new SchemaImpl(json, parent, refReg);
-    }
-};
+        @Override
+        public SchemaImpl _create(Schema schema, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+            return new SchemaImpl(schema, parent, refReg);
+        }
 
+        @Override
+        public SchemaImpl _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+            return new SchemaImpl(json, parent, refReg);
+        }
+    };
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/SecurityParameterImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/SecurityParameterImpl.java
@@ -1,18 +1,18 @@
 package com.reprezen.kaizen.oasparser.ovl3;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ChildListOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ListOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.OverlayFactory;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ChildListOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ReferenceRegistry;
-import com.reprezen.kaizen.oasparser.jsonoverlay.StringOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ListOverlay;
+import java.util.Collection;
 import com.reprezen.kaizen.oasparser.model3.OpenApi3;
 import com.reprezen.kaizen.oasparser.model3.SecurityParameter;
-import com.reprezen.kaizen.oasparser.ovl3.OpenApiObjectImpl;
-import java.util.Collection;
 import javax.annotation.Generated;
+import com.reprezen.kaizen.oasparser.ovl3.OpenApiObjectImpl;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.reprezen.kaizen.oasparser.jsonoverlay.OverlayFactory;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.reprezen.kaizen.oasparser.jsonoverlay.StringOverlay;
 
 public class SecurityParameterImpl extends OpenApiObjectImpl<OpenApi3, SecurityParameter> implements SecurityParameter {
 
@@ -24,13 +24,13 @@ public class SecurityParameterImpl extends OpenApiObjectImpl<OpenApi3, SecurityP
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public SecurityParameterImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
         super(json, parent, refReg);
-            super.maybeElaborateChildrenAtCreation();
+        super.maybeElaborateChildrenAtCreation();
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public SecurityParameterImpl(SecurityParameter securityParameter, JsonOverlay<?> parent, ReferenceRegistry refReg) {
         super(securityParameter, parent, refReg);
-            super.maybeElaborateChildrenAtCreation();
+        super.maybeElaborateChildrenAtCreation();
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
@@ -99,20 +99,20 @@ public class SecurityParameterImpl extends OpenApiObjectImpl<OpenApi3, SecurityP
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public static OverlayFactory<SecurityParameter, SecurityParameterImpl> factory = new OverlayFactory<SecurityParameter, SecurityParameterImpl>() {
-    @Override
-    protected Class<? super SecurityParameterImpl> getOverlayClass() {
-         return SecurityParameterImpl.class;
-    }
 
-    @Override
-    public SecurityParameterImpl _create(SecurityParameter securityParameter, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        return new SecurityParameterImpl(securityParameter, parent, refReg);
-    }
+        @Override
+        protected Class<? super SecurityParameterImpl> getOverlayClass() {
+            return SecurityParameterImpl.class;
+        }
 
-    @Override
-    public SecurityParameterImpl _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        return new SecurityParameterImpl(json, parent, refReg);
-    }
-};
+        @Override
+        public SecurityParameterImpl _create(SecurityParameter securityParameter, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+            return new SecurityParameterImpl(securityParameter, parent, refReg);
+        }
 
+        @Override
+        public SecurityParameterImpl _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+            return new SecurityParameterImpl(json, parent, refReg);
+        }
+    };
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/SecurityRequirementImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/SecurityRequirementImpl.java
@@ -1,31 +1,31 @@
 package com.reprezen.kaizen.oasparser.ovl3;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ChildMapOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.OverlayFactory;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ChildMapOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ReferenceRegistry;
+import com.reprezen.kaizen.oasparser.ovl3.SecurityParameterImpl;
+import com.reprezen.kaizen.oasparser.model3.SecurityRequirement;
 import com.reprezen.kaizen.oasparser.model3.OpenApi3;
 import com.reprezen.kaizen.oasparser.model3.SecurityParameter;
-import com.reprezen.kaizen.oasparser.model3.SecurityRequirement;
-import com.reprezen.kaizen.oasparser.ovl3.OpenApiObjectImpl;
-import com.reprezen.kaizen.oasparser.ovl3.SecurityParameterImpl;
-import java.util.Map;
+import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
 import javax.annotation.Generated;
+import com.reprezen.kaizen.oasparser.ovl3.OpenApiObjectImpl;
+import java.util.Map;
+import com.reprezen.kaizen.oasparser.jsonoverlay.OverlayFactory;
+import com.fasterxml.jackson.databind.JsonNode;
 
 public class SecurityRequirementImpl extends OpenApiObjectImpl<OpenApi3, SecurityRequirement> implements SecurityRequirement {
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public SecurityRequirementImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
         super(json, parent, refReg);
-            super.maybeElaborateChildrenAtCreation();
+        super.maybeElaborateChildrenAtCreation();
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public SecurityRequirementImpl(SecurityRequirement securityRequirement, JsonOverlay<?> parent, ReferenceRegistry refReg) {
         super(securityRequirement, parent, refReg);
-            super.maybeElaborateChildrenAtCreation();
+        super.maybeElaborateChildrenAtCreation();
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
@@ -82,20 +82,20 @@ public class SecurityRequirementImpl extends OpenApiObjectImpl<OpenApi3, Securit
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public static OverlayFactory<SecurityRequirement, SecurityRequirementImpl> factory = new OverlayFactory<SecurityRequirement, SecurityRequirementImpl>() {
-    @Override
-    protected Class<? super SecurityRequirementImpl> getOverlayClass() {
-         return SecurityRequirementImpl.class;
-    }
 
-    @Override
-    public SecurityRequirementImpl _create(SecurityRequirement securityRequirement, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        return new SecurityRequirementImpl(securityRequirement, parent, refReg);
-    }
+        @Override
+        protected Class<? super SecurityRequirementImpl> getOverlayClass() {
+            return SecurityRequirementImpl.class;
+        }
 
-    @Override
-    public SecurityRequirementImpl _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        return new SecurityRequirementImpl(json, parent, refReg);
-    }
-};
+        @Override
+        public SecurityRequirementImpl _create(SecurityRequirement securityRequirement, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+            return new SecurityRequirementImpl(securityRequirement, parent, refReg);
+        }
 
+        @Override
+        public SecurityRequirementImpl _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+            return new SecurityRequirementImpl(json, parent, refReg);
+        }
+    };
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/SecuritySchemeImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/SecuritySchemeImpl.java
@@ -1,37 +1,37 @@
 package com.reprezen.kaizen.oasparser.ovl3;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ChildListOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ChildMapOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ChildOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ListOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ObjectOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.OverlayFactory;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ReferenceRegistry;
-import com.reprezen.kaizen.oasparser.jsonoverlay.StringOverlay;
-import com.reprezen.kaizen.oasparser.model3.OAuthFlow;
-import com.reprezen.kaizen.oasparser.model3.OpenApi3;
-import com.reprezen.kaizen.oasparser.model3.SecurityScheme;
+import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ChildMapOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ChildListOverlay;
 import com.reprezen.kaizen.oasparser.ovl3.OAuthFlowImpl;
-import com.reprezen.kaizen.oasparser.ovl3.OpenApiObjectImpl;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ReferenceRegistry;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ListOverlay;
 import java.util.Collection;
-import java.util.Map;
+import com.reprezen.kaizen.oasparser.model3.OpenApi3;
+import com.reprezen.kaizen.oasparser.model3.OAuthFlow;
+import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ChildOverlay;
 import javax.annotation.Generated;
+import com.reprezen.kaizen.oasparser.ovl3.OpenApiObjectImpl;
+import java.util.Map;
+import com.reprezen.kaizen.oasparser.jsonoverlay.OverlayFactory;
+import com.reprezen.kaizen.oasparser.model3.SecurityScheme;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.reprezen.kaizen.oasparser.jsonoverlay.StringOverlay;
 
 public class SecuritySchemeImpl extends OpenApiObjectImpl<OpenApi3, SecurityScheme> implements SecurityScheme {
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public SecuritySchemeImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
         super(json, parent, refReg);
-            super.maybeElaborateChildrenAtCreation();
+        super.maybeElaborateChildrenAtCreation();
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public SecuritySchemeImpl(SecurityScheme securityScheme, JsonOverlay<?> parent, ReferenceRegistry refReg) {
         super(securityScheme, parent, refReg);
-            super.maybeElaborateChildrenAtCreation();
+        super.maybeElaborateChildrenAtCreation();
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
@@ -372,36 +372,36 @@ public class SecuritySchemeImpl extends OpenApiObjectImpl<OpenApi3, SecuritySche
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     protected void elaborateChildren() {
         type = createChild("type", this, StringOverlay.factory);
-            description = createChild("description", this, StringOverlay.factory);
-            name = createChild("name", this, StringOverlay.factory);
-            in = createChild("in", this, StringOverlay.factory);
-            scheme = createChild("scheme", this, StringOverlay.factory);
-            bearerFormat = createChild("bearerFormat", this, StringOverlay.factory);
-            implicitOAuthFlow = createChild("flow/implicit", this, OAuthFlowImpl.factory);
-            passwordOAuthFlow = createChild("flow/password", this, OAuthFlowImpl.factory);
-            clientCredentialsOAuthFlow = createChild("flow/clientCredentials", this, OAuthFlowImpl.factory);
-            authorizationCodeOAuthFlow = createChild("flow/authorizationCode", this, OAuthFlowImpl.factory);
-            oAuthFlowsExtensions = createChildMap("flow", this, ObjectOverlay.factory, "x-.+");
-            openIdConnectUrl = createChild("openIdConnectUrl", this, StringOverlay.factory);
-            extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
+        description = createChild("description", this, StringOverlay.factory);
+        name = createChild("name", this, StringOverlay.factory);
+        in = createChild("in", this, StringOverlay.factory);
+        scheme = createChild("scheme", this, StringOverlay.factory);
+        bearerFormat = createChild("bearerFormat", this, StringOverlay.factory);
+        implicitOAuthFlow = createChild("flow/implicit", this, OAuthFlowImpl.factory);
+        passwordOAuthFlow = createChild("flow/password", this, OAuthFlowImpl.factory);
+        clientCredentialsOAuthFlow = createChild("flow/clientCredentials", this, OAuthFlowImpl.factory);
+        authorizationCodeOAuthFlow = createChild("flow/authorizationCode", this, OAuthFlowImpl.factory);
+        oAuthFlowsExtensions = createChildMap("flow", this, ObjectOverlay.factory, "x-.+");
+        openIdConnectUrl = createChild("openIdConnectUrl", this, StringOverlay.factory);
+        extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public static OverlayFactory<SecurityScheme, SecuritySchemeImpl> factory = new OverlayFactory<SecurityScheme, SecuritySchemeImpl>() {
-    @Override
-    protected Class<? super SecuritySchemeImpl> getOverlayClass() {
-         return SecuritySchemeImpl.class;
-    }
 
-    @Override
-    public SecuritySchemeImpl _create(SecurityScheme securityScheme, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        return new SecuritySchemeImpl(securityScheme, parent, refReg);
-    }
+        @Override
+        protected Class<? super SecuritySchemeImpl> getOverlayClass() {
+            return SecuritySchemeImpl.class;
+        }
 
-    @Override
-    public SecuritySchemeImpl _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        return new SecuritySchemeImpl(json, parent, refReg);
-    }
-};
+        @Override
+        public SecuritySchemeImpl _create(SecurityScheme securityScheme, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+            return new SecuritySchemeImpl(securityScheme, parent, refReg);
+        }
 
+        @Override
+        public SecuritySchemeImpl _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+            return new SecuritySchemeImpl(json, parent, refReg);
+        }
+    };
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ServerImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ServerImpl.java
@@ -1,37 +1,37 @@
 package com.reprezen.kaizen.oasparser.ovl3;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ChildListOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ChildMapOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ChildOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ListOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ObjectOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.OverlayFactory;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ReferenceRegistry;
-import com.reprezen.kaizen.oasparser.jsonoverlay.StringOverlay;
-import com.reprezen.kaizen.oasparser.model3.OpenApi3;
+import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
 import com.reprezen.kaizen.oasparser.model3.Server;
-import com.reprezen.kaizen.oasparser.model3.ServerVariable;
-import com.reprezen.kaizen.oasparser.ovl3.OpenApiObjectImpl;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ChildMapOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ChildListOverlay;
 import com.reprezen.kaizen.oasparser.ovl3.ServerVariableImpl;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ReferenceRegistry;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ListOverlay;
 import java.util.Collection;
-import java.util.Map;
+import com.reprezen.kaizen.oasparser.model3.OpenApi3;
+import com.reprezen.kaizen.oasparser.model3.ServerVariable;
+import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ChildOverlay;
 import javax.annotation.Generated;
+import com.reprezen.kaizen.oasparser.ovl3.OpenApiObjectImpl;
+import java.util.Map;
+import com.reprezen.kaizen.oasparser.jsonoverlay.OverlayFactory;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.reprezen.kaizen.oasparser.jsonoverlay.StringOverlay;
 
 public class ServerImpl extends OpenApiObjectImpl<OpenApi3, Server> implements Server {
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public ServerImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
         super(json, parent, refReg);
-            super.maybeElaborateChildrenAtCreation();
+        super.maybeElaborateChildrenAtCreation();
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public ServerImpl(Server server, JsonOverlay<?> parent, ReferenceRegistry refReg) {
         super(server, parent, refReg);
-            super.maybeElaborateChildrenAtCreation();
+        super.maybeElaborateChildrenAtCreation();
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
@@ -220,28 +220,28 @@ public class ServerImpl extends OpenApiObjectImpl<OpenApi3, Server> implements S
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     protected void elaborateChildren() {
         url = createChild("url", this, StringOverlay.factory);
-            description = createChild("description", this, StringOverlay.factory);
-            serverVariables = createChildMap("variables", this, ServerVariableImpl.factory, "(?!x-)[a-zA-Z0-9\\._-]+");
-            variablesExtensions = createChildMap("variables", this, ObjectOverlay.factory, "x-.+");
-            extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
+        description = createChild("description", this, StringOverlay.factory);
+        serverVariables = createChildMap("variables", this, ServerVariableImpl.factory, "(?!x-)[a-zA-Z0-9\\._-]+");
+        variablesExtensions = createChildMap("variables", this, ObjectOverlay.factory, "x-.+");
+        extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public static OverlayFactory<Server, ServerImpl> factory = new OverlayFactory<Server, ServerImpl>() {
-    @Override
-    protected Class<? super ServerImpl> getOverlayClass() {
-         return ServerImpl.class;
-    }
 
-    @Override
-    public ServerImpl _create(Server server, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        return new ServerImpl(server, parent, refReg);
-    }
+        @Override
+        protected Class<? super ServerImpl> getOverlayClass() {
+            return ServerImpl.class;
+        }
 
-    @Override
-    public ServerImpl _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        return new ServerImpl(json, parent, refReg);
-    }
-};
+        @Override
+        public ServerImpl _create(Server server, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+            return new ServerImpl(server, parent, refReg);
+        }
 
+        @Override
+        public ServerImpl _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+            return new ServerImpl(json, parent, refReg);
+        }
+    };
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ServerVariableImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ServerVariableImpl.java
@@ -1,36 +1,36 @@
 package com.reprezen.kaizen.oasparser.ovl3;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ChildListOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ChildMapOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ChildOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ListOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ObjectOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.OverlayFactory;
-import com.reprezen.kaizen.oasparser.jsonoverlay.PrimitiveOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ChildMapOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ChildListOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ReferenceRegistry;
-import com.reprezen.kaizen.oasparser.jsonoverlay.StringOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.PrimitiveOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ListOverlay;
+import java.util.Collection;
 import com.reprezen.kaizen.oasparser.model3.OpenApi3;
 import com.reprezen.kaizen.oasparser.model3.ServerVariable;
-import com.reprezen.kaizen.oasparser.ovl3.OpenApiObjectImpl;
-import java.util.Collection;
-import java.util.Map;
+import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ChildOverlay;
 import javax.annotation.Generated;
+import com.reprezen.kaizen.oasparser.ovl3.OpenApiObjectImpl;
+import java.util.Map;
+import com.reprezen.kaizen.oasparser.jsonoverlay.OverlayFactory;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.reprezen.kaizen.oasparser.jsonoverlay.StringOverlay;
 
 public class ServerVariableImpl extends OpenApiObjectImpl<OpenApi3, ServerVariable> implements ServerVariable {
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public ServerVariableImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
         super(json, parent, refReg);
-            super.maybeElaborateChildrenAtCreation();
+        super.maybeElaborateChildrenAtCreation();
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public ServerVariableImpl(ServerVariable serverVariable, JsonOverlay<?> parent, ReferenceRegistry refReg) {
         super(serverVariable, parent, refReg);
-            super.maybeElaborateChildrenAtCreation();
+        super.maybeElaborateChildrenAtCreation();
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
@@ -185,27 +185,27 @@ public class ServerVariableImpl extends OpenApiObjectImpl<OpenApi3, ServerVariab
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     protected void elaborateChildren() {
         enumValues = createChildList("enum", this, PrimitiveOverlay.factory);
-            defaultValue = createChild("default", this, PrimitiveOverlay.factory);
-            description = createChild("description", this, StringOverlay.factory);
-            extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
+        defaultValue = createChild("default", this, PrimitiveOverlay.factory);
+        description = createChild("description", this, StringOverlay.factory);
+        extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public static OverlayFactory<ServerVariable, ServerVariableImpl> factory = new OverlayFactory<ServerVariable, ServerVariableImpl>() {
-    @Override
-    protected Class<? super ServerVariableImpl> getOverlayClass() {
-         return ServerVariableImpl.class;
-    }
 
-    @Override
-    public ServerVariableImpl _create(ServerVariable serverVariable, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        return new ServerVariableImpl(serverVariable, parent, refReg);
-    }
+        @Override
+        protected Class<? super ServerVariableImpl> getOverlayClass() {
+            return ServerVariableImpl.class;
+        }
 
-    @Override
-    public ServerVariableImpl _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        return new ServerVariableImpl(json, parent, refReg);
-    }
-};
+        @Override
+        public ServerVariableImpl _create(ServerVariable serverVariable, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+            return new ServerVariableImpl(serverVariable, parent, refReg);
+        }
 
+        @Override
+        public ServerVariableImpl _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+            return new ServerVariableImpl(json, parent, refReg);
+        }
+    };
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/TagImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/TagImpl.java
@@ -1,37 +1,37 @@
 package com.reprezen.kaizen.oasparser.ovl3;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ChildListOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ChildMapOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ChildOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ListOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ObjectOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.OverlayFactory;
+import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ChildMapOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ChildListOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ReferenceRegistry;
-import com.reprezen.kaizen.oasparser.jsonoverlay.StringOverlay;
-import com.reprezen.kaizen.oasparser.model3.ExternalDocs;
-import com.reprezen.kaizen.oasparser.model3.OpenApi3;
-import com.reprezen.kaizen.oasparser.model3.Tag;
-import com.reprezen.kaizen.oasparser.ovl3.ExternalDocsImpl;
-import com.reprezen.kaizen.oasparser.ovl3.OpenApiObjectImpl;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ListOverlay;
 import java.util.Collection;
-import java.util.Map;
+import com.reprezen.kaizen.oasparser.model3.OpenApi3;
+import com.reprezen.kaizen.oasparser.ovl3.ExternalDocsImpl;
+import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ChildOverlay;
 import javax.annotation.Generated;
+import com.reprezen.kaizen.oasparser.model3.Tag;
+import com.reprezen.kaizen.oasparser.ovl3.OpenApiObjectImpl;
+import java.util.Map;
+import com.reprezen.kaizen.oasparser.jsonoverlay.OverlayFactory;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.reprezen.kaizen.oasparser.model3.ExternalDocs;
+import com.reprezen.kaizen.oasparser.jsonoverlay.StringOverlay;
 
 public class TagImpl extends OpenApiObjectImpl<OpenApi3, Tag> implements Tag {
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public TagImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
         super(json, parent, refReg);
-            super.maybeElaborateChildrenAtCreation();
+        super.maybeElaborateChildrenAtCreation();
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public TagImpl(Tag tag, JsonOverlay<?> parent, ReferenceRegistry refReg) {
         super(tag, parent, refReg);
-            super.maybeElaborateChildrenAtCreation();
+        super.maybeElaborateChildrenAtCreation();
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
@@ -150,27 +150,27 @@ public class TagImpl extends OpenApiObjectImpl<OpenApi3, Tag> implements Tag {
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     protected void elaborateChildren() {
         name = createChild("name", this, StringOverlay.factory);
-            description = createChild("description", this, StringOverlay.factory);
-            externalDocs = createChild("externalDocs", this, ExternalDocsImpl.factory);
-            extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
+        description = createChild("description", this, StringOverlay.factory);
+        externalDocs = createChild("externalDocs", this, ExternalDocsImpl.factory);
+        extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public static OverlayFactory<Tag, TagImpl> factory = new OverlayFactory<Tag, TagImpl>() {
-    @Override
-    protected Class<? super TagImpl> getOverlayClass() {
-         return TagImpl.class;
-    }
 
-    @Override
-    public TagImpl _create(Tag tag, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        return new TagImpl(tag, parent, refReg);
-    }
+        @Override
+        protected Class<? super TagImpl> getOverlayClass() {
+            return TagImpl.class;
+        }
 
-    @Override
-    public TagImpl _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        return new TagImpl(json, parent, refReg);
-    }
-};
+        @Override
+        public TagImpl _create(Tag tag, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+            return new TagImpl(tag, parent, refReg);
+        }
 
+        @Override
+        public TagImpl _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+            return new TagImpl(json, parent, refReg);
+        }
+    };
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/XmlImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/XmlImpl.java
@@ -1,36 +1,36 @@
 package com.reprezen.kaizen.oasparser.ovl3;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.reprezen.kaizen.oasparser.jsonoverlay.BooleanOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ChildListOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ChildMapOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ChildOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ListOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ObjectOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.OverlayFactory;
+import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ChildMapOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ChildListOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ReferenceRegistry;
-import com.reprezen.kaizen.oasparser.jsonoverlay.StringOverlay;
-import com.reprezen.kaizen.oasparser.model3.OpenApi3;
-import com.reprezen.kaizen.oasparser.model3.Xml;
-import com.reprezen.kaizen.oasparser.ovl3.OpenApiObjectImpl;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ListOverlay;
 import java.util.Collection;
-import java.util.Map;
+import com.reprezen.kaizen.oasparser.model3.OpenApi3;
+import com.reprezen.kaizen.oasparser.jsonoverlay.BooleanOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ChildOverlay;
+import com.reprezen.kaizen.oasparser.model3.Xml;
 import javax.annotation.Generated;
+import com.reprezen.kaizen.oasparser.ovl3.OpenApiObjectImpl;
+import java.util.Map;
+import com.reprezen.kaizen.oasparser.jsonoverlay.OverlayFactory;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.reprezen.kaizen.oasparser.jsonoverlay.StringOverlay;
 
 public class XmlImpl extends OpenApiObjectImpl<OpenApi3, Xml> implements Xml {
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public XmlImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
         super(json, parent, refReg);
-            super.maybeElaborateChildrenAtCreation();
+        super.maybeElaborateChildrenAtCreation();
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public XmlImpl(Xml xml, JsonOverlay<?> parent, ReferenceRegistry refReg) {
         super(xml, parent, refReg);
-            super.maybeElaborateChildrenAtCreation();
+        super.maybeElaborateChildrenAtCreation();
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
@@ -205,29 +205,29 @@ public class XmlImpl extends OpenApiObjectImpl<OpenApi3, Xml> implements Xml {
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     protected void elaborateChildren() {
         name = createChild("name", this, StringOverlay.factory);
-            namespace = createChild("namespace", this, StringOverlay.factory);
-            prefix = createChild("prefix", this, StringOverlay.factory);
-            attribute = createChild("attribute", this, BooleanOverlay.factory);
-            wrapped = createChild("wrapped", this, BooleanOverlay.factory);
-            extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
+        namespace = createChild("namespace", this, StringOverlay.factory);
+        prefix = createChild("prefix", this, StringOverlay.factory);
+        attribute = createChild("attribute", this, BooleanOverlay.factory);
+        wrapped = createChild("wrapped", this, BooleanOverlay.factory);
+        extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
     }
 
     @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
     public static OverlayFactory<Xml, XmlImpl> factory = new OverlayFactory<Xml, XmlImpl>() {
-    @Override
-    protected Class<? super XmlImpl> getOverlayClass() {
-         return XmlImpl.class;
-    }
 
-    @Override
-    public XmlImpl _create(Xml xml, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        return new XmlImpl(xml, parent, refReg);
-    }
+        @Override
+        protected Class<? super XmlImpl> getOverlayClass() {
+            return XmlImpl.class;
+        }
 
-    @Override
-    public XmlImpl _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        return new XmlImpl(json, parent, refReg);
-    }
-};
+        @Override
+        public XmlImpl _create(Xml xml, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+            return new XmlImpl(xml, parent, refReg);
+        }
 
+        @Override
+        public XmlImpl _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+            return new XmlImpl(json, parent, refReg);
+        }
+    };
 }


### PR DESCRIPTION
You can now supply hand-crafted definitions of members (constructors, fields, and methods) that would normally be generated. The generated versions will be omitted, with a warning.

In addition, names for generated fields and methods can be changed via a "renames" map in the type data. This is useful, for example, if you want to provide a hand-crafted method implementation that makes use of the generated version, e.g. a `Path#getServers` implementation that returns the top-level servers list if none are declared for the path, with the generated method renamed to `getPathServers` and used by `Path#getServers`