### PR TITLE
Task/108 Implement subtype-aware factories

### DIFF
--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/gen/CodeGenerator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/gen/CodeGenerator.java
@@ -29,127 +29,127 @@ import com.reprezen.kaizen.oasparser.jsonoverlay.gen.TypeData.Type;
 
 public class CodeGenerator {
 
-    public static void main(String[] args)
-            throws JsonParseException, JsonMappingException, IOException, ParseException {
-        Opts opts = new Opts(args);
-        Object parsedYaml = new Yaml().load(new FileInputStream(opts.typeDataFile));
-        TypeData typeData = new YAMLMapper().convertValue(parsedYaml, TypeData.class);
-        typeData.init();
-        new CodeGenerator(opts).generate(typeData);
-    }
+	public static void main(String[] args)
+			throws JsonParseException, JsonMappingException, IOException, ParseException {
+		Opts opts = new Opts(args);
+		Object parsedYaml = new Yaml().load(new FileInputStream(opts.typeDataFile));
+		TypeData typeData = new YAMLMapper().convertValue(parsedYaml, TypeData.class);
+		typeData.init();
+		new CodeGenerator(opts).generate(typeData);
+	}
 
-    private Opts opts;
+	private Opts opts;
 
-    private CodeGenerator(Opts opts) {
-        this.opts = opts;
-    }
+	private CodeGenerator(Opts opts) {
+		this.opts = opts;
+	}
 
-    private void generate(TypeData typeData) throws IOException {
-        generateInterfaces(typeData);
-        generateImpls(typeData);
-        if (!opts.preserve) {
-            System.err.println("WARNING: Preservation of non-generated code is suppressed!");
-            System.err
-                    .println("This is normally appropriate only when modifying the code generator and/or input data,");
-            System.err.println("during which compilation errors are likely to be present in generated code.");
-            System.err.println("");
-            System.err.println("Please be sure to revert the generated code to a known good state and then regenerate");
-            System.err.println("after completing modifications, so as to carry forward any non-generated code that");
-            System.err.println("has been previously added.");
-        }
-    }
+	private void generate(TypeData typeData) throws IOException {
+		generateInterfaces(typeData);
+		generateImpls(typeData);
+		if (!opts.preserve) {
+			System.err.println("WARNING: Preservation of non-generated code is suppressed!");
+			System.err
+					.println("This is normally appropriate only when modifying the code generator and/or input data,");
+			System.err.println("during which compilation errors are likely to be present in generated code.");
+			System.err.println("");
+			System.err.println("Please be sure to revert the generated code to a known good state and then regenerate");
+			System.err.println("after completing modifications, so as to carry forward any non-generated code that");
+			System.err.println("has been previously added.");
+		}
+	}
 
-    private void generateInterfaces(TypeData typeData) throws IOException {
-        File intfDir = getIntfDir();
-        String intfPackage = getIntfPackage();
-        String implPackage = getImplPackage();
-        for (Type type : typeData.getTypes()) {
-            if (type.isNoGen()) {
-                return;
-            }
-            new InterfaceGenerator(intfDir, intfPackage, implPackage, "", opts.preserve).generate(type);
-        }
-    }
+	private void generateInterfaces(TypeData typeData) throws IOException {
+		File intfDir = getIntfDir();
+		String intfPackage = getIntfPackage();
+		String implPackage = getImplPackage();
+		for (Type type : typeData.getTypes()) {
+			if (type.isNoGen()) {
+				return;
+			}
+			new InterfaceGenerator(intfDir, intfPackage, implPackage, "", opts.preserve).generate(type);
+		}
+	}
 
-    private void generateImpls(TypeData typeData) throws IOException {
-        File implDir = getImplDir();
-        String intfPackage = getIntfPackage();
-        String implPackage = getImplPackage();
-        for (Type type : typeData.getTypes()) {
-            if (type.isNoGen()) {
-                return;
-            }
-            new ImplGenerator(implDir, intfPackage, implPackage, opts.classSuffix, opts.preserve).generate(type);
-        }
-    }
+	private void generateImpls(TypeData typeData) throws IOException {
+		File implDir = getImplDir();
+		String intfPackage = getIntfPackage();
+		String implPackage = getImplPackage();
+		for (Type type : typeData.getTypes()) {
+			if (type.isNoGen()) {
+				return;
+			}
+			new ImplGenerator(implDir, intfPackage, implPackage, opts.classSuffix, opts.preserve).generate(type);
+		}
+	}
 
-    private File getImplDir() {
-        return new File(opts.topDir, opts.classDir.getPath());
-    }
+	private File getImplDir() {
+		return new File(opts.topDir, opts.classDir.getPath());
+	}
 
-    private String getImplPackage() {
-        return StringUtils.join(Arrays.asList(opts.pkg, opts.classPackage), ".");
-    }
+	private String getImplPackage() {
+		return StringUtils.join(Arrays.asList(opts.pkg, opts.classPackage), ".");
+	}
 
-    private File getIntfDir() {
-        return new File(opts.topDir, opts.interfaceDir.getPath());
-    }
+	private File getIntfDir() {
+		return new File(opts.topDir, opts.interfaceDir.getPath());
+	}
 
-    private String getIntfPackage() {
-        return StringUtils.join(Arrays.asList(opts.pkg, opts.interfacePackage), ".");
-    }
+	private String getIntfPackage() {
+		return StringUtils.join(Arrays.asList(opts.pkg, opts.interfacePackage), ".");
+	}
 
-    private static class Opts {
-        private static Options options = new Options() //
-                .addOption("t", "typeData", true, "type data file") //
-                .addOption("d", "dir", true, "top-level generation directory") //
-                .addOption("i", "interfaces", true, "directory to write interfaces") //
-                .addOption("c", "classes", true, "directory to write implementation classes") //
-                .addOption("p", "package", true, "containing package") //
-                .addOption("I", "interface-package", true, "subpackage for interfaces") //
-                .addOption("C", "class-package", true, "subpackage for classes") //
-                .addOption("s", "suffix", true, "suffix for implementation classes") //
-                .addOption("n", "noPreserve", false, "suppress preservation of non-genereated methods");
+	private static class Opts {
+		private static Options options = new Options() //
+				.addOption("t", "typeData", true, "type data file") //
+				.addOption("d", "dir", true, "top-level generation directory") //
+				.addOption("i", "interfaces", true, "directory to write interfaces") //
+				.addOption("c", "classes", true, "directory to write implementation classes") //
+				.addOption("p", "package", true, "containing package") //
+				.addOption("I", "interface-package", true, "subpackage for interfaces") //
+				.addOption("C", "class-package", true, "subpackage for classes") //
+				.addOption("s", "suffix", true, "suffix for implementation classes") //
+				.addOption("n", "noPreserve", false, "suppress preservation of non-genereated methods");
 
-        public File topDir = new File(".");
-        public File typeDataFile = new File("type-data.yaml");
-        public String interfacePackage = "";
-        public File interfaceDir = new File(".");
-        public File classDir = new File("impl");
-        public String pkg = CodeGenerator.class.getPackage().getName();
-        public String classPackage = "impl";
-        public String classSuffix = "Impl";
-        public boolean preserve = true;
+		public File topDir = new File(".");
+		public File typeDataFile = new File("type-data.yaml");
+		public String interfacePackage = "";
+		public File interfaceDir = new File(".");
+		public File classDir = new File("impl");
+		public String pkg = CodeGenerator.class.getPackage().getName();
+		public String classPackage = "impl";
+		public String classSuffix = "Impl";
+		public boolean preserve = true;
 
-        public Opts(String[] args) throws ParseException {
-            CommandLine cmd = new DefaultParser().parse(options,  args); 
-            if (cmd.hasOption('t')) {
-                typeDataFile = new File(cmd.getOptionValue('t'));
-            }
-            if (cmd.hasOption('d')) {
-                topDir = new File(cmd.getOptionValue('d'));
-            }
-            if (cmd.hasOption('i')) {
-                interfaceDir = new File(cmd.getOptionValue('i'));
-            }
-            if (cmd.hasOption('I')) {
-                interfacePackage = cmd.getOptionValue('I');
-            }
-            if (cmd.hasOption('c')) {
-                classDir = new File(cmd.getOptionValue('c'));
-            }
-            if (cmd.hasOption('C')) {
-                classPackage = cmd.getOptionValue('C');
-            }
-            if (cmd.hasOption('s')) {
-                classSuffix = cmd.getOptionValue('s');
-            }
-            if (cmd.hasOption('p')) {
-                pkg = cmd.getOptionValue('p');
-            }
-            if (cmd.hasOption('n')) {
-                preserve = false;
-            }
-        }
-    }
+		public Opts(String[] args) throws ParseException {
+			CommandLine cmd = new DefaultParser().parse(options, args);
+			if (cmd.hasOption('t')) {
+				typeDataFile = new File(cmd.getOptionValue('t'));
+			}
+			if (cmd.hasOption('d')) {
+				topDir = new File(cmd.getOptionValue('d'));
+			}
+			if (cmd.hasOption('i')) {
+				interfaceDir = new File(cmd.getOptionValue('i'));
+			}
+			if (cmd.hasOption('I')) {
+				interfacePackage = cmd.getOptionValue('I');
+			}
+			if (cmd.hasOption('c')) {
+				classDir = new File(cmd.getOptionValue('c'));
+			}
+			if (cmd.hasOption('C')) {
+				classPackage = cmd.getOptionValue('C');
+			}
+			if (cmd.hasOption('s')) {
+				classSuffix = cmd.getOptionValue('s');
+			}
+			if (cmd.hasOption('p')) {
+				pkg = cmd.getOptionValue('p');
+			}
+			if (cmd.hasOption('n')) {
+				preserve = false;
+			}
+		}
+	}
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/gen/ImplGenerator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/gen/ImplGenerator.java
@@ -14,12 +14,20 @@ import static com.reprezen.kaizen.oasparser.jsonoverlay.gen.Template.t;
 
 import java.io.File;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Queue;
+import java.util.Set;
+import java.util.stream.Collectors;
 
+import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.google.common.base.Function;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Queues;
+import com.google.common.collect.Sets;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ChildListOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ChildMapOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ChildOverlay;
@@ -38,265 +46,358 @@ import com.reprezen.kaizen.oasparser.jsonoverlay.gen.TypeData.Type;
 
 public class ImplGenerator extends TypeGenerator {
 
-    public ImplGenerator(File dir, String intfPackage, String implPackage, String suffix, boolean preserve) {
-        super(dir, intfPackage, implPackage, suffix, preserve);
-    }
+	public ImplGenerator(File dir, String intfPackage, String implPackage, String suffix, boolean preserve) {
+		super(dir, intfPackage, implPackage, suffix, preserve);
+	}
 
-    @Override
-    protected String getPackage() {
-        return implPackage;
-    }
+	@Override
+	protected String getPackage() {
+		return implPackage;
+	}
 
-    @Override
-    protected Collection<String> getImports(Type type) {
-        return type.getRequiredImports("impl");
-    }
+	@Override
+	protected Collection<String> getImports(Type type) {
+		return type.getRequiredImports("impl");
+	}
 
-    @Override
-    public Members getOtherMembers(Type type) {
-        Members members = new Members(type);
-        members.add(getElaborateChildrenMethod(type));
-        members.add(getFactoryMethod(type));
-        return members;
-    }
+	@Override
+	protected boolean needIntfImports() {
+		return true;
+	}
 
-    @Override
-    public ClassOrInterfaceDeclaration getTypeDeclaration(Type type, String suffix) {
-        requireTypes(type);
-        ClassOrInterfaceDeclaration decl = new ClassOrInterfaceDeclaration();
-        decl.setInterface(false);
-        decl.setPublic(true);
-        decl.setName(type.getName() + suffix);
-        decl.addExtendedType(getSuperType(type));
-        decl.addImplementedType(type.getName());
-        return decl;
-    }
+	@Override
+	public Members getOtherMembers(Type type) {
+		Members members = new Members(type);
+		members.add(getElaborateChildrenMethod(type));
+		members.addAll(getFactoryMembers(type));
+		return members;
+	}
 
-    private String getSuperType(Type type) {
-        String superType = type.getExtensionOf();
-        if (superType == null) {
-            requireTypes("PropertiesOverlay");
-            superType = t("PropertiesOverlay<${name}>", type);
-        } else {
-            superType = superType + suffix;
-        }
-        return superType;
-    }
+	@Override
+	public ClassOrInterfaceDeclaration getTypeDeclaration(Type type, String suffix) {
+		ClassOrInterfaceDeclaration decl = new ClassOrInterfaceDeclaration();
+		decl.setInterface(false);
+		decl.setPublic(true);
+		decl.setName(type.getName() + suffix);
+		decl.addExtendedType(getSuperType(type));
+		decl.addImplementedType(type.getName());
+		return decl;
+	}
 
-    @Override
-    protected Members getConstructors(Type type) {
-        Members members = new Members(type);
-        members.addConstructor("${implName}", //
-                "JsonNode", "json", "JsonOverlay<?>", "parent", "ReferenceRegistry", "refReg") //
-                .code( //
-                        "super(json, parent, refReg);", //
-                        "super.maybeElaborateChildrenAtCreation();");
-        requireTypes(JsonNode.class, JsonOverlay.class);
-        members.addConstructor("${implName}", //
-                "${name}", "${lcName}", "JsonOverlay<?>", "parent", "ReferenceRegistry", "refReg") //
-                .code( //
-                        "super(${lcName}, parent, refReg);", //
-                        "super.maybeElaborateChildrenAtCreation();");
-        return members;
-    }
+	private String getSuperType(Type type) {
+		String superType = type.getExtensionOf();
+		if (superType == null) {
+			requireTypes("PropertiesOverlay");
+			superType = t("PropertiesOverlay<${name}>", type);
+		} else {
+			superType = superType + suffix;
+		}
+		return superType;
+	}
 
-    @Override
-    protected boolean skipField(Field field) {
-        return field.isNoImpl();
-    }
+	@Override
+	protected Members getConstructors(Type type) {
+		Members members = new Members(type);
+		members.addConstructor("${implName}", //
+				"JsonNode", "json", "JsonOverlay<?>", "parent", "ReferenceRegistry", "refReg") //
+				.code( //
+						"super(json, parent, refReg);", //
+						"super.maybeElaborateChildrenAtCreation();");
+		requireTypes(JsonNode.class, JsonOverlay.class);
+		members.addConstructor("${implName}", //
+				"${name}", "${lcName}", "JsonOverlay<?>", "parent", "ReferenceRegistry", "refReg") //
+				.code( //
+						"super(${lcName}, parent, refReg);", //
+						"super.maybeElaborateChildrenAtCreation();");
+		return members;
+	}
 
-    @Override
-    protected Members getFieldMembers(Field field) {
-        requireTypes(field.getType(), field.getImplType());
-        Members members = new Members(field);
-        members.addField("${propType}", "${propName}", "null");
-        switch (field.getStructure()) {
-        case scalar:
-            requireTypes(ChildOverlay.class);
-        case collection:
-            requireTypes(Collection.class, ListOverlay.class, ChildListOverlay.class);
-            break;
-        case map:
-            requireTypes(Map.class, MapOverlay.class, ChildMapOverlay.class);
-            break;
-        default:
-            break;
-        }
-        return members;
-    }
+	@Override
+	protected boolean skipField(Field field) {
+		return field.isNoImpl();
+	}
 
-    @Override
-    protected Members getFieldMethods(Field field) {
-        Members methods = new Members(field);
-        boolean first = true;
-        String typeComment = field.getName();
-        if (field.isRefable()) {
-            requireTypes(Reference.class);
-        }
-        switch (field.getStructure()) {
-        case scalar:
-            for (Member method : getScalarMethods(field)) {
-                methods.addMember(method).override().comment(first ? typeComment : null);
-                first = false;
-            }
-            break;
-        case collection:
-            for (Member method : getCollectionMethods(field)) {
-                methods.addMember(method).override().comment(first ? typeComment : null);
-                first = false;
-            }
-            break;
-        case map:
-            for (Member method : getMapMethods(field)) {
-                methods.addMember(method).override().comment(first ? typeComment : null);
-                first = false;
-            }
-            break;
-        }
-        return methods;
-    }
+	@Override
+	protected Members getFieldMembers(Field field) {
+		requireTypes(field.getType(), field.getImplType());
+		Members members = new Members(field);
+		members.addField("${propType}", "${propName}", "null");
+		switch (field.getStructure()) {
+		case scalar:
+			requireTypes(ChildOverlay.class);
+		case collection:
+			requireTypes(Collection.class, ListOverlay.class, ChildListOverlay.class);
+			break;
+		case map:
+			requireTypes(Map.class, MapOverlay.class, ChildMapOverlay.class);
+			break;
+		default:
+			break;
+		}
+		return members;
+	}
 
-    private Members getScalarMethods(Field field) {
-        Members methods = new Members(field);
-        // T getFoo() => return foo.get()
-        methods.addMethod("${type}", "get${name}").code("return ${lcName}.get();");
-        // T getFoo(boolean elaborate) => return foo.get(elaborate)
-        methods.addMethod("${type}", "get${name}", "boolean", "elaborate").code("return ${lcName}.get(elaborate);");
-        if (field.isBoolean()) {
-            // boolean isFoo() => foo.get() != null ? foo.get() : boolDefault
-            methods.addMethod("boolean", "is${name}")
-                    .code("return ${lcName}.get() != null ? ${lcName}.get() : ${boolDefault};");
-        }
-        // void setFoo(T foo) => foo = this.foo.set(foo)
-        methods.addMethod("void", "set${name}", "${type}", "${lcName}").code("this.${lcName}.set(${lcName});");
-        if (field.isRefable()) {
-            // boolean isFooReference() => foo.isReference()
-            methods.addMethod("boolean", "is${name}Reference")
-                    .code("return ${lcName} != null ? ${lcName}.isReference() : false;");
-            // Reference getFooReference() => foo.getReference()
-            methods.addMethod("Reference", "get${name}Reference")
-                    .code("return ${lcName} != null ? ${lcName}.getReference() : null;");
-        }
-        return methods;
-    }
+	@Override
+	protected Members getFieldMethods(Field field) {
+		Members methods = new Members(field);
+		boolean first = true;
+		String typeComment = field.getName();
+		if (field.isRefable()) {
+			requireTypes(Reference.class);
+		}
+		switch (field.getStructure()) {
+		case scalar:
+			for (Member method : getScalarMethods(field)) {
+				methods.addMember(method).override().comment(first ? typeComment : null);
+				first = false;
+			}
+			break;
+		case collection:
+			for (Member method : getCollectionMethods(field)) {
+				methods.addMember(method).override().comment(first ? typeComment : null);
+				first = false;
+			}
+			break;
+		case map:
+			for (Member method : getMapMethods(field)) {
+				methods.addMember(method).override().comment(first ? typeComment : null);
+				first = false;
+			}
+			break;
+		}
+		return methods;
+	}
 
-    private Members getCollectionMethods(Field field) {
-        Members methods = new Members(field);
+	private Members getScalarMethods(Field field) {
+		Members methods = new Members(field);
+		// T getFoo() => return foo.get()
+		methods.addMethod("${type}", "get${name}").code("return ${lcName}.get();");
+		// T getFoo(boolean elaborate) => return foo.get(elaborate)
+		methods.addMethod("${type}", "get${name}", "boolean", "elaborate").code("return ${lcName}.get(elaborate);");
+		if (field.isBoolean()) {
+			// boolean isFoo() => foo.get() != null ? foo.get() : boolDefault
+			methods.addMethod("boolean", "is${name}")
+					.code("return ${lcName}.get() != null ? ${lcName}.get() : ${boolDefault};");
+		}
+		// void setFoo(T foo) => foo = this.foo.set(foo)
+		methods.addMethod("void", "set${name}", "${type}", "${lcName}").code("this.${lcName}.set(${lcName});");
+		if (field.isRefable()) {
+			// boolean isFooReference() => foo.isReference()
+			methods.addMethod("boolean", "is${name}Reference")
+					.code("return ${lcName} != null ? ${lcName}.isReference() : false;");
+			// Reference getFooReference() => foo.getReference()
+			methods.addMethod("Reference", "get${name}Reference")
+					.code("return ${lcName} != null ? ${lcName}.getReference() : null;");
+		}
+		return methods;
+	}
 
-        // Collection<T> getFoos(boolean) => foos.get()
-        methods.addMethod("Collection<${collType}>", "get${plural}").code("return ${lcPlural}.get();");
-        // Collection<T> getFoos(boolean elaborate) => foos.get(elaborate)
-        methods.addMethod("Collection<${collType}>", "get${plural}", "boolean", "elaborate")
-                .code("return ${lcPlural}.get(elaborate);");
-        // boolean hasFoos() => foos.isPresent()
-        methods.addMethod("boolean", "has${plural}").code("return ${lcPlural}.isPresent();");
-        // T getFoo(int index) => foos.get(index)
-        methods.addMethod("${type}", "get${name}", "int", "index").code("return ${lcPlural}.get(index);");
-        // void setFoos(Collection<T> foos) => this.foos.set((TImpl) foos)
-        methods.addMethod("void", "set${plural}", "Collection<${collType}>", "${lcPlural}")
-                .code("this.${lcPlural}.set((Collection<${collType}>) ${lcPlural});");
-        // void setFoo(int index, T foo) => foos.set(index, foo)
-        methods.addMethod("void", "set${name}", "int", "index", "${type}", "${lcName}")
-                .code("${lcPlural}.set(index, ${lcName});");
-        // void addFoo(Foo foo) => foos.add(foo)
-        methods.addMethod("void", "add${name}", "${type}", "${lcName}").code("${lcPlural}.add(${lcName});");
-        // void insertFoo(int index, Foo foo) => foos.insertOveraly(index, foo)
-        methods.addMethod("void", "insert${name}", "int", "index", "${type}", "${lcName}")
-                .code("${lcPlural}.insert(index, ${lcName});");
-        // void removeFoo(int index) => foos.remove(index)
-        methods.addMethod("void", "remove${name}", "int", "index").code("${lcPlural}.remove(index);");
-        // methods.addAll(getKeyedCollectionMethods(field));
-        if (field.isRefable()) {
-            // boolean isFooReference(int index) => foos.getChild(index).isReference()
-            methods.addMethod("boolean", "is${name}Reference", "int", "index")
-                    .code("return ${lcPlural}.getChild(index).isReference();");
-            // Reference getFooReference(int index) => foos.getChild(index).getReference()
-            methods.addMethod("Reference", "get${name}Reference", "int", "index")
-                    .code("return ${lcPlural}.getChild(index).getReference();");
-        }
-        return methods;
-    }
+	private Members getCollectionMethods(Field field) {
+		Members methods = new Members(field);
 
-    private Member getElaborateChildrenMethod(Type type) {
-        Collection<String> code = Lists.newArrayList();
-        for (Field field : type.getFields().values()) {
-            if (!field.isNoImpl()) {
-                code.addAll(code(field, "${propName} = ${propCons};"));
-                if (field.isRefable()) {
-                    code.addAll(code(field, "refables.put(${qpath}, ${propName});"));
-                }
-            }
-        }
-        return new MethodMember(null, "void", "elaborateChildren").override().protectedAccess().code(code);
-    }
+		// Collection<T> getFoos(boolean) => foos.get()
+		methods.addMethod("Collection<${collType}>", "get${plural}").code("return ${lcPlural}.get();");
+		// Collection<T> getFoos(boolean elaborate) => foos.get(elaborate)
+		methods.addMethod("Collection<${collType}>", "get${plural}", "boolean", "elaborate")
+				.code("return ${lcPlural}.get(elaborate);");
+		// boolean hasFoos() => foos.isPresent()
+		methods.addMethod("boolean", "has${plural}").code("return ${lcPlural}.isPresent();");
+		// T getFoo(int index) => foos.get(index)
+		methods.addMethod("${type}", "get${name}", "int", "index").code("return ${lcPlural}.get(index);");
+		// void setFoos(Collection<T> foos) => this.foos.set((TImpl) foos)
+		methods.addMethod("void", "set${plural}", "Collection<${collType}>", "${lcPlural}")
+				.code("this.${lcPlural}.set((Collection<${collType}>) ${lcPlural});");
+		// void setFoo(int index, T foo) => foos.set(index, foo)
+		methods.addMethod("void", "set${name}", "int", "index", "${type}", "${lcName}")
+				.code("${lcPlural}.set(index, ${lcName});");
+		// void addFoo(Foo foo) => foos.add(foo)
+		methods.addMethod("void", "add${name}", "${type}", "${lcName}").code("${lcPlural}.add(${lcName});");
+		// void insertFoo(int index, Foo foo) => foos.insertOveraly(index, foo)
+		methods.addMethod("void", "insert${name}", "int", "index", "${type}", "${lcName}")
+				.code("${lcPlural}.insert(index, ${lcName});");
+		// void removeFoo(int index) => foos.remove(index)
+		methods.addMethod("void", "remove${name}", "int", "index").code("${lcPlural}.remove(index);");
+		// methods.addAll(getKeyedCollectionMethods(field));
+		if (field.isRefable()) {
+			// boolean isFooReference(int index) => foos.getChild(index).isReference()
+			methods.addMethod("boolean", "is${name}Reference", "int", "index")
+					.code("return ${lcPlural}.getChild(index).isReference();");
+			// Reference getFooReference(int index) => foos.getChild(index).getReference()
+			methods.addMethod("Reference", "get${name}Reference", "int", "index")
+					.code("return ${lcPlural}.getChild(index).getReference();");
+		}
+		return methods;
+	}
 
-    private Member getFactoryMethod(Type type) {
-        requireTypes(OverlayFactory.class, JsonNode.class, ReferenceRegistry.class, IJsonOverlay.class);
-        String initializer = String.join("\n", t(type, "new OverlayFactory<${name}>() {", //
-                "    @Override", //
-                "    protected Class<? extends IJsonOverlay<? super ${name}>> getOverlayClass() {", //
-                "         return ${implName}.class;", //
-                "    }", //
-                "", //
-                "    @Override", //
-                "    public JsonOverlay<${name}> _create(${name} ${lcName}, JsonOverlay<?> parent, ReferenceRegistry refReg) {", //
-                "        JsonOverlay<?> overlay = new ${implName}(${lcName}, parent, refReg);", //
-                "        @SuppressWarnings(\"unchecked\")", //
-                "        JsonOverlay<${name}> castOverlay = (JsonOverlay<${name}>) overlay;", //
-                "        return castOverlay;", //
-                "    }", //
-                "", //
-                "    @Override", //
-                "    public JsonOverlay<${name}> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {", //
-                "        JsonOverlay<?> overlay = new ${implName}(json, parent, refReg);", //
-                "        @SuppressWarnings(\"unchecked\")", //
-                "        JsonOverlay<${name}> castOverlay = (JsonOverlay<${name}>) overlay;", //
-                "        return castOverlay;", //
-                "    }", //
-                "}"));
-        return new FieldMember(null, t("OverlayFactory<${name}>", type), "factory", initializer)._static(true)
-                .publicAccess();
-    }
+	private Member getElaborateChildrenMethod(Type type) {
+		Collection<String> code = Lists.newArrayList();
+		for (Field field : type.getFields().values()) {
+			if (!field.isNoImpl()) {
+				code.addAll(code(field, "${propName} = ${propCons};"));
+				if (field.isRefable()) {
+					code.addAll(code(field, "refables.put(${qpath}, ${propName});"));
+				}
+			}
+		}
+		return new MethodMember("void", "elaborateChildren").override().protectedAccess().code(code);
+	}
 
-    private Members getMapMethods(Field field) {
-        Members methods = new Members(field);
-        // Map<String, ? extends T> getFoos() => foos.get()
-        methods.addMethod("Map<String, ${collType}>", "get${plural}").code("return ${lcPlural}.get();");
-        // Map<String, ? extends T> getFoos(boolean elaborate) => foos.get(elaborate)
-        methods.addMethod("Map<String, ${collType}>", "get${plural}", "boolean", "elaborate")
-                .code("return ${lcPlural}.get(elaborate);");
-        // boolean hasFoo(String key) => foos.containsKey(key)
-        methods.addMethod("boolean", "has${name}", "String", "${keyName}")
-                .code("return ${lcPlural}.containsKey(${keyName});");
-        // T getFoo(String key) => foos.get(key)
-        methods.addMethod("${type}", "get${name}", "String", "${keyName}").code("return ${lcPlural}.get(${keyName});");
-        // void setFoos(Map<String, T> foos) => this.foos.set(foos)
-        methods.addMethod("void", "set${plural}", "Map<String, ${type}>", "${lcPlural}")
-                .code("this.${lcPlural}.set(${lcPlural});");
-        // void setFoo(String key, Foo foo) => foos.set(key, foo)
-        methods.addMethod("void", "set${name}", "String", "${keyName}", "${type}", "${lcName}")
-                .code("${lcPlural}.set(${keyName}, ${lcName});");
-        // void removeFoo(String key) => foos.remove(key)
-        methods.addMethod("void", "remove${name}", "String", "${keyName}").code("${lcPlural}.remove(${keyName});");
-        if (field.isRefable()) {
-            // boolean isFooReference(String key) => foos.getChild(key).isReference()
-            methods.addMethod("boolean", "is${name}Reference", "String", "key").code(
-                    "ChildOverlay<${type}> child = ${lcPlural}.getChild(key);",
-                    "return child != null ? child.isReference() : false;");
-            // Reference getFooReference(String key) => foos.getChild(key).getReference()
-            methods.addMethod("Reference", "get${name}Reference", "String", "key").code(
-                    "ChildOverlay<${type}> child = ${lcPlural}.getChild(key);",
-                    "return child != null ? child.getReference() : null;");
-        }
-        return methods;
-    }
+	private Members getFactoryMembers(Type type) {
+		Members members = new Members(type);
+		members.add(getFactoryMember(type));
+		members.addAll(getSubtypeSelectors(type));
+		return members;
+	}
 
-    private Collection<String> code(final Field field, String... lines) {
-        return Lists.transform(Lists.newArrayList(lines), new Function<String, String>() {
-            @Override
-            public String apply(String template) {
-                return t(template, field);
-            }
-        });
-    }
+	private Member getFactoryMember(Type type) {
+		requireTypes(OverlayFactory.class, JsonNode.class, ReferenceRegistry.class, IJsonOverlay.class);
+		String initializer = "" //
+				+ String.join("\n", t(type, //
+						"new OverlayFactory<${name}>() {", //
+						"    @Override", //
+						"    protected Class<? extends IJsonOverlay<? super ${name}>> getOverlayClass() {", //
+						"         return ${implName}.class;", //
+						"    }", //
+						"", //
+						"    @Override", //
+						"    public JsonOverlay<${name}> _create(${name} ${lcName}, JsonOverlay<?> parent, ReferenceRegistry refReg) {", //
+						"        Class<? extends ${name}> subtype = getSubtypeOf(${lcName});", //
+						"        IJsonOverlay<?> overlay;", //
+						"        if (subtype == null || subtype == ${name}.class) {", //
+						"            overlay = new ${implName}(${lcName}, parent, refReg);", //
+						"        } else {")) //
+				+ getSubtypeCreate(type, t("${lcName}", type)) //
+				+ String.join("\n", t(type, //
+						"        }", //
+						"        @SuppressWarnings(\"unchecked\")", //
+						"        JsonOverlay<${name}> castOverlay = (JsonOverlay<${name}>) overlay;", //
+						"        return castOverlay;", //
+						"    }", //
+						"", //
+						"    @Override", //
+						"    public JsonOverlay<${name}> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {", //
+						"        Class<? extends ${name}> subtype = getSubtypeOf(json);", //
+						"        IJsonOverlay<?> overlay;", //
+						"        if (subtype == null || subtype == ${name}.class) {", //
+						"            overlay = new ${implName}(json, parent, refReg);", //
+						"        } else {")) //
+				+ getSubtypeCreate(type, "json") //
+				+ String.join("\n", t(type, //
+						"        }", //
+						"        @SuppressWarnings(\"unchecked\")", //
+						"        JsonOverlay<${name}> castOverlay = (JsonOverlay<${name}>) overlay;", //
+						"        return castOverlay;", //
+						"    }", //
+						"}"));
+		return new FieldMember(null, t("OverlayFactory<${name}>", type), "factory", initializer)._static(true)
+				.publicAccess();
+	}
+
+	private Members getSubtypeSelectors(Type type) {
+		Members members = new Members(type);
+		Collection<Type> subTypes = getSubTypes(type);
+		if (!subTypes.isEmpty() && !type.isAbstract()) {
+			subTypes.add(type);
+		}
+		members.add(getValueSubtypeSelector(type, subTypes));
+		members.add(getJsonSubtypeSelector(type, subTypes));
+		return members;
+	}
+
+	private Member getValueSubtypeSelector(Type type, Collection<Type> subTypes) {
+		return new MethodMember(t("Class<? extends ${name}>", type), "getSubtypeOf", t("${name}", type),
+				t("${lcName}", type)) //
+						.privateAccess()._static(true) //
+						.code(getSubtypeSwitch(type, subTypes, t("${lcName}.getClass().getSimpleName()", type)));
+	}
+
+	private Member getJsonSubtypeSelector(Type type, Collection<Type> subTypes) {
+		requireTypes(JsonPointer.class, Collectors.class);
+		return new MethodMember(t("Class<? extends ${name}>", type), "getSubtypeOf", "JsonNode", "json") //
+				.privateAccess()._static(true) //
+				.code(getSubtypeSwitch(type, subTypes,
+						t("json.at(JsonPointer.compile(\"/${discriminator}\")).asText()", type)));
+	}
+
+	private String getSubtypeSwitch(Type type, Collection<Type> subTypes, String switchExpr) {
+		if (subTypes.isEmpty()) {
+			return t("return ${name}.class;", type);
+		} else {
+			return t("switch(${0}) {"
+					+ subTypes.stream().map(t -> t("case \"${discValue}\": return ${name}.class;", t))
+							.collect(Collectors.joining()) //
+					+ "default: return null;}", type, switchExpr);
+		}
+
+	}
+
+	private String getSubtypeCreate(Type type, String arg0) {
+		Collection<Type> subtypes = getSubTypes(type);
+		return "switch (subtype.getSimpleName()) {" //
+				+ subtypes.stream().map(t -> {
+					String cast = arg0.equals("json") ? "" : t("(${name}) ", t);
+					return t(
+							"case \"${discValue}\": overlay = ${implName}.factory.create(${1}${0}, parent, refReg, null); break;",
+							t, arg0, cast);
+				}).collect(Collectors.joining()) //
+				+ "default: overlay = null;}";
+	}
+
+	private Collection<Type> getSubTypes(Type type) {
+		Set<Type> subTypes = Sets.newHashSet();
+		Queue<Type> todo = Queues.newArrayDeque();
+		todo.add(type);
+		while (!todo.isEmpty()) {
+			Type nextType = todo.remove();
+			if (!subTypes.contains(nextType)) {
+				List<Type> directSubtypes = type.getTypeData().getTypes().stream() //
+						.filter(t -> Objects.equals(t.getExtensionOf(), nextType.getName())) //
+						.collect(Collectors.toList());
+				subTypes.addAll(directSubtypes);
+			}
+		}
+		return subTypes;
+	}
+
+	private Members getMapMethods(Field field) {
+		Members methods = new Members(field);
+		// Map<String, ? extends T> getFoos() => foos.get()
+		methods.addMethod("Map<String, ${collType}>", "get${plural}").code("return ${lcPlural}.get();");
+		// Map<String, ? extends T> getFoos(boolean elaborate) => foos.get(elaborate)
+		methods.addMethod("Map<String, ${collType}>", "get${plural}", "boolean", "elaborate")
+				.code("return ${lcPlural}.get(elaborate);");
+		// boolean hasFoo(String key) => foos.containsKey(key)
+		methods.addMethod("boolean", "has${name}", "String", "${keyName}")
+				.code("return ${lcPlural}.containsKey(${keyName});");
+		// T getFoo(String key) => foos.get(key)
+		methods.addMethod("${type}", "get${name}", "String", "${keyName}").code("return ${lcPlural}.get(${keyName});");
+		// void setFoos(Map<String, T> foos) => this.foos.set(foos)
+		methods.addMethod("void", "set${plural}", "Map<String, ${type}>", "${lcPlural}")
+				.code("this.${lcPlural}.set(${lcPlural});");
+		// void setFoo(String key, Foo foo) => foos.set(key, foo)
+		methods.addMethod("void", "set${name}", "String", "${keyName}", "${type}", "${lcName}")
+				.code("${lcPlural}.set(${keyName}, ${lcName});");
+		// void removeFoo(String key) => foos.remove(key)
+		methods.addMethod("void", "remove${name}", "String", "${keyName}").code("${lcPlural}.remove(${keyName});");
+		if (field.isRefable()) {
+			// boolean isFooReference(String key) => foos.getChild(key).isReference()
+			methods.addMethod("boolean", "is${name}Reference", "String", "key").code(
+					"ChildOverlay<${type}> child = ${lcPlural}.getChild(key);",
+					"return child != null ? child.isReference() : false;");
+			// Reference getFooReference(String key) => foos.getChild(key).getReference()
+			methods.addMethod("Reference", "get${name}Reference", "String", "key").code(
+					"ChildOverlay<${type}> child = ${lcPlural}.getChild(key);",
+					"return child != null ? child.getReference() : null;");
+		}
+		return methods;
+	}
+
+	private Collection<String> code(final Field field, String... lines) {
+		return Lists.transform(Lists.newArrayList(lines), new Function<String, String>() {
+			@Override
+			public String apply(String template) {
+				return t(template, field);
+			}
+		});
+	}
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/gen/InterfaceGenerator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/gen/InterfaceGenerator.java
@@ -24,154 +24,154 @@ import com.reprezen.kaizen.oasparser.jsonoverlay.gen.TypeData.Type;
 
 public class InterfaceGenerator extends TypeGenerator {
 
-    public InterfaceGenerator(File dir, String intfPackage, String implPackage, String suffix, boolean preserve) {
-        super(dir, intfPackage, implPackage, suffix, preserve);
-    }
+	public InterfaceGenerator(File dir, String intfPackage, String implPackage, String suffix, boolean preserve) {
+		super(dir, intfPackage, implPackage, suffix, preserve);
+	}
 
-    @Override
-    protected String getPackage() {
-        return intfPackage;
-    }
+	@Override
+	protected String getPackage() {
+		return intfPackage;
+	}
 
-    @Override
-    protected ClassOrInterfaceDeclaration getTypeDeclaration(Type type, String suffix) {
-        ClassOrInterfaceDeclaration decl = new ClassOrInterfaceDeclaration();
-        decl.setInterface(true);
-        decl.setName(type.getName());
-        decl.setPublic(true);
-        String superType = getSuperType(type);
-        requireTypes(superType);
-        decl.addExtendedType(superType);
-        if (type.getTypeData().getModelType() != null) {
-            requireTypes("IModelPart");
-            decl.addExtendedType(t("IModelPart<${modelType}, ${name}>", type));
-        }
-        for (String extensionType : type.getExtendInterfaces()) {
-            requireTypes(extensionType);
-            decl.addExtendedType(extensionType);
-        }
-        return decl;
-    }
+	@Override
+	protected ClassOrInterfaceDeclaration getTypeDeclaration(Type type, String suffix) {
+		ClassOrInterfaceDeclaration decl = new ClassOrInterfaceDeclaration();
+		decl.setInterface(true);
+		decl.setName(type.getName());
+		decl.setPublic(true);
+		String superType = getSuperType(type);
+		requireTypes(superType);
+		decl.addExtendedType(superType);
+		if (type.getTypeData().getModelType() != null) {
+			requireTypes("IModelPart");
+			decl.addExtendedType(t("IModelPart<${modelType}, ${name}>", type));
+		}
+		for (String extensionType : type.getExtendInterfaces()) {
+			requireTypes(extensionType);
+			decl.addExtendedType(extensionType);
+		}
+		return decl;
+	}
 
-    @Override
-    protected Collection<String> getImports(Type type) {
-        return type.getRequiredImports("intf");
-    }
+	@Override
+	protected Collection<String> getImports(Type type) {
+		return type.getRequiredImports("intf");
+	}
 
-    private String getSuperType(Type type) {
-        String superType = type.getExtensionOf();
-        return superType != null ? superType : t("IPropertiesOverlay<${name}>", type);
-    }
+	private String getSuperType(Type type) {
+		String superType = type.getExtensionOf();
+		return superType != null ? superType : t("IPropertiesOverlay<${name}>", type);
+	}
 
-    @Override
-    protected Members getFieldMethods(Field field) {
-        Members methods = new Members(field);
-        requireTypes(field.getType());
-        boolean first = true;
-        String typeComment = field.getName();
-        if (field.isRefable()) {
-            requireTypes(Reference.class);
-        }
-        switch (field.getStructure()) {
-        case scalar:
-            for (Member method : getScalarMethods(field)) {
-                methods.addMember(method).comment(first ? typeComment : null);
-                first = false;
-            }
-            break;
-        case collection:
-            requireTypes(Collection.class);
-            for (Member method : getCollectionMethods(field)) {
-                methods.addMember(method).comment(first ? typeComment : null);
-                first = false;
-            }
-            break;
-        case map:
-            requireTypes(Map.class);
-            for (Member method : getMapMethods(field)) {
-                methods.addMember(method).comment(first ? typeComment : null);
-                first = false;
-            }
-            break;
-        }
-        for (Member method : methods) {
-            method.packageAccess();
-        }
-        return methods;
-    }
+	@Override
+	protected Members getFieldMethods(Field field) {
+		Members methods = new Members(field);
+		requireTypes(field.getType());
+		boolean first = true;
+		String typeComment = field.getName();
+		if (field.isRefable()) {
+			requireTypes(Reference.class);
+		}
+		switch (field.getStructure()) {
+		case scalar:
+			for (Member method : getScalarMethods(field)) {
+				methods.addMember(method).comment(first ? typeComment : null);
+				first = false;
+			}
+			break;
+		case collection:
+			requireTypes(Collection.class);
+			for (Member method : getCollectionMethods(field)) {
+				methods.addMember(method).comment(first ? typeComment : null);
+				first = false;
+			}
+			break;
+		case map:
+			requireTypes(Map.class);
+			for (Member method : getMapMethods(field)) {
+				methods.addMember(method).comment(first ? typeComment : null);
+				first = false;
+			}
+			break;
+		}
+		for (Member method : methods) {
+			method.packageAccess();
+		}
+		return methods;
+	}
 
-    private Members getScalarMethods(Field field) {
-        Members methods = new Members(field);
-        // T getFoo()
-        methods.addMethod("${type}", "get${name}");
-        // T getFoo(boolean elaborate)
-        methods.addMethod("${type}", "get${name}", "boolean", "elaborate");
-        if (field.getType().equals("Boolean")) {
-            // boolean isFoo()
-            methods.addMethod("boolean", "is${name}");
-        }
-        // void setFoo(T foo)
-        methods.addMethod("void", "set${name}", "${type}", "${lcName}");
-        if (field.isRefable()) {
-            // boolean isFooReference()
-            methods.addMethod("boolean", "is${name}Reference");
-            // Reference getFooReference()
-            methods.addMethod("Reference", "get${name}Reference");
-        }
-        return methods;
-    }
+	private Members getScalarMethods(Field field) {
+		Members methods = new Members(field);
+		// T getFoo()
+		methods.addMethod("${type}", "get${name}");
+		// T getFoo(boolean elaborate)
+		methods.addMethod("${type}", "get${name}", "boolean", "elaborate");
+		if (field.getType().equals("Boolean")) {
+			// boolean isFoo()
+			methods.addMethod("boolean", "is${name}");
+		}
+		// void setFoo(T foo)
+		methods.addMethod("void", "set${name}", "${type}", "${lcName}");
+		if (field.isRefable()) {
+			// boolean isFooReference()
+			methods.addMethod("boolean", "is${name}Reference");
+			// Reference getFooReference()
+			methods.addMethod("Reference", "get${name}Reference");
+		}
+		return methods;
+	}
 
-    private Members getCollectionMethods(Field field) {
-        Members methods = new Members(field);
-        // Collection<? extends T> getFoos()
-        methods.addMethod("Collection<${collType}>", "get${plural}");
-        // Collection<? extends T> getFoos(boolean elaborate)
-        methods.addMethod(t("Collection<${collType}>", field), t("get${plural}", field), "boolean", "elaborate");
-        // boolean hasFoos()
-        methods.addMethod("boolean", t("has${plural}", field));
-        // T getFoo(int index)
-        methods.addMethod(t("${type}", field), t("get${name}", field), "int", "index");
-        // void setFoos(Collection<? extends T> foos)
-        methods.addMethod("void", "set${plural}", "Collection<${collType}>", "${lcPlural}");
-        // void setFoo(int index, Foo foo)
-        methods.addMethod("void", "set${name}", "int", "index", "${type}", "${lcName}");
-        // void addFoo(Foo foo)
-        methods.addMethod("void", "add${name}", "${type}", "${lcName}");
-        // void insertFoo(int index, Foo foo)
-        methods.addMethod("void", "insert${name}", "int", "index", "${type}", "${lcName}");
-        // void removeFoo(int index)
-        methods.addMethod("void", "remove${name}", "int", "index");
-        if (field.isRefable()) {
-            // boolean isFooReference(int index)
-            methods.addMethod("boolean", "is${name}Reference", "int", "index");
-            // ReferencegetFooReference(int index)
-            methods.addMethod("Reference", "get${name}Reference", "int", "index");
-        }
-        return methods;
-    }
+	private Members getCollectionMethods(Field field) {
+		Members methods = new Members(field);
+		// Collection<? extends T> getFoos()
+		methods.addMethod("Collection<${collType}>", "get${plural}");
+		// Collection<? extends T> getFoos(boolean elaborate)
+		methods.addMethod(t("Collection<${collType}>", field), t("get${plural}", field), "boolean", "elaborate");
+		// boolean hasFoos()
+		methods.addMethod("boolean", t("has${plural}", field));
+		// T getFoo(int index)
+		methods.addMethod(t("${type}", field), t("get${name}", field), "int", "index");
+		// void setFoos(Collection<? extends T> foos)
+		methods.addMethod("void", "set${plural}", "Collection<${collType}>", "${lcPlural}");
+		// void setFoo(int index, Foo foo)
+		methods.addMethod("void", "set${name}", "int", "index", "${type}", "${lcName}");
+		// void addFoo(Foo foo)
+		methods.addMethod("void", "add${name}", "${type}", "${lcName}");
+		// void insertFoo(int index, Foo foo)
+		methods.addMethod("void", "insert${name}", "int", "index", "${type}", "${lcName}");
+		// void removeFoo(int index)
+		methods.addMethod("void", "remove${name}", "int", "index");
+		if (field.isRefable()) {
+			// boolean isFooReference(int index)
+			methods.addMethod("boolean", "is${name}Reference", "int", "index");
+			// ReferencegetFooReference(int index)
+			methods.addMethod("Reference", "get${name}Reference", "int", "index");
+		}
+		return methods;
+	}
 
-    private Members getMapMethods(Field field) {
-        Members methods = new Members(field);
-        // Map<String, ? extends T> getFoos()
-        methods.addMethod("Map<String, ${collType}>", "get${plural}");
-        // Map<String, ? extends T> getFoos(boolean elaborate)
-        methods.addMethod("Map<String, ${collType}>", "get${plural}", "boolean", "elaborate");
-        // boolean hasFoo(String name)
-        methods.addMethod("boolean", "has${name}", "String", "${keyName}");
-        // Foo getFoo(String name)
-        methods.addMethod("${type}", "get${name}", "String", "${keyName}");
-        // void setFoos(Map<String, ? extends T> foos)
-        methods.addMethod("void", "set${plural}", "Map<String, ${collType}>", "${lcPlural}");
-        // void setFoo(String name, Foo foo)
-        methods.addMethod("void", "set${name}", "String", "${keyName}", "${type}", "${lcName}");
-        // void removeFoo(String name)
-        methods.addMethod("void", "remove${name}", "String", "${keyName}");
-        if (field.isRefable()) {
-            // boolean isFooReference(String key)
-            methods.addMethod("boolean", "is${name}Reference", "String", "key");
-            // ReferencegetFooReference(int index)
-            methods.addMethod("Reference", "get${name}Reference", "String", "key");
-        }
-        return methods;
-    }
+	private Members getMapMethods(Field field) {
+		Members methods = new Members(field);
+		// Map<String, ? extends T> getFoos()
+		methods.addMethod("Map<String, ${collType}>", "get${plural}");
+		// Map<String, ? extends T> getFoos(boolean elaborate)
+		methods.addMethod("Map<String, ${collType}>", "get${plural}", "boolean", "elaborate");
+		// boolean hasFoo(String name)
+		methods.addMethod("boolean", "has${name}", "String", "${keyName}");
+		// Foo getFoo(String name)
+		methods.addMethod("${type}", "get${name}", "String", "${keyName}");
+		// void setFoos(Map<String, ? extends T> foos)
+		methods.addMethod("void", "set${plural}", "Map<String, ${collType}>", "${lcPlural}");
+		// void setFoo(String name, Foo foo)
+		methods.addMethod("void", "set${name}", "String", "${keyName}", "${type}", "${lcName}");
+		// void removeFoo(String name)
+		methods.addMethod("void", "remove${name}", "String", "${keyName}");
+		if (field.isRefable()) {
+			// boolean isFooReference(String key)
+			methods.addMethod("boolean", "is${name}Reference", "String", "key");
+			// ReferencegetFooReference(int index)
+			methods.addMethod("Reference", "get${name}Reference", "String", "key");
+		}
+		return methods;
+	}
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/gen/SimpleJavaGenerator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/gen/SimpleJavaGenerator.java
@@ -49,381 +49,389 @@ import com.reprezen.kaizen.oasparser.jsonoverlay.gen.TypeData.Field;
 
 public class SimpleJavaGenerator {
 
-    private String pkg;
-    private Set<String> imports = Sets.newHashSet();
-    private ClassOrInterfaceDeclaration type;
-    private List<Member> members = Lists.newArrayList();
-    private String fileComment;
-    private static JavaParser parser = new JavaParser(new ParserConfiguration().setValidator(new Java8Validator()));
-    private static int indentation = 4;
+	private String pkg;
+	private Set<String> imports = Sets.newHashSet();
+	private ClassOrInterfaceDeclaration type;
+	private List<Member> members = Lists.newArrayList();
+	private String fileComment;
+	private static JavaParser parser = new JavaParser(new ParserConfiguration().setValidator(new Java8Validator()));
+	private static int indentation = 4;
 
-    public SimpleJavaGenerator(String pkg, ClassOrInterfaceDeclaration type) {
-        this.pkg = pkg;
-        this.type = type;
-    }
+	public SimpleJavaGenerator(String pkg, ClassOrInterfaceDeclaration type) {
+		this.pkg = pkg;
+		this.type = type;
+	}
 
-    public String getPackage() {
-        return pkg;
-    }
+	public String getPackage() {
+		return pkg;
+	}
 
-    public void setPackage(String pkg) {
-        this.pkg = pkg;
-    }
+	public void setPackage(String pkg) {
+		this.pkg = pkg;
+	}
 
-    public int getIndentation() {
-        return indentation;
-    }
+	public int getIndentation() {
+		return indentation;
+	}
 
-    public void setIndentation(int indentation) {
-        SimpleJavaGenerator.indentation = indentation;
-    }
+	public void setIndentation(int indentation) {
+		SimpleJavaGenerator.indentation = indentation;
+	}
 
-    public Collection<Member> getMembers() {
-        return members;
-    }
+	public Collection<Member> getMembers() {
+		return members;
+	}
 
-    public void addMember(Member member) {
-        members.add(member);
-    }
+	public void addMember(Member member) {
+		members.add(member);
+	}
 
-    public void addMembers(Collection<Member> members) {
-        this.members.addAll(members);
-    }
+	public void addMembers(Collection<Member> members) {
+		this.members.addAll(members);
+	}
 
-    public void addGeneratedMembers(Collection<Member> members) {
-        for (Member member : members) {
-            this.members.add(member.generated(true));
-        }
-    }
+	public void addGeneratedMembers(Collection<Member> members) {
+		for (Member member : members) {
+			this.members.add(member.generated(true));
+		}
+	}
 
-    public void setFileComment(String fileComment) {
-        this.fileComment = fileComment;
-    }
+	public void setFileComment(String fileComment) {
+		this.fileComment = fileComment;
+	}
 
-    public void addImport(String imp) {
-        if (imp != null) {
-            imports.add(imp);
-        }
-    }
+	public void addImport(String imp) {
+		if (imp != null) {
+			imports.add(imp);
+		}
+	}
 
-    public String format() {
-        CompilationUnit cu = new CompilationUnit();
-        if (fileComment != null) {
-            cu.addOrphanComment(new JavadocComment(fileComment));
-        }
-        cu.setPackageDeclaration(pkg);
-        for (String imp : imports) {
-            cu.addImport(imp);
-        }
-        cu.addType(type);
-        for (Member member : gatherFinalMembers(members, cu)) {
-            type.addMember(member.getDeclaration());
-        }
-        return cu.toString();
-    }
+	public String format() {
+		CompilationUnit cu = new CompilationUnit();
+		if (fileComment != null) {
+			cu.addOrphanComment(new JavadocComment(fileComment));
+		}
+		cu.setPackageDeclaration(pkg);
+		for (String imp : imports) {
+			cu.addImport(imp);
+		}
+		cu.addType(type);
+		for (Member member : gatherFinalMembers(members, cu)) {
+			type.addMember(member.getDeclaration());
+		}
+		return cu.toString();
+	}
 
-    private Collection<Member> gatherFinalMembers(List<Member> members, CompilationUnit cu) {
-        Map<String, Member> memberMap = Maps.newLinkedHashMap();
-        for (Member member : members) {
-            String key = member.getKey();
-            if (!memberMap.containsKey(key)) {
-                memberMap.put(key, member);
-            } else {
-                BodyDeclaration<?> copy = member.getDeclaration().clone();
-                if (copy instanceof ConstructorDeclaration) {
-                    ((ConstructorDeclaration) copy).setBody(JavaParser.parseBlock("{}"));
-                    ((ConstructorDeclaration) copy).setComment(null);
-                } else if (copy instanceof MethodDeclaration) {
-                    ((MethodDeclaration) copy).setBody(null);
-                    ((MethodDeclaration) copy).setComment(null);
-                } else if (copy instanceof FieldDeclaration) {
-                    ((FieldDeclaration) copy).getVariable(0).setInitializer((Expression) null);
-                    ((FieldDeclaration) copy).setComment(null);
-                }
-                copy.setAnnotations(new NodeList<>());
-                Logger.getGlobal().warning(String.format("Suppressing already-present generated member in type %s: %s",
-                        cu.getType(0).getNameAsString(), copy.toString()));
-            }
-        }
-        return memberMap.values();
-    }
+	private Collection<Member> gatherFinalMembers(List<Member> members, CompilationUnit cu) {
+		Map<String, Member> memberMap = Maps.newLinkedHashMap();
+		for (Member member : members) {
+			String key = member.getKey();
+			if (!memberMap.containsKey(key)) {
+				memberMap.put(key, member);
+			} else {
+				BodyDeclaration<?> copy = member.getDeclaration().clone();
+				if (copy instanceof ConstructorDeclaration) {
+					((ConstructorDeclaration) copy).setBody(JavaParser.parseBlock("{}"));
+					((ConstructorDeclaration) copy).setComment(null);
+				} else if (copy instanceof MethodDeclaration) {
+					((MethodDeclaration) copy).setBody(null);
+					((MethodDeclaration) copy).setComment(null);
+				} else if (copy instanceof FieldDeclaration) {
+					((FieldDeclaration) copy).getVariable(0).setInitializer((Expression) null);
+					((FieldDeclaration) copy).setComment(null);
+				}
+				copy.setAnnotations(new NodeList<>());
+				Logger.getGlobal().warning(String.format("Suppressing already-present generated member in type %s: %s",
+						cu.getType(0).getNameAsString(), copy.toString()));
+			}
+		}
+		return memberMap.values();
+	}
 
-    public static class Member {
-        protected BodyDeclaration<?> declaration;
-        protected Field field = null;
-        protected com.reprezen.kaizen.oasparser.jsonoverlay.gen.TypeData.Type type = null;
+	public static class Member {
+		protected BodyDeclaration<?> declaration;
+		protected Field field = null;
+		protected com.reprezen.kaizen.oasparser.jsonoverlay.gen.TypeData.Type type = null;
 
-        public Member(com.reprezen.kaizen.oasparser.jsonoverlay.gen.TypeData.Type type,
-                BodyDeclaration<?> declaration) {
-            this(declaration);
-            this.type = type;
-        }
+		public Member(com.reprezen.kaizen.oasparser.jsonoverlay.gen.TypeData.Type type,
+				BodyDeclaration<?> declaration) {
+			this(declaration);
+			this.type = type;
+		}
 
-        public Member(Field field, BodyDeclaration<?> declaration) {
-            this(declaration);
-            this.field = field;
-        }
+		public Member(Field field, BodyDeclaration<?> declaration) {
+			this(declaration);
+			this.field = field;
+		}
 
-        public Member(BodyDeclaration<?> declaration) {
-            this.declaration = declaration;
-        }
+		public Member(BodyDeclaration<?> declaration) {
+			this.declaration = declaration;
+		}
 
-        public BodyDeclaration<?> getDeclaration() {
-            return declaration;
-        }
+		public BodyDeclaration<?> getDeclaration() {
+			return declaration;
+		}
 
-        public String getKey() {
-            if (declaration instanceof FieldDeclaration) {
-                FieldDeclaration field = (FieldDeclaration) declaration;
-                if (field.getVariables().size() != 1) {
-                    throw new RuntimeException(
-                            "Multiple fields in a single manual field declaration is not yet supported: "
-                                    + field.toString());
-                }
-                return "F:" + field.getVariable(0).getNameAsString();
-            } else if (declaration instanceof MethodDeclaration) {
-                MethodDeclaration method = (MethodDeclaration) declaration;
-                return "M:" + method.getNameAsString() + ":" + method.getParameters().stream()
-                        .map(p -> p.getType().toString()).collect(Collectors.joining(","));
-            } else if (declaration instanceof ConstructorDeclaration) {
-                ConstructorDeclaration constructor = (ConstructorDeclaration) declaration;
-                return "C:" + constructor.getParameters().stream().map(p -> p.getType().toString())
-                        .collect(Collectors.joining(","));
-            }
-            throw new RuntimeException(
-                    "Unsupported manual member type encountered: " + declaration.getClass().getName());
-        }
+		public String getKey() {
+			if (declaration instanceof FieldDeclaration) {
+				FieldDeclaration field = (FieldDeclaration) declaration;
+				if (field.getVariables().size() != 1) {
+					throw new RuntimeException(
+							"Multiple fields in a single manual field declaration is not yet supported: "
+									+ field.toString());
+				}
+				return "F:" + field.getVariable(0).getNameAsString();
+			} else if (declaration instanceof MethodDeclaration) {
+				MethodDeclaration method = (MethodDeclaration) declaration;
+				return "M:" + method.getNameAsString() + ":" + method.getParameters().stream()
+						.map(p -> p.getType().toString()).collect(Collectors.joining(","));
+			} else if (declaration instanceof ConstructorDeclaration) {
+				ConstructorDeclaration constructor = (ConstructorDeclaration) declaration;
+				return "C:" + constructor.getParameters().stream().map(p -> p.getType().toString())
+						.collect(Collectors.joining(","));
+			}
+			throw new RuntimeException(
+					"Unsupported manual member type encountered: " + declaration.getClass().getName());
+		}
 
-        public Member override() {
-            declaration.addMarkerAnnotation(Override.class);
-            return this;
-        }
+		public Member override() {
+			declaration.addMarkerAnnotation(Override.class);
+			return this;
+		}
 
-        public Member comment(String comment) {
-            return this;
-        }
+		public Member comment(String comment) {
+			return this;
+		}
 
-        public Member generated(boolean generated) {
-            if (generated) {
-                declaration.addSingleMemberAnnotation(Generated.class, "\"" + CodeGenerator.class.getName() + "\"");
-            }
-            return this;
-        }
+		public Member generated(boolean generated) {
+			if (generated) {
+				declaration.addSingleMemberAnnotation(Generated.class, "\"" + CodeGenerator.class.getName() + "\"");
+			}
+			return this;
+		}
 
-        public Member code(String... code) {
-            return code(Arrays.asList(code));
-        }
+		public Member code(String... code) {
+			return code(Arrays.asList(code));
+		}
 
-        public Member code(Collection<String> code) {
-            throw new RuntimeException("Cannot add code to member of type " + this.declaration.getClass());
-        }
+		public Member code(Collection<String> code) {
+			throw new RuntimeException("Cannot add code to member of type " + this.declaration.getClass());
+		}
 
-        public Member _static(boolean _static) {
-            throw new RuntimeException("Cannot set member of type " + this.declaration.getClass() + " static");
-        }
+		public Member _static(boolean _static) {
+			throw new RuntimeException("Cannot set member of type " + this.declaration.getClass() + " static");
+		}
 
-        public Member publicAccess() {
-            setAccess(Modifier.PUBLIC);
-            return this;
-        }
+		public Member publicAccess() {
+			setAccess(Modifier.PUBLIC);
+			return this;
+		}
 
-        public Member protectedAccess() {
-            setAccess(Modifier.PROTECTED);
-            return this;
-        }
+		public Member protectedAccess() {
+			setAccess(Modifier.PROTECTED);
+			return this;
+		}
 
-        public Member packageAccess() {
-            setAccess(null);
-            return this;
-        }
+		public Member packageAccess() {
+			setAccess(null);
+			return this;
+		}
 
-        public Member privateAccess() {
-            setAccess(Modifier.PRIVATE);
-            return this;
-        }
+		public Member privateAccess() {
+			setAccess(Modifier.PRIVATE);
+			return this;
+		}
 
-        protected void setAccess(Modifier mod) {
-        }
+		protected void setAccess(Modifier mod) {
+		}
 
-        protected final EnumSet<Modifier> setAccessModifier(EnumSet<Modifier> mods, Modifier mod) {
-            mods.remove(Modifier.PUBLIC);
-            mods.remove(Modifier.PROTECTED);
-            mods.remove(Modifier.PRIVATE);
-            if (mod != null) { // package private
-                mods.add(mod);
-            }
-            return mods;
-        }
+		protected final EnumSet<Modifier> setAccessModifier(EnumSet<Modifier> mods, Modifier mod) {
+			mods.remove(Modifier.PUBLIC);
+			mods.remove(Modifier.PROTECTED);
+			mods.remove(Modifier.PRIVATE);
+			if (mod != null) { // package private
+				mods.add(mod);
+			}
+			return mods;
+		}
 
-        public String format() {
-            return declaration.toString();
-        }
+		public String format() {
+			return declaration.toString();
+		}
 
-        public String getName() {
-            return null;
-        }
+		public String getName() {
+			return null;
+		}
 
-        public void setName(String name) {
-        }
-    }
+		public void setName(String name) {
+		}
+	}
 
-    public static class ConstructorMember extends Member {
-        private ConstructorDeclaration cons;
+	public static class ConstructorMember extends Member {
+		private ConstructorDeclaration cons;
 
-        public ConstructorMember(com.reprezen.kaizen.oasparser.jsonoverlay.gen.TypeData.Type type, String className,
-                String... paramPairs) {
-            this(type, className, Arrays.asList(paramPairs));
-            this.cons = (ConstructorDeclaration) declaration;
-        }
+		public ConstructorMember(com.reprezen.kaizen.oasparser.jsonoverlay.gen.TypeData.Type type, String className,
+				String... paramPairs) {
+			this(type, className, Arrays.asList(paramPairs));
+			this.cons = (ConstructorDeclaration) declaration;
+		}
 
-        public ConstructorMember(com.reprezen.kaizen.oasparser.jsonoverlay.gen.TypeData.Type type, String className,
-                List<String> paramPairs) {
-            super(type, constructorDecl(type, className, paramPairs));
-        }
+		public ConstructorMember(com.reprezen.kaizen.oasparser.jsonoverlay.gen.TypeData.Type type, String className,
+				List<String> paramPairs) {
+			super(type, constructorDecl(type, className, paramPairs));
+		}
 
-        @Override
-        public Member code(Collection<String> code) {
-            // JavaParser does not appear capable of parsing calls to super() and this() in
-            // block statements. So we need to just add the statements one at a time...
-            BlockStmt body = cons.getBody();
-            for (String stmt : expandStrings(type, code)) {
-                body.addStatement(stmt);
-            }
-            return this;
-        }
+		@Override
+		public Member code(Collection<String> code) {
+			// JavaParser does not appear capable of parsing calls to super() and this() in
+			// block statements. So we need to just add the statements one at a time...
+			BlockStmt body = cons.getBody();
+			for (String stmt : expandStrings(type, code)) {
+				body.addStatement(stmt);
+			}
+			return this;
+		}
 
-        @Override
-        protected void setAccess(Modifier mod) {
-            cons.setModifiers(setAccessModifier(cons.getModifiers(), mod));
-        }
-    }
+		@Override
+		protected void setAccess(Modifier mod) {
+			cons.setModifiers(setAccessModifier(cons.getModifiers(), mod));
+		}
+	}
 
-    private static ConstructorDeclaration constructorDecl(
-            com.reprezen.kaizen.oasparser.jsonoverlay.gen.TypeData.Type type, String className,
-            List<String> paramPairs) {
-        ConstructorDeclaration decl = new ConstructorDeclaration();
-        decl.setPublic(true);
-        decl.setName(t(className, type));
-        for (int i = 0; i < paramPairs.size(); i += 2) {
-            decl.addParameter(t(paramPairs.get(i), type), t(paramPairs.get(i + 1), type));
-        }
-        return decl;
-    }
+	private static ConstructorDeclaration constructorDecl(
+			com.reprezen.kaizen.oasparser.jsonoverlay.gen.TypeData.Type type, String className,
+			List<String> paramPairs) {
+		ConstructorDeclaration decl = new ConstructorDeclaration();
+		decl.setPublic(true);
+		decl.setName(t(className, type));
+		for (int i = 0; i < paramPairs.size(); i += 2) {
+			decl.addParameter(t(paramPairs.get(i), type), t(paramPairs.get(i + 1), type));
+		}
+		return decl;
+	}
 
-    public static class MethodMember extends Member {
-        private MethodDeclaration meth;
+	public static class MethodMember extends Member {
+		private MethodDeclaration meth;
 
-        public MethodMember(Field field, String type, String name, String... paramPairs) {
-            this(field, type, name, Arrays.asList(paramPairs));
-            this.meth = (MethodDeclaration) declaration;
-        }
+		public MethodMember(String type, String name, String... paramPairs) {
+			this(null, type, name, paramPairs);
+		}
 
-        public MethodMember(Field field, String type, String name, List<String> paramPairs) {
-            super(field, methodDecl(field, type, name, paramPairs));
-        }
+		public MethodMember(String type, String name, List<String> paramPairs) {
+			this(null, type, name, paramPairs);
+		}
 
-        private static MethodDeclaration methodDecl(Field field, String type, String name, List<String> paramPairs) {
-            MethodDeclaration decl = new MethodDeclaration();
-            decl.setPublic(true);
-            decl.setType(t(type, field));
-            decl.setName(t(name, field));
-            decl.setBody(null);
-            for (int i = 0; i < paramPairs.size(); i += 2) {
-                decl.addParameter(t(paramPairs.get(i), field), t(paramPairs.get(i + 1), field));
-            }
-            return decl;
-        }
+		public MethodMember(Field field, String type, String name, String... paramPairs) {
+			this(field, type, name, Arrays.asList(paramPairs));
+			this.meth = (MethodDeclaration) declaration;
+		}
 
-        @Override
-        public Member code(Collection<String> code) {
-            String blockCode = code != null ? "{" + String.join("", expandStrings(field, code)) + "}" : "{}";
-            BlockStmt block = SimpleJavaGenerator.parser.parse(ParseStart.BLOCK, new StringProvider(blockCode))
-                    .getResult().get();
-            meth.setBody(block);
-            return this;
-        }
+		public MethodMember(Field field, String type, String name, List<String> paramPairs) {
+			super(field, methodDecl(field, type, name, paramPairs));
+		}
 
-        @Override
-        public Member _static(boolean _static) {
-            meth.setStatic(_static);
-            return this;
-        }
+		private static MethodDeclaration methodDecl(Field field, String type, String name, List<String> paramPairs) {
+			MethodDeclaration decl = new MethodDeclaration();
+			decl.setPublic(true);
+			decl.setType(t(type, field));
+			decl.setName(t(name, field));
+			decl.setBody(null);
+			for (int i = 0; i < paramPairs.size(); i += 2) {
+				decl.addParameter(t(paramPairs.get(i), field), t(paramPairs.get(i + 1), field));
+			}
+			return decl;
+		}
 
-        @Override
-        public Member comment(String comment) {
-            meth.setComment(comment != null ? new LineComment(comment) : null);
-            return this;
-        }
+		@Override
+		public Member code(Collection<String> code) {
+			String blockCode = code != null ? "{" + String.join("", expandStrings(field, code)) + "}" : "{}";
+			BlockStmt block = SimpleJavaGenerator.parser.parse(ParseStart.BLOCK, new StringProvider(blockCode))
+					.getResult().get();
+			meth.setBody(block);
+			return this;
+		}
 
-        @Override
-        protected void setAccess(Modifier mod) {
-            meth.setModifiers(setAccessModifier(meth.getModifiers(), mod));
-        }
+		@Override
+		public Member _static(boolean _static) {
+			meth.setStatic(_static);
+			return this;
+		}
 
-        @Override
-        public String getName() {
-            return meth.getNameAsString();
-        }
+		@Override
+		public Member comment(String comment) {
+			meth.setComment(comment != null ? new LineComment(comment) : null);
+			return this;
+		}
 
-        @Override
-        public void setName(String name) {
-            meth.setName(name);
-        }
-    }
+		@Override
+		protected void setAccess(Modifier mod) {
+			meth.setModifiers(setAccessModifier(meth.getModifiers(), mod));
+		}
 
-    public static class FieldMember extends Member {
-        private FieldDeclaration fld;
+		@Override
+		public String getName() {
+			return meth.getNameAsString();
+		}
 
-        public FieldMember(Field field, String type, String name) {
-            this(field, type, name, null);
-        }
+		@Override
+		public void setName(String name) {
+			meth.setName(name);
+		}
+	}
 
-        public FieldMember(Field field, String type, String name, String initializer) {
-            super(field, fieldDecl(field, type, name, initializer));
-            this.fld = (FieldDeclaration) declaration;
-        }
+	public static class FieldMember extends Member {
+		private FieldDeclaration fld;
 
-        private static FieldDeclaration fieldDecl(Field field, String typeString, String name, String initializer) {
-            FieldDeclaration decl = new FieldDeclaration();
-            decl.setPrivate(true);
-            Type type = parser.parse(ParseStart.TYPE, new StringProvider(t(typeString, field))).getResult().get();
-            VariableDeclarator var = new VariableDeclarator(type, t(name, field));
-            if (initializer != null) {
-                var.setInitializer(parser.parse(ParseStart.EXPRESSION, new StringProvider(t(initializer, field)))
-                        .getResult().get());
-            }
-            decl.addVariable(var);
-            return decl;
-        }
+		public FieldMember(Field field, String type, String name) {
+			this(field, type, name, null);
+		}
 
-        @Override
-        public Member _static(boolean _static) {
-            fld.setStatic(_static);
-            return this;
-        }
+		public FieldMember(Field field, String type, String name, String initializer) {
+			super(field, fieldDecl(field, type, name, initializer));
+			this.fld = (FieldDeclaration) declaration;
+		}
 
-        @Override
-        protected void setAccess(Modifier mod) {
-            fld.setModifiers(setAccessModifier(fld.getModifiers(), mod));
-        }
+		private static FieldDeclaration fieldDecl(Field field, String typeString, String name, String initializer) {
+			FieldDeclaration decl = new FieldDeclaration();
+			decl.setPrivate(true);
+			Type type = parser.parse(ParseStart.TYPE, new StringProvider(t(typeString, field))).getResult().get();
+			VariableDeclarator var = new VariableDeclarator(type, t(name, field));
+			if (initializer != null) {
+				var.setInitializer(parser.parse(ParseStart.EXPRESSION, new StringProvider(t(initializer, field)))
+						.getResult().get());
+			}
+			decl.addVariable(var);
+			return decl;
+		}
 
-        @Override
-        public String getName() {
-            return fld.getVariable(0).getNameAsString();
-        }
+		@Override
+		public Member _static(boolean _static) {
+			fld.setStatic(_static);
+			return this;
+		}
 
-        @Override
-        public void setName(String name) {
-            fld.getVariable(0).setName(name);
-        }
-    }
+		@Override
+		protected void setAccess(Modifier mod) {
+			fld.setModifiers(setAccessModifier(fld.getModifiers(), mod));
+		}
 
-    private static List<String> expandStrings(Field field, Collection<String> strings) {
-        return strings.stream().map(s -> t(s, field)).collect(Collectors.toList());
-    }
+		@Override
+		public String getName() {
+			return fld.getVariable(0).getNameAsString();
+		}
 
-    private static List<String> expandStrings(com.reprezen.kaizen.oasparser.jsonoverlay.gen.TypeData.Type type,
-            Collection<String> strings) {
-        return strings.stream().map(s -> t(s, type)).collect(Collectors.toList());
-    }
+		@Override
+		public void setName(String name) {
+			fld.getVariable(0).setName(name);
+		}
+	}
+
+	private static List<String> expandStrings(Field field, Collection<String> strings) {
+		return strings.stream().map(s -> t(s, field)).collect(Collectors.toList());
+	}
+
+	private static List<String> expandStrings(com.reprezen.kaizen.oasparser.jsonoverlay.gen.TypeData.Type type,
+			Collection<String> strings) {
+		return strings.stream().map(s -> t(s, type)).collect(Collectors.toList());
+	}
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/gen/Template.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/gen/Template.java
@@ -114,6 +114,10 @@ public class Template {
 			return type.getImplType();
 		case "modelType":
 			return type.getTypeData().getModelType();
+		case "discriminator":
+			return type.getDiscriminator();
+		case "discValue":
+			return type.getDiscriminatorValue();
 		default:
 			return args[Integer.valueOf(var)];
 		}

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/gen/TypeData.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/gen/TypeData.java
@@ -28,362 +28,383 @@ import com.google.common.collect.Sets;
 
 public class TypeData {
 
-    private Collection<Type> types;
-    private Map<String, String> imports = Maps.newHashMap();
-    private List<String> defaultExtendInterfaces = null;
-    private Map<String, Type> typeMap = null;
-    private String modelType = null;
-
-    // Container for "decls" section that is solely used to define reusable anchors
-    @JsonProperty
-    private Object decls;
-
-    public void init() {
-        typeMap = Maps.uniqueIndex(types, new Function<Type, String>() {
-            @Override
-            public String apply(Type type) {
-                return type.getName();
-            }
-        });
-        for (Type type : types) {
-            type.init(this);
-        }
-    }
-
-    public String getModelType() {
-        return modelType;
-    }
-
-    public Collection<Type> getTypes() {
-        return types;
-    }
-
-    public Map<String, Type> getTypeMap() {
-        return typeMap;
-    }
-
-    public Type getType(String typeName) {
-        return typeMap.get(typeName);
-    }
-
-    public Map<String, String> getImports() {
-        return imports;
-    }
-
-    public List<String> getDefaultExtendInterfaces() {
-        return defaultExtendInterfaces;
-    }
-
-    public static class Type {
-
-        private String name;
-        private Map<String, Field> fields = Maps.newLinkedHashMap();
-        private List<String> extendInterfaces = Lists.newArrayList();
-        private List<Method> extraMethods = Lists.newArrayList();
-        private Map<String, Collection<String>> imports = Maps.newHashMap();
-        private boolean noGen = false;
-        private String extensionOf;
-        private Map<String, String> renames = Maps.newHashMap();
-
-        private TypeData typeData;
-
-        public void init(TypeData typeData) {
-            this.typeData = typeData;
-            for (Entry<String, Field> field : fields.entrySet()) {
-                field.getValue().init(field.getKey(), this);
-            }
-        }
-
-        public TypeData getTypeData() {
-            return typeData;
-        }
-
-        public Collection<String> getRequiredImports(String moduleType) {
-            Set<String> results = Sets.newLinkedHashSet();
-            Collection<String> interfaces = extendInterfaces != null ? extendInterfaces
-                    : typeData.defaultExtendInterfaces;
-            if (interfaces != null) {
-                for (String intf : interfaces) {
-                    if (typeData.imports.containsKey(intf)) {
-                        results.add(typeData.imports.get(intf));
-                    }
-                }
-            }
-            if (imports.get(moduleType) != null) {
-                for (String imp : imports.get(moduleType)) {
-                    results.add(imp);
-                }
-            }
-            return results;
-        }
-
-        public String getIntfExtendsDecl() {
-            List<String> interfaces = extendInterfaces != null ? extendInterfaces : typeData.defaultExtendInterfaces;
-            return interfaces != null ? " extends " + StringUtils.join(interfaces, ", ") : "";
-        }
-
-        public String getName() {
-            return name;
-        }
-
-        public String getLcName() {
-            String lcName = lcFirst(name);
-            return lcName;
-        }
-
-        public Map<String, Field> getFields() {
-            return fields;
-        }
-
-        public List<String> getExtendInterfaces() {
-            return extendInterfaces;
-        }
-
-        public List<Method> getExtraMethods() {
-            return extraMethods;
-        }
-
-        public Map<String, Collection<String>> getImports() {
-            return imports;
-        }
-
-        public boolean isNoGen() {
-            return noGen;
-        }
-
-        public String getExtensionOf() {
-            return extensionOf;
-        }
-
-        public Map<String, String> getRenames() {
-            return renames;
-        }
-
-        public String getImplType() {
-            return isNoGen() ? name : getImplType(name);
-        }
-
-        public static String getImplType(String typeName) {
-            switch (typeName) {
-            case "String":
-            case "Integer":
-            case "Number":
-            case "Boolean":
-            case "Primitive":
-            case "Object":
-                return typeName + "Overlay";
-            default:
-                return typeName + "Impl";
-            }
-        }
-
-        String lcFirst(String s) {
-            return s.substring(0, 1).toLowerCase() + s.substring(1);
-        }
-    }
-
-    public static class Field {
-        private String name;
-        private String plural;
-        private Structure structure = Structure.scalar;
-        private String type;
-        private String keyName = "name";
-        private List<String> keyDecls;
-        private boolean selfKeyed = false;
-        private String keyPattern;
-        private boolean noImpl;
-        private String id;
-        private boolean boolDefault = false;
-        private String parentPath;
-        private String createTest;
-        private boolean refable = false;
-
-        private Type container;
-
-        public void init(String id, Type container) {
-            this.id = id;
-            this.container = container;
-        }
-
-        public String getId() {
-            return id;
-        }
-
-        public Type getContainer() {
-            return container;
-        }
-
-        public TypeData getTypeData() {
-            return container.getTypeData();
-        }
-
-        public String getName() {
-            return name;
-        }
-
-        public String getLcName() {
-            String lcName = lcFirst(name);
-            switch (lcName) {
-            case "default":
-            case "enum":
-                lcName = lcName + "Value";
-            }
-            return lcName;
-        }
-
-        public String getPlural() {
-            return plural != null ? plural : name + "s";
-        }
-
-        public String getLcPlural() {
-            return lcFirst(getPlural());
-        }
-
-        public Structure getStructure() {
-            return structure;
-        }
-
-        public String getType() {
-            return type != null ? type : name;
-        }
-
-        String lcFirst(String s) {
-            return s.substring(0, 1).toLowerCase() + s.substring(1);
-        }
-
-        public String getKeyName() {
-            return keyName;
-        }
-
-        public Collection<String> getKeyDecls() {
-            return keyDecls;
-        }
-
-        public boolean isSelfKeyed() {
-            return selfKeyed;
-        }
-
-        public String getKeyPattern() {
-            return keyPattern;
-        }
-
-        public String getCreateTest() {
-            if (createTest != null) {
-                if (createTest.startsWith(".")) {
-                    return t("json.at(${qpointer})${0}", this, createTest);
-                } else if (createTest.matches("^[a-zA-Z][a-zA-Z0-9_]*$")) {
-                    return t("${0}(json.at(${qpointer}))", this, createTest);
-                }
-            }
-            return createTest;
-        }
-
-        public boolean isNoImpl() {
-            return noImpl;
-        }
-
-        public boolean isBoolean() {
-            return getType().equals("Boolean");
-        }
-
-        public boolean getBoolDefault() {
-            return boolDefault;
-        }
-
-        public String getParentPath() {
-            return parentPath != null ? parentPath : id;
-        }
-
-        public String getImplType() {
-            Type objectType = getContainer().getTypeData().getTypeMap().get(getType());
-            return Type.getImplType(objectType != null ? objectType.getName() : getType());
-        }
-
-        public boolean isScalarType() {
-            switch (getType()) {
-            case "String":
-            case "Integer":
-            case "Number":
-            case "Boolean":
-            case "Primitive":
-            case "Object":
-                return true;
-            default:
-                return false;
-            }
-        }
-
-        private String getOverlayVariant() {
-            switch (structure) {
-            case scalar:
-                return "";
-            case collection:
-                return "List";
-            case map:
-                return "Map";
-            }
-            return null;
-        }
-
-        public String getPropertyName() {
-            return structure == Structure.scalar ? getLcName() : getLcPlural();
-        }
-
-        public String getPropertyType() {
-            return t("Child${0}Overlay<${type}>", this, getOverlayVariant());
-        }
-
-        public String getPropertyNew() {
-            String createTest = getCreateTest();
-            createTest = createTest != null ? createTest + ", " : "";
-            switch (structure) {
-            case scalar:
-                return t("createChild(${0}${qpath}, this, ${implType}.factory)", this, createTest);
-            case collection:
-                return t("createChildList(${0}${qpath}, this, ${implType}.factory)", this, createTest);
-            case map:
-                return t("createChildMap(${0}${qpath}, this, ${implType}.factory, ${qkeyPat})", this, createTest);
-            }
-            return null;
-        }
-
-        public String getOverlayType() {
-            return getType() + (isScalarType() ? "Overlay" : "");
-        }
-
-        public String getTypeInCollection() {
-            return isScalarType() ? type : t("? extends ${type}", this);
-        }
-
-        public boolean isRefable() {
-            return refable;
-        }
-    }
-
-    public static class Method {
-        private String name;
-        private String type;
-        private List<String> argDecls;
-        private List<String> code;
-
-        public String getName() {
-            return name;
-        }
-
-        public String getType() {
-            return type;
-        }
-
-        public List<String> getArgDecls() {
-            return argDecls;
-        }
-
-        public List<String> getCode() {
-            return code;
-        }
-    }
-
-    public enum Structure {
-        scalar, collection, map
-    }
+	private Collection<Type> types;
+	private Map<String, String> imports = Maps.newHashMap();
+	private List<String> defaultExtendInterfaces = null;
+	private Map<String, Type> typeMap = null;
+	private String modelType = null;
+	private String discriminator = null;
+
+	// Container for "decls" section that is solely used to define reusable anchors
+	@JsonProperty
+	private Object decls;
+
+	public void init() {
+		typeMap = Maps.uniqueIndex(types, new Function<Type, String>() {
+			@Override
+			public String apply(Type type) {
+				return type.getName();
+			}
+		});
+		for (Type type : types) {
+			type.init(this);
+		}
+	}
+
+	public String getModelType() {
+		return modelType;
+	}
+
+	public String getDiscriminator() {
+		return discriminator;
+	}
+
+	public Collection<Type> getTypes() {
+		return types;
+	}
+
+	public Map<String, Type> getTypeMap() {
+		return typeMap;
+	}
+
+	public Type getType(String typeName) {
+		return typeMap.get(typeName);
+	}
+
+	public Map<String, String> getImports() {
+		return imports;
+	}
+
+	public List<String> getDefaultExtendInterfaces() {
+		return defaultExtendInterfaces;
+	}
+
+	public static class Type {
+
+		private String name;
+		private Map<String, Field> fields = Maps.newLinkedHashMap();
+		private List<String> extendInterfaces = Lists.newArrayList();
+		private List<Method> extraMethods = Lists.newArrayList();
+		private Map<String, Collection<String>> imports = Maps.newHashMap();
+		private boolean noGen = false;
+		private String extensionOf;
+		private Map<String, String> renames = Maps.newHashMap();
+		@JsonProperty("abstract")
+		private boolean abstractType = false;
+		private String discriminator = null;
+		private String discriminatorValue = null;
+
+		private TypeData typeData;
+
+		public void init(TypeData typeData) {
+			this.typeData = typeData;
+			for (Entry<String, Field> field : fields.entrySet()) {
+				field.getValue().init(field.getKey(), this);
+			}
+		}
+
+		public TypeData getTypeData() {
+			return typeData;
+		}
+
+		public Collection<String> getRequiredImports(String moduleType) {
+			Set<String> results = Sets.newLinkedHashSet();
+			Collection<String> interfaces = extendInterfaces != null ? extendInterfaces
+					: typeData.defaultExtendInterfaces;
+			if (interfaces != null) {
+				for (String intf : interfaces) {
+					if (typeData.imports.containsKey(intf)) {
+						results.add(typeData.imports.get(intf));
+					}
+				}
+			}
+			if (imports.get(moduleType) != null) {
+				for (String imp : imports.get(moduleType)) {
+					results.add(imp);
+				}
+			}
+			return results;
+		}
+
+		public String getIntfExtendsDecl() {
+			List<String> interfaces = extendInterfaces != null ? extendInterfaces : typeData.defaultExtendInterfaces;
+			return interfaces != null ? " extends " + StringUtils.join(interfaces, ", ") : "";
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public String getLcName() {
+			String lcName = lcFirst(name);
+			return lcName;
+		}
+
+		public Map<String, Field> getFields() {
+			return fields;
+		}
+
+		public List<String> getExtendInterfaces() {
+			return extendInterfaces;
+		}
+
+		public List<Method> getExtraMethods() {
+			return extraMethods;
+		}
+
+		public Map<String, Collection<String>> getImports() {
+			return imports;
+		}
+
+		public boolean isNoGen() {
+			return noGen;
+		}
+
+		public String getExtensionOf() {
+			return extensionOf;
+		}
+
+		public Map<String, String> getRenames() {
+			return renames;
+		}
+
+		public boolean isAbstract() {
+			return abstractType;
+		}
+
+		public String getDiscriminator() {
+			return discriminator != null ? discriminator : typeData.getDiscriminator();
+		}
+
+		public String getDiscriminatorValue() {
+			return discriminatorValue != null ? discriminatorValue : name;
+		}
+
+		public String getImplType() {
+			return isNoGen() ? name : getImplType(name);
+		}
+
+		public static String getImplType(String typeName) {
+			switch (typeName) {
+			case "String":
+			case "Integer":
+			case "Number":
+			case "Boolean":
+			case "Primitive":
+			case "Object":
+				return typeName + "Overlay";
+			default:
+				return typeName + "Impl";
+			}
+		}
+
+		String lcFirst(String s) {
+			return s.substring(0, 1).toLowerCase() + s.substring(1);
+		}
+	}
+
+	public static class Field {
+		private String name;
+		private String plural;
+		private Structure structure = Structure.scalar;
+		private String type;
+		private String keyName = "name";
+		private List<String> keyDecls;
+		private boolean selfKeyed = false;
+		private String keyPattern;
+		private boolean noImpl;
+		private String id;
+		private boolean boolDefault = false;
+		private String parentPath;
+		private String createTest;
+		private boolean refable = false;
+
+		private Type container;
+
+		public void init(String id, Type container) {
+			this.id = id;
+			this.container = container;
+		}
+
+		public String getId() {
+			return id;
+		}
+
+		public Type getContainer() {
+			return container;
+		}
+
+		public TypeData getTypeData() {
+			return container.getTypeData();
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public String getLcName() {
+			String lcName = lcFirst(name);
+			switch (lcName) {
+			case "default":
+			case "enum":
+				lcName = lcName + "Value";
+			}
+			return lcName;
+		}
+
+		public String getPlural() {
+			return plural != null ? plural : name + "s";
+		}
+
+		public String getLcPlural() {
+			return lcFirst(getPlural());
+		}
+
+		public Structure getStructure() {
+			return structure;
+		}
+
+		public String getType() {
+			return type != null ? type : name;
+		}
+
+		String lcFirst(String s) {
+			return s.substring(0, 1).toLowerCase() + s.substring(1);
+		}
+
+		public String getKeyName() {
+			return keyName;
+		}
+
+		public Collection<String> getKeyDecls() {
+			return keyDecls;
+		}
+
+		public boolean isSelfKeyed() {
+			return selfKeyed;
+		}
+
+		public String getKeyPattern() {
+			return keyPattern;
+		}
+
+		public String getCreateTest() {
+			if (createTest != null) {
+				if (createTest.startsWith(".")) {
+					return t("json.at(${qpointer})${0}", this, createTest);
+				} else if (createTest.matches("^[a-zA-Z][a-zA-Z0-9_]*$")) {
+					return t("${0}(json.at(${qpointer}))", this, createTest);
+				}
+			}
+			return createTest;
+		}
+
+		public boolean isNoImpl() {
+			return noImpl;
+		}
+
+		public boolean isBoolean() {
+			return getType().equals("Boolean");
+		}
+
+		public boolean getBoolDefault() {
+			return boolDefault;
+		}
+
+		public String getParentPath() {
+			return parentPath != null ? parentPath : id;
+		}
+
+		public String getImplType() {
+			Type objectType = getContainer().getTypeData().getTypeMap().get(getType());
+			return Type.getImplType(objectType != null ? objectType.getName() : getType());
+		}
+
+		public boolean isScalarType() {
+			switch (getType()) {
+			case "String":
+			case "Integer":
+			case "Number":
+			case "Boolean":
+			case "Primitive":
+			case "Object":
+				return true;
+			default:
+				return false;
+			}
+		}
+
+		private String getOverlayVariant() {
+			switch (structure) {
+			case scalar:
+				return "";
+			case collection:
+				return "List";
+			case map:
+				return "Map";
+			}
+			return null;
+		}
+
+		public String getPropertyName() {
+			return structure == Structure.scalar ? getLcName() : getLcPlural();
+		}
+
+		public String getPropertyType() {
+			return t("Child${0}Overlay<${type}>", this, getOverlayVariant());
+		}
+
+		public String getPropertyNew() {
+			String createTest = getCreateTest();
+			createTest = createTest != null ? createTest + ", " : "";
+			switch (structure) {
+			case scalar:
+				return t("createChild(${0}${qpath}, this, ${implType}.factory)", this, createTest);
+			case collection:
+				return t("createChildList(${0}${qpath}, this, ${implType}.factory)", this, createTest);
+			case map:
+				return t("createChildMap(${0}${qpath}, this, ${implType}.factory, ${qkeyPat})", this, createTest);
+			}
+			return null;
+		}
+
+		public String getOverlayType() {
+			return getType() + (isScalarType() ? "Overlay" : "");
+		}
+
+		public String getTypeInCollection() {
+			return isScalarType() ? type : t("? extends ${type}", this);
+		}
+
+		public boolean isRefable() {
+			return refable;
+		}
+	}
+
+	public static class Method {
+		private String name;
+		private String type;
+		private List<String> argDecls;
+		private List<String> code;
+
+		public String getName() {
+			return name;
+		}
+
+		public String getType() {
+			return type;
+		}
+
+		public List<String> getArgDecls() {
+			return argDecls;
+		}
+
+		public List<String> getCode() {
+			return code;
+		}
+	}
+
+	public enum Structure {
+		scalar, collection, map
+	}
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/gen/TypeGenerator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/gen/TypeGenerator.java
@@ -20,6 +20,7 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import javax.annotation.Generated;
 
@@ -103,6 +104,9 @@ public abstract class TypeGenerator {
 			addManualMembers(gen, existing);
 		}
 		requireTypes(getImports(type));
+		if (needIntfImports()) {
+			gen.addImport(intfPackage + ".*");
+		}
 		addGeneratedMembers(type, gen);
 		requireTypes(Generated.class);
 		resolveImports(type, gen);
@@ -112,6 +116,10 @@ public abstract class TypeGenerator {
 	protected abstract String getPackage();
 
 	protected abstract Collection<String> getImports(Type type);
+
+	protected boolean needIntfImports() {
+		return false;
+	}
 
 	protected void requireTypes(Class<?>... types) {
 		requireTypes(Collections2.transform(Arrays.asList(types), new Function<Class<?>, String>() {
@@ -178,6 +186,7 @@ public abstract class TypeGenerator {
 				Collection.class, //
 				Map.class, //
 				Optional.class, //
+				Collectors.class, //
 				JsonNode.class, //
 				ObjectNode.class, //
 				JsonNodeFactory.class, //

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/CallbackImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/CallbackImpl.java
@@ -6,10 +6,12 @@ import com.reprezen.kaizen.oasparser.jsonoverlay.ChildMapOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ReferenceRegistry;
 import com.reprezen.kaizen.oasparser.model3.Path;
 import com.reprezen.kaizen.oasparser.ovl3.PathImpl;
+import java.util.stream.Collectors;
+import com.reprezen.kaizen.oasparser.model3.*;
 import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
-import com.reprezen.kaizen.oasparser.model3.Callback;
 import javax.annotation.Generated;
 import com.reprezen.kaizen.oasparser.jsonoverlay.PropertiesOverlay;
+import com.fasterxml.jackson.core.JsonPointer;
 import java.util.Map;
 import com.reprezen.kaizen.oasparser.jsonoverlay.OverlayFactory;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -138,16 +140,44 @@ public class CallbackImpl extends PropertiesOverlay<Callback> implements Callbac
 
         @Override
         public JsonOverlay<Callback> _create(Callback callback, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            JsonOverlay<?> overlay = new CallbackImpl(callback, parent, refReg);
+            Class<? extends Callback> subtype = getSubtypeOf(callback);
+            IJsonOverlay<?> overlay;
+            if (subtype == null || subtype == Callback.class) {
+                overlay = new CallbackImpl(callback, parent, refReg);
+            } else {
+                switch(subtype.getSimpleName()) {
+                    default:
+                        overlay = null;
+                }
+            }
             @SuppressWarnings("unchecked") JsonOverlay<Callback> castOverlay = (JsonOverlay<Callback>) overlay;
             return castOverlay;
         }
 
         @Override
         public JsonOverlay<Callback> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            JsonOverlay<?> overlay = new CallbackImpl(json, parent, refReg);
+            Class<? extends Callback> subtype = getSubtypeOf(json);
+            IJsonOverlay<?> overlay;
+            if (subtype == null || subtype == Callback.class) {
+                overlay = new CallbackImpl(json, parent, refReg);
+            } else {
+                switch(subtype.getSimpleName()) {
+                    default:
+                        overlay = null;
+                }
+            }
             @SuppressWarnings("unchecked") JsonOverlay<Callback> castOverlay = (JsonOverlay<Callback>) overlay;
             return castOverlay;
         }
     };
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private static Class<? extends Callback> getSubtypeOf(Callback callback) {
+        return Callback.class;
+    }
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private static Class<? extends Callback> getSubtypeOf(JsonNode json) {
+        return Callback.class;
+    }
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ContactImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ContactImpl.java
@@ -7,15 +7,17 @@ import com.reprezen.kaizen.oasparser.jsonoverlay.ChildListOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ReferenceRegistry;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ListOverlay;
 import java.util.Collection;
+import java.util.stream.Collectors;
+import com.reprezen.kaizen.oasparser.model3.*;
 import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ChildOverlay;
 import javax.annotation.Generated;
 import com.reprezen.kaizen.oasparser.jsonoverlay.PropertiesOverlay;
+import com.fasterxml.jackson.core.JsonPointer;
 import java.util.Map;
 import com.reprezen.kaizen.oasparser.jsonoverlay.OverlayFactory;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.reprezen.kaizen.oasparser.jsonoverlay.IJsonOverlay;
-import com.reprezen.kaizen.oasparser.model3.Contact;
 import com.reprezen.kaizen.oasparser.jsonoverlay.StringOverlay;
 
 public class ContactImpl extends PropertiesOverlay<Contact> implements Contact {
@@ -163,16 +165,44 @@ public class ContactImpl extends PropertiesOverlay<Contact> implements Contact {
 
         @Override
         public JsonOverlay<Contact> _create(Contact contact, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            JsonOverlay<?> overlay = new ContactImpl(contact, parent, refReg);
+            Class<? extends Contact> subtype = getSubtypeOf(contact);
+            IJsonOverlay<?> overlay;
+            if (subtype == null || subtype == Contact.class) {
+                overlay = new ContactImpl(contact, parent, refReg);
+            } else {
+                switch(subtype.getSimpleName()) {
+                    default:
+                        overlay = null;
+                }
+            }
             @SuppressWarnings("unchecked") JsonOverlay<Contact> castOverlay = (JsonOverlay<Contact>) overlay;
             return castOverlay;
         }
 
         @Override
         public JsonOverlay<Contact> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            JsonOverlay<?> overlay = new ContactImpl(json, parent, refReg);
+            Class<? extends Contact> subtype = getSubtypeOf(json);
+            IJsonOverlay<?> overlay;
+            if (subtype == null || subtype == Contact.class) {
+                overlay = new ContactImpl(json, parent, refReg);
+            } else {
+                switch(subtype.getSimpleName()) {
+                    default:
+                        overlay = null;
+                }
+            }
             @SuppressWarnings("unchecked") JsonOverlay<Contact> castOverlay = (JsonOverlay<Contact>) overlay;
             return castOverlay;
         }
     };
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private static Class<? extends Contact> getSubtypeOf(Contact contact) {
+        return Contact.class;
+    }
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private static Class<? extends Contact> getSubtypeOf(JsonNode json) {
+        return Contact.class;
+    }
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/EncodingPropertyImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/EncodingPropertyImpl.java
@@ -7,16 +7,18 @@ import com.reprezen.kaizen.oasparser.jsonoverlay.ChildListOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ReferenceRegistry;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ListOverlay;
 import java.util.Collection;
+import java.util.stream.Collectors;
 import com.reprezen.kaizen.oasparser.jsonoverlay.Reference;
+import com.reprezen.kaizen.oasparser.model3.*;
 import com.reprezen.kaizen.oasparser.jsonoverlay.BooleanOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ChildOverlay;
 import javax.annotation.Generated;
 import com.reprezen.kaizen.oasparser.jsonoverlay.PropertiesOverlay;
+import com.fasterxml.jackson.core.JsonPointer;
 import java.util.Map;
 import com.reprezen.kaizen.oasparser.jsonoverlay.OverlayFactory;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.reprezen.kaizen.oasparser.model3.EncodingProperty;
 import com.reprezen.kaizen.oasparser.jsonoverlay.IJsonOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.StringOverlay;
 
@@ -233,16 +235,44 @@ public class EncodingPropertyImpl extends PropertiesOverlay<EncodingProperty> im
 
         @Override
         public JsonOverlay<EncodingProperty> _create(EncodingProperty encodingProperty, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            JsonOverlay<?> overlay = new EncodingPropertyImpl(encodingProperty, parent, refReg);
+            Class<? extends EncodingProperty> subtype = getSubtypeOf(encodingProperty);
+            IJsonOverlay<?> overlay;
+            if (subtype == null || subtype == EncodingProperty.class) {
+                overlay = new EncodingPropertyImpl(encodingProperty, parent, refReg);
+            } else {
+                switch(subtype.getSimpleName()) {
+                    default:
+                        overlay = null;
+                }
+            }
             @SuppressWarnings("unchecked") JsonOverlay<EncodingProperty> castOverlay = (JsonOverlay<EncodingProperty>) overlay;
             return castOverlay;
         }
 
         @Override
         public JsonOverlay<EncodingProperty> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            JsonOverlay<?> overlay = new EncodingPropertyImpl(json, parent, refReg);
+            Class<? extends EncodingProperty> subtype = getSubtypeOf(json);
+            IJsonOverlay<?> overlay;
+            if (subtype == null || subtype == EncodingProperty.class) {
+                overlay = new EncodingPropertyImpl(json, parent, refReg);
+            } else {
+                switch(subtype.getSimpleName()) {
+                    default:
+                        overlay = null;
+                }
+            }
             @SuppressWarnings("unchecked") JsonOverlay<EncodingProperty> castOverlay = (JsonOverlay<EncodingProperty>) overlay;
             return castOverlay;
         }
     };
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private static Class<? extends EncodingProperty> getSubtypeOf(EncodingProperty encodingProperty) {
+        return EncodingProperty.class;
+    }
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private static Class<? extends EncodingProperty> getSubtypeOf(JsonNode json) {
+        return EncodingProperty.class;
+    }
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ExampleImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ExampleImpl.java
@@ -7,11 +7,13 @@ import com.reprezen.kaizen.oasparser.jsonoverlay.ChildListOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ReferenceRegistry;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ListOverlay;
 import java.util.Collection;
+import java.util.stream.Collectors;
+import com.reprezen.kaizen.oasparser.model3.*;
 import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ChildOverlay;
 import javax.annotation.Generated;
 import com.reprezen.kaizen.oasparser.jsonoverlay.PropertiesOverlay;
-import com.reprezen.kaizen.oasparser.model3.Example;
+import com.fasterxml.jackson.core.JsonPointer;
 import java.util.Map;
 import com.reprezen.kaizen.oasparser.jsonoverlay.OverlayFactory;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -186,16 +188,44 @@ public class ExampleImpl extends PropertiesOverlay<Example> implements Example {
 
         @Override
         public JsonOverlay<Example> _create(Example example, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            JsonOverlay<?> overlay = new ExampleImpl(example, parent, refReg);
+            Class<? extends Example> subtype = getSubtypeOf(example);
+            IJsonOverlay<?> overlay;
+            if (subtype == null || subtype == Example.class) {
+                overlay = new ExampleImpl(example, parent, refReg);
+            } else {
+                switch(subtype.getSimpleName()) {
+                    default:
+                        overlay = null;
+                }
+            }
             @SuppressWarnings("unchecked") JsonOverlay<Example> castOverlay = (JsonOverlay<Example>) overlay;
             return castOverlay;
         }
 
         @Override
         public JsonOverlay<Example> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            JsonOverlay<?> overlay = new ExampleImpl(json, parent, refReg);
+            Class<? extends Example> subtype = getSubtypeOf(json);
+            IJsonOverlay<?> overlay;
+            if (subtype == null || subtype == Example.class) {
+                overlay = new ExampleImpl(json, parent, refReg);
+            } else {
+                switch(subtype.getSimpleName()) {
+                    default:
+                        overlay = null;
+                }
+            }
             @SuppressWarnings("unchecked") JsonOverlay<Example> castOverlay = (JsonOverlay<Example>) overlay;
             return castOverlay;
         }
     };
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private static Class<? extends Example> getSubtypeOf(Example example) {
+        return Example.class;
+    }
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private static Class<? extends Example> getSubtypeOf(JsonNode json) {
+        return Example.class;
+    }
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ExternalDocsImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ExternalDocsImpl.java
@@ -7,15 +7,17 @@ import com.reprezen.kaizen.oasparser.jsonoverlay.ChildListOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ReferenceRegistry;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ListOverlay;
 import java.util.Collection;
+import java.util.stream.Collectors;
+import com.reprezen.kaizen.oasparser.model3.*;
 import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ChildOverlay;
 import javax.annotation.Generated;
 import com.reprezen.kaizen.oasparser.jsonoverlay.PropertiesOverlay;
+import com.fasterxml.jackson.core.JsonPointer;
 import java.util.Map;
 import com.reprezen.kaizen.oasparser.jsonoverlay.OverlayFactory;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.reprezen.kaizen.oasparser.jsonoverlay.IJsonOverlay;
-import com.reprezen.kaizen.oasparser.model3.ExternalDocs;
 import com.reprezen.kaizen.oasparser.jsonoverlay.StringOverlay;
 
 public class ExternalDocsImpl extends PropertiesOverlay<ExternalDocs> implements ExternalDocs {
@@ -140,16 +142,44 @@ public class ExternalDocsImpl extends PropertiesOverlay<ExternalDocs> implements
 
         @Override
         public JsonOverlay<ExternalDocs> _create(ExternalDocs externalDocs, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            JsonOverlay<?> overlay = new ExternalDocsImpl(externalDocs, parent, refReg);
+            Class<? extends ExternalDocs> subtype = getSubtypeOf(externalDocs);
+            IJsonOverlay<?> overlay;
+            if (subtype == null || subtype == ExternalDocs.class) {
+                overlay = new ExternalDocsImpl(externalDocs, parent, refReg);
+            } else {
+                switch(subtype.getSimpleName()) {
+                    default:
+                        overlay = null;
+                }
+            }
             @SuppressWarnings("unchecked") JsonOverlay<ExternalDocs> castOverlay = (JsonOverlay<ExternalDocs>) overlay;
             return castOverlay;
         }
 
         @Override
         public JsonOverlay<ExternalDocs> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            JsonOverlay<?> overlay = new ExternalDocsImpl(json, parent, refReg);
+            Class<? extends ExternalDocs> subtype = getSubtypeOf(json);
+            IJsonOverlay<?> overlay;
+            if (subtype == null || subtype == ExternalDocs.class) {
+                overlay = new ExternalDocsImpl(json, parent, refReg);
+            } else {
+                switch(subtype.getSimpleName()) {
+                    default:
+                        overlay = null;
+                }
+            }
             @SuppressWarnings("unchecked") JsonOverlay<ExternalDocs> castOverlay = (JsonOverlay<ExternalDocs>) overlay;
             return castOverlay;
         }
     };
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private static Class<? extends ExternalDocs> getSubtypeOf(ExternalDocs externalDocs) {
+        return ExternalDocs.class;
+    }
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private static Class<? extends ExternalDocs> getSubtypeOf(JsonNode json) {
+        return ExternalDocs.class;
+    }
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/HeaderImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/HeaderImpl.java
@@ -6,6 +6,7 @@ import com.reprezen.kaizen.oasparser.jsonoverlay.ChildMapOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ReferenceRegistry;
 import com.reprezen.kaizen.oasparser.jsonoverlay.BooleanOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
+import com.fasterxml.jackson.core.JsonPointer;
 import javax.annotation.Generated;
 import com.reprezen.kaizen.oasparser.jsonoverlay.PropertiesOverlay;
 import com.reprezen.kaizen.oasparser.ovl3.SchemaImpl;
@@ -20,8 +21,9 @@ import com.reprezen.kaizen.oasparser.ovl3.MediaTypeImpl;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ListOverlay;
 import com.reprezen.kaizen.oasparser.ovl3.ExampleImpl;
 import java.util.Collection;
-import com.reprezen.kaizen.oasparser.model3.Header;
+import java.util.stream.Collectors;
 import com.reprezen.kaizen.oasparser.jsonoverlay.Reference;
+import com.reprezen.kaizen.oasparser.model3.*;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ChildOverlay;
 import com.reprezen.kaizen.oasparser.model3.MediaType;
 import com.reprezen.kaizen.oasparser.jsonoverlay.StringOverlay;
@@ -507,16 +509,44 @@ public class HeaderImpl extends PropertiesOverlay<Header> implements Header {
 
         @Override
         public JsonOverlay<Header> _create(Header header, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            JsonOverlay<?> overlay = new HeaderImpl(header, parent, refReg);
+            Class<? extends Header> subtype = getSubtypeOf(header);
+            IJsonOverlay<?> overlay;
+            if (subtype == null || subtype == Header.class) {
+                overlay = new HeaderImpl(header, parent, refReg);
+            } else {
+                switch(subtype.getSimpleName()) {
+                    default:
+                        overlay = null;
+                }
+            }
             @SuppressWarnings("unchecked") JsonOverlay<Header> castOverlay = (JsonOverlay<Header>) overlay;
             return castOverlay;
         }
 
         @Override
         public JsonOverlay<Header> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            JsonOverlay<?> overlay = new HeaderImpl(json, parent, refReg);
+            Class<? extends Header> subtype = getSubtypeOf(json);
+            IJsonOverlay<?> overlay;
+            if (subtype == null || subtype == Header.class) {
+                overlay = new HeaderImpl(json, parent, refReg);
+            } else {
+                switch(subtype.getSimpleName()) {
+                    default:
+                        overlay = null;
+                }
+            }
             @SuppressWarnings("unchecked") JsonOverlay<Header> castOverlay = (JsonOverlay<Header>) overlay;
             return castOverlay;
         }
     };
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private static Class<? extends Header> getSubtypeOf(Header header) {
+        return Header.class;
+    }
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private static Class<? extends Header> getSubtypeOf(JsonNode json) {
+        return Header.class;
+    }
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/InfoImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/InfoImpl.java
@@ -8,14 +8,16 @@ import com.reprezen.kaizen.oasparser.jsonoverlay.ReferenceRegistry;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ListOverlay;
 import com.reprezen.kaizen.oasparser.model3.License;
 import java.util.Collection;
+import java.util.stream.Collectors;
+import com.reprezen.kaizen.oasparser.model3.*;
 import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ChildOverlay;
 import javax.annotation.Generated;
 import com.reprezen.kaizen.oasparser.jsonoverlay.PropertiesOverlay;
+import com.fasterxml.jackson.core.JsonPointer;
 import com.reprezen.kaizen.oasparser.ovl3.ContactImpl;
 import java.util.Map;
 import com.reprezen.kaizen.oasparser.jsonoverlay.OverlayFactory;
-import com.reprezen.kaizen.oasparser.model3.Info;
 import com.reprezen.kaizen.oasparser.ovl3.LicenseImpl;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.reprezen.kaizen.oasparser.jsonoverlay.IJsonOverlay;
@@ -236,16 +238,44 @@ public class InfoImpl extends PropertiesOverlay<Info> implements Info {
 
         @Override
         public JsonOverlay<Info> _create(Info info, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            JsonOverlay<?> overlay = new InfoImpl(info, parent, refReg);
+            Class<? extends Info> subtype = getSubtypeOf(info);
+            IJsonOverlay<?> overlay;
+            if (subtype == null || subtype == Info.class) {
+                overlay = new InfoImpl(info, parent, refReg);
+            } else {
+                switch(subtype.getSimpleName()) {
+                    default:
+                        overlay = null;
+                }
+            }
             @SuppressWarnings("unchecked") JsonOverlay<Info> castOverlay = (JsonOverlay<Info>) overlay;
             return castOverlay;
         }
 
         @Override
         public JsonOverlay<Info> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            JsonOverlay<?> overlay = new InfoImpl(json, parent, refReg);
+            Class<? extends Info> subtype = getSubtypeOf(json);
+            IJsonOverlay<?> overlay;
+            if (subtype == null || subtype == Info.class) {
+                overlay = new InfoImpl(json, parent, refReg);
+            } else {
+                switch(subtype.getSimpleName()) {
+                    default:
+                        overlay = null;
+                }
+            }
             @SuppressWarnings("unchecked") JsonOverlay<Info> castOverlay = (JsonOverlay<Info>) overlay;
             return castOverlay;
         }
     };
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private static Class<? extends Info> getSubtypeOf(Info info) {
+        return Info.class;
+    }
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private static Class<? extends Info> getSubtypeOf(JsonNode json) {
+        return Info.class;
+    }
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/LicenseImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/LicenseImpl.java
@@ -6,12 +6,14 @@ import com.reprezen.kaizen.oasparser.jsonoverlay.ChildMapOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ChildListOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ReferenceRegistry;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ListOverlay;
-import com.reprezen.kaizen.oasparser.model3.License;
 import java.util.Collection;
+import java.util.stream.Collectors;
+import com.reprezen.kaizen.oasparser.model3.*;
 import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ChildOverlay;
 import javax.annotation.Generated;
 import com.reprezen.kaizen.oasparser.jsonoverlay.PropertiesOverlay;
+import com.fasterxml.jackson.core.JsonPointer;
 import java.util.Map;
 import com.reprezen.kaizen.oasparser.jsonoverlay.OverlayFactory;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -142,16 +144,44 @@ public class LicenseImpl extends PropertiesOverlay<License> implements License {
 
         @Override
         public JsonOverlay<License> _create(License license, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            JsonOverlay<?> overlay = new LicenseImpl(license, parent, refReg);
+            Class<? extends License> subtype = getSubtypeOf(license);
+            IJsonOverlay<?> overlay;
+            if (subtype == null || subtype == License.class) {
+                overlay = new LicenseImpl(license, parent, refReg);
+            } else {
+                switch(subtype.getSimpleName()) {
+                    default:
+                        overlay = null;
+                }
+            }
             @SuppressWarnings("unchecked") JsonOverlay<License> castOverlay = (JsonOverlay<License>) overlay;
             return castOverlay;
         }
 
         @Override
         public JsonOverlay<License> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            JsonOverlay<?> overlay = new LicenseImpl(json, parent, refReg);
+            Class<? extends License> subtype = getSubtypeOf(json);
+            IJsonOverlay<?> overlay;
+            if (subtype == null || subtype == License.class) {
+                overlay = new LicenseImpl(json, parent, refReg);
+            } else {
+                switch(subtype.getSimpleName()) {
+                    default:
+                        overlay = null;
+                }
+            }
             @SuppressWarnings("unchecked") JsonOverlay<License> castOverlay = (JsonOverlay<License>) overlay;
             return castOverlay;
         }
     };
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private static Class<? extends License> getSubtypeOf(License license) {
+        return License.class;
+    }
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private static Class<? extends License> getSubtypeOf(JsonNode json) {
+        return License.class;
+    }
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/LinkImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/LinkImpl.java
@@ -10,11 +10,13 @@ import com.reprezen.kaizen.oasparser.jsonoverlay.ReferenceRegistry;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ListOverlay;
 import java.util.Collection;
 import com.reprezen.kaizen.oasparser.model3.Header;
-import com.reprezen.kaizen.oasparser.model3.Link;
+import java.util.stream.Collectors;
+import com.reprezen.kaizen.oasparser.model3.*;
 import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ChildOverlay;
 import javax.annotation.Generated;
 import com.reprezen.kaizen.oasparser.jsonoverlay.PropertiesOverlay;
+import com.fasterxml.jackson.core.JsonPointer;
 import java.util.Map;
 import com.reprezen.kaizen.oasparser.jsonoverlay.OverlayFactory;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -284,16 +286,44 @@ public class LinkImpl extends PropertiesOverlay<Link> implements Link {
 
         @Override
         public JsonOverlay<Link> _create(Link link, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            JsonOverlay<?> overlay = new LinkImpl(link, parent, refReg);
+            Class<? extends Link> subtype = getSubtypeOf(link);
+            IJsonOverlay<?> overlay;
+            if (subtype == null || subtype == Link.class) {
+                overlay = new LinkImpl(link, parent, refReg);
+            } else {
+                switch(subtype.getSimpleName()) {
+                    default:
+                        overlay = null;
+                }
+            }
             @SuppressWarnings("unchecked") JsonOverlay<Link> castOverlay = (JsonOverlay<Link>) overlay;
             return castOverlay;
         }
 
         @Override
         public JsonOverlay<Link> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            JsonOverlay<?> overlay = new LinkImpl(json, parent, refReg);
+            Class<? extends Link> subtype = getSubtypeOf(json);
+            IJsonOverlay<?> overlay;
+            if (subtype == null || subtype == Link.class) {
+                overlay = new LinkImpl(json, parent, refReg);
+            } else {
+                switch(subtype.getSimpleName()) {
+                    default:
+                        overlay = null;
+                }
+            }
             @SuppressWarnings("unchecked") JsonOverlay<Link> castOverlay = (JsonOverlay<Link>) overlay;
             return castOverlay;
         }
     };
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private static Class<? extends Link> getSubtypeOf(Link link) {
+        return Link.class;
+    }
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private static Class<? extends Link> getSubtypeOf(JsonNode json) {
+        return Link.class;
+    }
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/MediaTypeImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/MediaTypeImpl.java
@@ -1,28 +1,30 @@
 package com.reprezen.kaizen.oasparser.ovl3;
 
 import com.reprezen.kaizen.oasparser.model3.Schema;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ObjectOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ChildMapOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ChildListOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ChildMapOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ReferenceRegistry;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ListOverlay;
-import java.util.Collection;
-import com.reprezen.kaizen.oasparser.ovl3.ExampleImpl;
-import com.reprezen.kaizen.oasparser.jsonoverlay.Reference;
 import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
-import com.reprezen.kaizen.oasparser.ovl3.EncodingPropertyImpl;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ChildOverlay;
+import com.fasterxml.jackson.core.JsonPointer;
 import javax.annotation.Generated;
 import com.reprezen.kaizen.oasparser.jsonoverlay.PropertiesOverlay;
 import com.reprezen.kaizen.oasparser.ovl3.SchemaImpl;
-import com.reprezen.kaizen.oasparser.model3.MediaType;
 import com.reprezen.kaizen.oasparser.model3.Example;
 import java.util.Map;
 import com.reprezen.kaizen.oasparser.jsonoverlay.OverlayFactory;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.reprezen.kaizen.oasparser.model3.EncodingProperty;
 import com.reprezen.kaizen.oasparser.jsonoverlay.IJsonOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ObjectOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ListOverlay;
+import com.reprezen.kaizen.oasparser.ovl3.ExampleImpl;
+import java.util.Collection;
+import java.util.stream.Collectors;
+import com.reprezen.kaizen.oasparser.jsonoverlay.Reference;
+import com.reprezen.kaizen.oasparser.model3.*;
+import com.reprezen.kaizen.oasparser.ovl3.EncodingPropertyImpl;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ChildOverlay;
+import com.reprezen.kaizen.oasparser.model3.EncodingProperty;
 
 public class MediaTypeImpl extends PropertiesOverlay<MediaType> implements MediaType {
 
@@ -268,16 +270,44 @@ public class MediaTypeImpl extends PropertiesOverlay<MediaType> implements Media
 
         @Override
         public JsonOverlay<MediaType> _create(MediaType mediaType, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            JsonOverlay<?> overlay = new MediaTypeImpl(mediaType, parent, refReg);
+            Class<? extends MediaType> subtype = getSubtypeOf(mediaType);
+            IJsonOverlay<?> overlay;
+            if (subtype == null || subtype == MediaType.class) {
+                overlay = new MediaTypeImpl(mediaType, parent, refReg);
+            } else {
+                switch(subtype.getSimpleName()) {
+                    default:
+                        overlay = null;
+                }
+            }
             @SuppressWarnings("unchecked") JsonOverlay<MediaType> castOverlay = (JsonOverlay<MediaType>) overlay;
             return castOverlay;
         }
 
         @Override
         public JsonOverlay<MediaType> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            JsonOverlay<?> overlay = new MediaTypeImpl(json, parent, refReg);
+            Class<? extends MediaType> subtype = getSubtypeOf(json);
+            IJsonOverlay<?> overlay;
+            if (subtype == null || subtype == MediaType.class) {
+                overlay = new MediaTypeImpl(json, parent, refReg);
+            } else {
+                switch(subtype.getSimpleName()) {
+                    default:
+                        overlay = null;
+                }
+            }
             @SuppressWarnings("unchecked") JsonOverlay<MediaType> castOverlay = (JsonOverlay<MediaType>) overlay;
             return castOverlay;
         }
     };
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private static Class<? extends MediaType> getSubtypeOf(MediaType mediaType) {
+        return MediaType.class;
+    }
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private static Class<? extends MediaType> getSubtypeOf(JsonNode json) {
+        return MediaType.class;
+    }
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/OAuthFlowImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/OAuthFlowImpl.java
@@ -7,11 +7,13 @@ import com.reprezen.kaizen.oasparser.jsonoverlay.ChildListOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ReferenceRegistry;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ListOverlay;
 import java.util.Collection;
-import com.reprezen.kaizen.oasparser.model3.OAuthFlow;
+import java.util.stream.Collectors;
+import com.reprezen.kaizen.oasparser.model3.*;
 import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ChildOverlay;
 import javax.annotation.Generated;
 import com.reprezen.kaizen.oasparser.jsonoverlay.PropertiesOverlay;
+import com.fasterxml.jackson.core.JsonPointer;
 import java.util.Map;
 import com.reprezen.kaizen.oasparser.jsonoverlay.OverlayFactory;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -257,16 +259,44 @@ public class OAuthFlowImpl extends PropertiesOverlay<OAuthFlow> implements OAuth
 
         @Override
         public JsonOverlay<OAuthFlow> _create(OAuthFlow oAuthFlow, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            JsonOverlay<?> overlay = new OAuthFlowImpl(oAuthFlow, parent, refReg);
+            Class<? extends OAuthFlow> subtype = getSubtypeOf(oAuthFlow);
+            IJsonOverlay<?> overlay;
+            if (subtype == null || subtype == OAuthFlow.class) {
+                overlay = new OAuthFlowImpl(oAuthFlow, parent, refReg);
+            } else {
+                switch(subtype.getSimpleName()) {
+                    default:
+                        overlay = null;
+                }
+            }
             @SuppressWarnings("unchecked") JsonOverlay<OAuthFlow> castOverlay = (JsonOverlay<OAuthFlow>) overlay;
             return castOverlay;
         }
 
         @Override
         public JsonOverlay<OAuthFlow> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            JsonOverlay<?> overlay = new OAuthFlowImpl(json, parent, refReg);
+            Class<? extends OAuthFlow> subtype = getSubtypeOf(json);
+            IJsonOverlay<?> overlay;
+            if (subtype == null || subtype == OAuthFlow.class) {
+                overlay = new OAuthFlowImpl(json, parent, refReg);
+            } else {
+                switch(subtype.getSimpleName()) {
+                    default:
+                        overlay = null;
+                }
+            }
             @SuppressWarnings("unchecked") JsonOverlay<OAuthFlow> castOverlay = (JsonOverlay<OAuthFlow>) overlay;
             return castOverlay;
         }
     };
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private static Class<? extends OAuthFlow> getSubtypeOf(OAuthFlow oAuthFlow) {
+        return OAuthFlow.class;
+    }
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private static Class<? extends OAuthFlow> getSubtypeOf(JsonNode json) {
+        return OAuthFlow.class;
+    }
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/OpenApi3Impl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/OpenApi3Impl.java
@@ -3,7 +3,6 @@ package com.reprezen.kaizen.oasparser.ovl3;
 import com.reprezen.kaizen.oasparser.ovl3.HeaderImpl;
 import com.reprezen.kaizen.oasparser.ovl3.CallbackImpl;
 import com.google.inject.Inject;
-import com.reprezen.kaizen.oasparser.model3.OpenApi3;
 import com.reprezen.kaizen.oasparser.ovl3.SecuritySchemeImpl;
 import com.reprezen.kaizen.oasparser.ovl3.SecurityRequirementImpl;
 import javax.annotation.Generated;
@@ -20,6 +19,8 @@ import com.reprezen.kaizen.oasparser.val.ValidationResults.Severity;
 import java.util.Collection;
 import com.reprezen.kaizen.oasparser.ovl3.ResponseImpl;
 import com.reprezen.kaizen.oasparser.model3.Header;
+import java.util.stream.Collectors;
+import com.reprezen.kaizen.oasparser.model3.*;
 import com.reprezen.kaizen.oasparser.ovl3.ExternalDocsImpl;
 import com.reprezen.kaizen.oasparser.val3.OpenApi3Validator;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
@@ -38,6 +39,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
 import com.reprezen.kaizen.oasparser.model3.Callback;
 import com.reprezen.kaizen.oasparser.val.Validator;
+import com.fasterxml.jackson.core.JsonPointer;
 import com.reprezen.kaizen.oasparser.jsonoverlay.PropertiesOverlay;
 import com.reprezen.kaizen.oasparser.model3.Response;
 import com.reprezen.kaizen.oasparser.ovl3.SchemaImpl;
@@ -1134,16 +1136,44 @@ public class OpenApi3Impl extends PropertiesOverlay<OpenApi3> implements OpenApi
 
         @Override
         public JsonOverlay<OpenApi3> _create(OpenApi3 openApi3, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            JsonOverlay<?> overlay = new OpenApi3Impl(openApi3, parent, refReg);
+            Class<? extends OpenApi3> subtype = getSubtypeOf(openApi3);
+            IJsonOverlay<?> overlay;
+            if (subtype == null || subtype == OpenApi3.class) {
+                overlay = new OpenApi3Impl(openApi3, parent, refReg);
+            } else {
+                switch(subtype.getSimpleName()) {
+                    default:
+                        overlay = null;
+                }
+            }
             @SuppressWarnings("unchecked") JsonOverlay<OpenApi3> castOverlay = (JsonOverlay<OpenApi3>) overlay;
             return castOverlay;
         }
 
         @Override
         public JsonOverlay<OpenApi3> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            JsonOverlay<?> overlay = new OpenApi3Impl(json, parent, refReg);
+            Class<? extends OpenApi3> subtype = getSubtypeOf(json);
+            IJsonOverlay<?> overlay;
+            if (subtype == null || subtype == OpenApi3.class) {
+                overlay = new OpenApi3Impl(json, parent, refReg);
+            } else {
+                switch(subtype.getSimpleName()) {
+                    default:
+                        overlay = null;
+                }
+            }
             @SuppressWarnings("unchecked") JsonOverlay<OpenApi3> castOverlay = (JsonOverlay<OpenApi3>) overlay;
             return castOverlay;
         }
     };
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private static Class<? extends OpenApi3> getSubtypeOf(OpenApi3 openApi3) {
+        return OpenApi3.class;
+    }
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private static Class<? extends OpenApi3> getSubtypeOf(JsonNode json) {
+        return OpenApi3.class;
+    }
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/OperationImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/OperationImpl.java
@@ -10,6 +10,7 @@ import com.reprezen.kaizen.oasparser.jsonoverlay.BooleanOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
 import com.reprezen.kaizen.oasparser.ovl3.SecurityRequirementImpl;
 import com.reprezen.kaizen.oasparser.model3.Callback;
+import com.fasterxml.jackson.core.JsonPointer;
 import javax.annotation.Generated;
 import com.reprezen.kaizen.oasparser.jsonoverlay.PropertiesOverlay;
 import com.reprezen.kaizen.oasparser.model3.Response;
@@ -26,10 +27,11 @@ import com.reprezen.kaizen.oasparser.model3.SecurityRequirement;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ListOverlay;
 import java.util.Collection;
 import com.reprezen.kaizen.oasparser.ovl3.ResponseImpl;
+import java.util.stream.Collectors;
 import com.reprezen.kaizen.oasparser.jsonoverlay.Reference;
+import com.reprezen.kaizen.oasparser.model3.*;
 import com.reprezen.kaizen.oasparser.ovl3.ExternalDocsImpl;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ChildOverlay;
-import com.reprezen.kaizen.oasparser.model3.Operation;
 import com.reprezen.kaizen.oasparser.ovl3.RequestBodyImpl;
 import com.reprezen.kaizen.oasparser.model3.ExternalDocs;
 import com.reprezen.kaizen.oasparser.jsonoverlay.StringOverlay;
@@ -734,16 +736,44 @@ public class OperationImpl extends PropertiesOverlay<Operation> implements Opera
 
         @Override
         public JsonOverlay<Operation> _create(Operation operation, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            JsonOverlay<?> overlay = new OperationImpl(operation, parent, refReg);
+            Class<? extends Operation> subtype = getSubtypeOf(operation);
+            IJsonOverlay<?> overlay;
+            if (subtype == null || subtype == Operation.class) {
+                overlay = new OperationImpl(operation, parent, refReg);
+            } else {
+                switch(subtype.getSimpleName()) {
+                    default:
+                        overlay = null;
+                }
+            }
             @SuppressWarnings("unchecked") JsonOverlay<Operation> castOverlay = (JsonOverlay<Operation>) overlay;
             return castOverlay;
         }
 
         @Override
         public JsonOverlay<Operation> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            JsonOverlay<?> overlay = new OperationImpl(json, parent, refReg);
+            Class<? extends Operation> subtype = getSubtypeOf(json);
+            IJsonOverlay<?> overlay;
+            if (subtype == null || subtype == Operation.class) {
+                overlay = new OperationImpl(json, parent, refReg);
+            } else {
+                switch(subtype.getSimpleName()) {
+                    default:
+                        overlay = null;
+                }
+            }
             @SuppressWarnings("unchecked") JsonOverlay<Operation> castOverlay = (JsonOverlay<Operation>) overlay;
             return castOverlay;
         }
     };
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private static Class<? extends Operation> getSubtypeOf(Operation operation) {
+        return Operation.class;
+    }
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private static Class<? extends Operation> getSubtypeOf(JsonNode json) {
+        return Operation.class;
+    }
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ParameterImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ParameterImpl.java
@@ -6,10 +6,10 @@ import com.reprezen.kaizen.oasparser.jsonoverlay.ChildMapOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ReferenceRegistry;
 import com.reprezen.kaizen.oasparser.jsonoverlay.BooleanOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
+import com.fasterxml.jackson.core.JsonPointer;
 import javax.annotation.Generated;
 import com.reprezen.kaizen.oasparser.jsonoverlay.PropertiesOverlay;
 import com.reprezen.kaizen.oasparser.ovl3.SchemaImpl;
-import com.reprezen.kaizen.oasparser.model3.Parameter;
 import com.reprezen.kaizen.oasparser.model3.Example;
 import java.util.Map;
 import com.reprezen.kaizen.oasparser.jsonoverlay.OverlayFactory;
@@ -21,7 +21,9 @@ import com.reprezen.kaizen.oasparser.ovl3.MediaTypeImpl;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ListOverlay;
 import com.reprezen.kaizen.oasparser.ovl3.ExampleImpl;
 import java.util.Collection;
+import java.util.stream.Collectors;
 import com.reprezen.kaizen.oasparser.jsonoverlay.Reference;
+import com.reprezen.kaizen.oasparser.model3.*;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ChildOverlay;
 import com.reprezen.kaizen.oasparser.model3.MediaType;
 import com.reprezen.kaizen.oasparser.jsonoverlay.StringOverlay;
@@ -507,16 +509,44 @@ public class ParameterImpl extends PropertiesOverlay<Parameter> implements Param
 
         @Override
         public JsonOverlay<Parameter> _create(Parameter parameter, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            JsonOverlay<?> overlay = new ParameterImpl(parameter, parent, refReg);
+            Class<? extends Parameter> subtype = getSubtypeOf(parameter);
+            IJsonOverlay<?> overlay;
+            if (subtype == null || subtype == Parameter.class) {
+                overlay = new ParameterImpl(parameter, parent, refReg);
+            } else {
+                switch(subtype.getSimpleName()) {
+                    default:
+                        overlay = null;
+                }
+            }
             @SuppressWarnings("unchecked") JsonOverlay<Parameter> castOverlay = (JsonOverlay<Parameter>) overlay;
             return castOverlay;
         }
 
         @Override
         public JsonOverlay<Parameter> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            JsonOverlay<?> overlay = new ParameterImpl(json, parent, refReg);
+            Class<? extends Parameter> subtype = getSubtypeOf(json);
+            IJsonOverlay<?> overlay;
+            if (subtype == null || subtype == Parameter.class) {
+                overlay = new ParameterImpl(json, parent, refReg);
+            } else {
+                switch(subtype.getSimpleName()) {
+                    default:
+                        overlay = null;
+                }
+            }
             @SuppressWarnings("unchecked") JsonOverlay<Parameter> castOverlay = (JsonOverlay<Parameter>) overlay;
             return castOverlay;
         }
     };
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private static Class<? extends Parameter> getSubtypeOf(Parameter parameter) {
+        return Parameter.class;
+    }
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private static Class<? extends Parameter> getSubtypeOf(JsonNode json) {
+        return Parameter.class;
+    }
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/PathImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/PathImpl.java
@@ -1,28 +1,30 @@
 package com.reprezen.kaizen.oasparser.ovl3;
 
-import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ObjectOverlay;
 import com.reprezen.kaizen.oasparser.model3.Server;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ChildListOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ChildMapOverlay;
-import com.reprezen.kaizen.oasparser.ovl3.OperationImpl;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ReferenceRegistry;
-import com.reprezen.kaizen.oasparser.model3.Path;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ListOverlay;
-import java.util.Collection;
 import com.reprezen.kaizen.oasparser.ovl3.ParameterImpl;
-import com.reprezen.kaizen.oasparser.jsonoverlay.Reference;
 import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ChildOverlay;
+import com.fasterxml.jackson.core.JsonPointer;
 import javax.annotation.Generated;
 import com.reprezen.kaizen.oasparser.jsonoverlay.PropertiesOverlay;
-import com.reprezen.kaizen.oasparser.model3.Operation;
 import com.reprezen.kaizen.oasparser.model3.Parameter;
 import java.util.Map;
 import com.reprezen.kaizen.oasparser.jsonoverlay.OverlayFactory;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.reprezen.kaizen.oasparser.ovl3.ServerImpl;
 import com.reprezen.kaizen.oasparser.jsonoverlay.IJsonOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ObjectOverlay;
+import com.reprezen.kaizen.oasparser.ovl3.OperationImpl;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ListOverlay;
+import java.util.Collection;
+import java.util.stream.Collectors;
+import com.reprezen.kaizen.oasparser.jsonoverlay.Reference;
+import com.reprezen.kaizen.oasparser.model3.*;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ChildOverlay;
+import com.reprezen.kaizen.oasparser.model3.Operation;
 import com.reprezen.kaizen.oasparser.jsonoverlay.StringOverlay;
 
 public class PathImpl extends PropertiesOverlay<Path> implements Path {
@@ -445,16 +447,44 @@ public class PathImpl extends PropertiesOverlay<Path> implements Path {
 
         @Override
         public JsonOverlay<Path> _create(Path path, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            JsonOverlay<?> overlay = new PathImpl(path, parent, refReg);
+            Class<? extends Path> subtype = getSubtypeOf(path);
+            IJsonOverlay<?> overlay;
+            if (subtype == null || subtype == Path.class) {
+                overlay = new PathImpl(path, parent, refReg);
+            } else {
+                switch(subtype.getSimpleName()) {
+                    default:
+                        overlay = null;
+                }
+            }
             @SuppressWarnings("unchecked") JsonOverlay<Path> castOverlay = (JsonOverlay<Path>) overlay;
             return castOverlay;
         }
 
         @Override
         public JsonOverlay<Path> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            JsonOverlay<?> overlay = new PathImpl(json, parent, refReg);
+            Class<? extends Path> subtype = getSubtypeOf(json);
+            IJsonOverlay<?> overlay;
+            if (subtype == null || subtype == Path.class) {
+                overlay = new PathImpl(json, parent, refReg);
+            } else {
+                switch(subtype.getSimpleName()) {
+                    default:
+                        overlay = null;
+                }
+            }
             @SuppressWarnings("unchecked") JsonOverlay<Path> castOverlay = (JsonOverlay<Path>) overlay;
             return castOverlay;
         }
     };
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private static Class<? extends Path> getSubtypeOf(Path path) {
+        return Path.class;
+    }
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private static Class<? extends Path> getSubtypeOf(JsonNode json) {
+        return Path.class;
+    }
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/RequestBodyImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/RequestBodyImpl.java
@@ -8,13 +8,15 @@ import com.reprezen.kaizen.oasparser.jsonoverlay.ReferenceRegistry;
 import com.reprezen.kaizen.oasparser.ovl3.MediaTypeImpl;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ListOverlay;
 import java.util.Collection;
+import java.util.stream.Collectors;
+import com.reprezen.kaizen.oasparser.model3.*;
 import com.reprezen.kaizen.oasparser.jsonoverlay.BooleanOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ChildOverlay;
 import javax.annotation.Generated;
 import com.reprezen.kaizen.oasparser.jsonoverlay.PropertiesOverlay;
+import com.fasterxml.jackson.core.JsonPointer;
 import com.reprezen.kaizen.oasparser.model3.MediaType;
-import com.reprezen.kaizen.oasparser.model3.RequestBody;
 import java.util.Map;
 import com.reprezen.kaizen.oasparser.jsonoverlay.OverlayFactory;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -196,16 +198,44 @@ public class RequestBodyImpl extends PropertiesOverlay<RequestBody> implements R
 
         @Override
         public JsonOverlay<RequestBody> _create(RequestBody requestBody, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            JsonOverlay<?> overlay = new RequestBodyImpl(requestBody, parent, refReg);
+            Class<? extends RequestBody> subtype = getSubtypeOf(requestBody);
+            IJsonOverlay<?> overlay;
+            if (subtype == null || subtype == RequestBody.class) {
+                overlay = new RequestBodyImpl(requestBody, parent, refReg);
+            } else {
+                switch(subtype.getSimpleName()) {
+                    default:
+                        overlay = null;
+                }
+            }
             @SuppressWarnings("unchecked") JsonOverlay<RequestBody> castOverlay = (JsonOverlay<RequestBody>) overlay;
             return castOverlay;
         }
 
         @Override
         public JsonOverlay<RequestBody> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            JsonOverlay<?> overlay = new RequestBodyImpl(json, parent, refReg);
+            Class<? extends RequestBody> subtype = getSubtypeOf(json);
+            IJsonOverlay<?> overlay;
+            if (subtype == null || subtype == RequestBody.class) {
+                overlay = new RequestBodyImpl(json, parent, refReg);
+            } else {
+                switch(subtype.getSimpleName()) {
+                    default:
+                        overlay = null;
+                }
+            }
             @SuppressWarnings("unchecked") JsonOverlay<RequestBody> castOverlay = (JsonOverlay<RequestBody>) overlay;
             return castOverlay;
         }
     };
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private static Class<? extends RequestBody> getSubtypeOf(RequestBody requestBody) {
+        return RequestBody.class;
+    }
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private static Class<? extends RequestBody> getSubtypeOf(JsonNode json) {
+        return RequestBody.class;
+    }
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ResponseImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ResponseImpl.java
@@ -1,28 +1,30 @@
 package com.reprezen.kaizen.oasparser.ovl3;
 
-import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
-import com.reprezen.kaizen.oasparser.jsonoverlay.ObjectOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ChildListOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ChildMapOverlay;
 import com.reprezen.kaizen.oasparser.ovl3.HeaderImpl;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ReferenceRegistry;
+import com.reprezen.kaizen.oasparser.model3.Link;
+import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
+import com.fasterxml.jackson.core.JsonPointer;
+import javax.annotation.Generated;
+import com.reprezen.kaizen.oasparser.jsonoverlay.PropertiesOverlay;
+import java.util.Map;
+import com.reprezen.kaizen.oasparser.jsonoverlay.OverlayFactory;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.reprezen.kaizen.oasparser.jsonoverlay.IJsonOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.ObjectOverlay;
 import com.reprezen.kaizen.oasparser.ovl3.MediaTypeImpl;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ListOverlay;
 import java.util.Collection;
 import com.reprezen.kaizen.oasparser.model3.Header;
+import java.util.stream.Collectors;
 import com.reprezen.kaizen.oasparser.jsonoverlay.Reference;
-import com.reprezen.kaizen.oasparser.model3.Link;
-import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
+import com.reprezen.kaizen.oasparser.model3.*;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ChildOverlay;
-import javax.annotation.Generated;
-import com.reprezen.kaizen.oasparser.jsonoverlay.PropertiesOverlay;
-import com.reprezen.kaizen.oasparser.model3.Response;
 import com.reprezen.kaizen.oasparser.model3.MediaType;
-import java.util.Map;
-import com.reprezen.kaizen.oasparser.jsonoverlay.OverlayFactory;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.reprezen.kaizen.oasparser.ovl3.LinkImpl;
-import com.reprezen.kaizen.oasparser.jsonoverlay.IJsonOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.StringOverlay;
 
 public class ResponseImpl extends PropertiesOverlay<Response> implements Response {
@@ -295,16 +297,44 @@ public class ResponseImpl extends PropertiesOverlay<Response> implements Respons
 
         @Override
         public JsonOverlay<Response> _create(Response response, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            JsonOverlay<?> overlay = new ResponseImpl(response, parent, refReg);
+            Class<? extends Response> subtype = getSubtypeOf(response);
+            IJsonOverlay<?> overlay;
+            if (subtype == null || subtype == Response.class) {
+                overlay = new ResponseImpl(response, parent, refReg);
+            } else {
+                switch(subtype.getSimpleName()) {
+                    default:
+                        overlay = null;
+                }
+            }
             @SuppressWarnings("unchecked") JsonOverlay<Response> castOverlay = (JsonOverlay<Response>) overlay;
             return castOverlay;
         }
 
         @Override
         public JsonOverlay<Response> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            JsonOverlay<?> overlay = new ResponseImpl(json, parent, refReg);
+            Class<? extends Response> subtype = getSubtypeOf(json);
+            IJsonOverlay<?> overlay;
+            if (subtype == null || subtype == Response.class) {
+                overlay = new ResponseImpl(json, parent, refReg);
+            } else {
+                switch(subtype.getSimpleName()) {
+                    default:
+                        overlay = null;
+                }
+            }
             @SuppressWarnings("unchecked") JsonOverlay<Response> castOverlay = (JsonOverlay<Response>) overlay;
             return castOverlay;
         }
     };
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private static Class<? extends Response> getSubtypeOf(Response response) {
+        return Response.class;
+    }
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private static Class<? extends Response> getSubtypeOf(JsonNode json) {
+        return Response.class;
+    }
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/SchemaImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/SchemaImpl.java
@@ -21,7 +21,9 @@ import com.reprezen.kaizen.oasparser.jsonoverlay.ObjectOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ListOverlay;
 import com.reprezen.kaizen.oasparser.ovl3.ExampleImpl;
 import java.util.Collection;
+import java.util.stream.Collectors;
 import com.reprezen.kaizen.oasparser.jsonoverlay.Reference;
+import com.reprezen.kaizen.oasparser.model3.*;
 import com.reprezen.kaizen.oasparser.ovl3.ExternalDocsImpl;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ChildOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.NumberOverlay;
@@ -1336,16 +1338,44 @@ public class SchemaImpl extends PropertiesOverlay<Schema> implements Schema {
 
         @Override
         public JsonOverlay<Schema> _create(Schema schema, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            JsonOverlay<?> overlay = new SchemaImpl(schema, parent, refReg);
+            Class<? extends Schema> subtype = getSubtypeOf(schema);
+            IJsonOverlay<?> overlay;
+            if (subtype == null || subtype == Schema.class) {
+                overlay = new SchemaImpl(schema, parent, refReg);
+            } else {
+                switch(subtype.getSimpleName()) {
+                    default:
+                        overlay = null;
+                }
+            }
             @SuppressWarnings("unchecked") JsonOverlay<Schema> castOverlay = (JsonOverlay<Schema>) overlay;
             return castOverlay;
         }
 
         @Override
         public JsonOverlay<Schema> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            JsonOverlay<?> overlay = new SchemaImpl(json, parent, refReg);
+            Class<? extends Schema> subtype = getSubtypeOf(json);
+            IJsonOverlay<?> overlay;
+            if (subtype == null || subtype == Schema.class) {
+                overlay = new SchemaImpl(json, parent, refReg);
+            } else {
+                switch(subtype.getSimpleName()) {
+                    default:
+                        overlay = null;
+                }
+            }
             @SuppressWarnings("unchecked") JsonOverlay<Schema> castOverlay = (JsonOverlay<Schema>) overlay;
             return castOverlay;
         }
     };
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private static Class<? extends Schema> getSubtypeOf(Schema schema) {
+        return Schema.class;
+    }
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private static Class<? extends Schema> getSubtypeOf(JsonNode json) {
+        return Schema.class;
+    }
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/SecurityParameterImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/SecurityParameterImpl.java
@@ -5,9 +5,11 @@ import com.reprezen.kaizen.oasparser.jsonoverlay.ChildListOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ReferenceRegistry;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ListOverlay;
 import java.util.Collection;
-import com.reprezen.kaizen.oasparser.model3.SecurityParameter;
+import java.util.stream.Collectors;
+import com.reprezen.kaizen.oasparser.model3.*;
 import javax.annotation.Generated;
 import com.reprezen.kaizen.oasparser.jsonoverlay.PropertiesOverlay;
+import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.reprezen.kaizen.oasparser.jsonoverlay.OverlayFactory;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -107,16 +109,44 @@ public class SecurityParameterImpl extends PropertiesOverlay<SecurityParameter> 
 
         @Override
         public JsonOverlay<SecurityParameter> _create(SecurityParameter securityParameter, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            JsonOverlay<?> overlay = new SecurityParameterImpl(securityParameter, parent, refReg);
+            Class<? extends SecurityParameter> subtype = getSubtypeOf(securityParameter);
+            IJsonOverlay<?> overlay;
+            if (subtype == null || subtype == SecurityParameter.class) {
+                overlay = new SecurityParameterImpl(securityParameter, parent, refReg);
+            } else {
+                switch(subtype.getSimpleName()) {
+                    default:
+                        overlay = null;
+                }
+            }
             @SuppressWarnings("unchecked") JsonOverlay<SecurityParameter> castOverlay = (JsonOverlay<SecurityParameter>) overlay;
             return castOverlay;
         }
 
         @Override
         public JsonOverlay<SecurityParameter> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            JsonOverlay<?> overlay = new SecurityParameterImpl(json, parent, refReg);
+            Class<? extends SecurityParameter> subtype = getSubtypeOf(json);
+            IJsonOverlay<?> overlay;
+            if (subtype == null || subtype == SecurityParameter.class) {
+                overlay = new SecurityParameterImpl(json, parent, refReg);
+            } else {
+                switch(subtype.getSimpleName()) {
+                    default:
+                        overlay = null;
+                }
+            }
             @SuppressWarnings("unchecked") JsonOverlay<SecurityParameter> castOverlay = (JsonOverlay<SecurityParameter>) overlay;
             return castOverlay;
         }
     };
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private static Class<? extends SecurityParameter> getSubtypeOf(SecurityParameter securityParameter) {
+        return SecurityParameter.class;
+    }
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private static Class<? extends SecurityParameter> getSubtypeOf(JsonNode json) {
+        return SecurityParameter.class;
+    }
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/SecurityRequirementImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/SecurityRequirementImpl.java
@@ -4,11 +4,13 @@ import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ChildMapOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ReferenceRegistry;
 import com.reprezen.kaizen.oasparser.ovl3.SecurityParameterImpl;
-import com.reprezen.kaizen.oasparser.model3.SecurityRequirement;
 import com.reprezen.kaizen.oasparser.model3.SecurityParameter;
+import java.util.stream.Collectors;
+import com.reprezen.kaizen.oasparser.model3.*;
 import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
 import javax.annotation.Generated;
 import com.reprezen.kaizen.oasparser.jsonoverlay.PropertiesOverlay;
+import com.fasterxml.jackson.core.JsonPointer;
 import java.util.Map;
 import com.reprezen.kaizen.oasparser.jsonoverlay.OverlayFactory;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -90,16 +92,44 @@ public class SecurityRequirementImpl extends PropertiesOverlay<SecurityRequireme
 
         @Override
         public JsonOverlay<SecurityRequirement> _create(SecurityRequirement securityRequirement, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            JsonOverlay<?> overlay = new SecurityRequirementImpl(securityRequirement, parent, refReg);
+            Class<? extends SecurityRequirement> subtype = getSubtypeOf(securityRequirement);
+            IJsonOverlay<?> overlay;
+            if (subtype == null || subtype == SecurityRequirement.class) {
+                overlay = new SecurityRequirementImpl(securityRequirement, parent, refReg);
+            } else {
+                switch(subtype.getSimpleName()) {
+                    default:
+                        overlay = null;
+                }
+            }
             @SuppressWarnings("unchecked") JsonOverlay<SecurityRequirement> castOverlay = (JsonOverlay<SecurityRequirement>) overlay;
             return castOverlay;
         }
 
         @Override
         public JsonOverlay<SecurityRequirement> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            JsonOverlay<?> overlay = new SecurityRequirementImpl(json, parent, refReg);
+            Class<? extends SecurityRequirement> subtype = getSubtypeOf(json);
+            IJsonOverlay<?> overlay;
+            if (subtype == null || subtype == SecurityRequirement.class) {
+                overlay = new SecurityRequirementImpl(json, parent, refReg);
+            } else {
+                switch(subtype.getSimpleName()) {
+                    default:
+                        overlay = null;
+                }
+            }
             @SuppressWarnings("unchecked") JsonOverlay<SecurityRequirement> castOverlay = (JsonOverlay<SecurityRequirement>) overlay;
             return castOverlay;
         }
     };
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private static Class<? extends SecurityRequirement> getSubtypeOf(SecurityRequirement securityRequirement) {
+        return SecurityRequirement.class;
+    }
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private static Class<? extends SecurityRequirement> getSubtypeOf(JsonNode json) {
+        return SecurityRequirement.class;
+    }
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/SecuritySchemeImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/SecuritySchemeImpl.java
@@ -9,13 +9,15 @@ import com.reprezen.kaizen.oasparser.jsonoverlay.ReferenceRegistry;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ListOverlay;
 import java.util.Collection;
 import com.reprezen.kaizen.oasparser.model3.OAuthFlow;
+import java.util.stream.Collectors;
+import com.reprezen.kaizen.oasparser.model3.*;
 import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ChildOverlay;
 import javax.annotation.Generated;
 import com.reprezen.kaizen.oasparser.jsonoverlay.PropertiesOverlay;
+import com.fasterxml.jackson.core.JsonPointer;
 import java.util.Map;
 import com.reprezen.kaizen.oasparser.jsonoverlay.OverlayFactory;
-import com.reprezen.kaizen.oasparser.model3.SecurityScheme;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.reprezen.kaizen.oasparser.jsonoverlay.IJsonOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.StringOverlay;
@@ -396,16 +398,44 @@ public class SecuritySchemeImpl extends PropertiesOverlay<SecurityScheme> implem
 
         @Override
         public JsonOverlay<SecurityScheme> _create(SecurityScheme securityScheme, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            JsonOverlay<?> overlay = new SecuritySchemeImpl(securityScheme, parent, refReg);
+            Class<? extends SecurityScheme> subtype = getSubtypeOf(securityScheme);
+            IJsonOverlay<?> overlay;
+            if (subtype == null || subtype == SecurityScheme.class) {
+                overlay = new SecuritySchemeImpl(securityScheme, parent, refReg);
+            } else {
+                switch(subtype.getSimpleName()) {
+                    default:
+                        overlay = null;
+                }
+            }
             @SuppressWarnings("unchecked") JsonOverlay<SecurityScheme> castOverlay = (JsonOverlay<SecurityScheme>) overlay;
             return castOverlay;
         }
 
         @Override
         public JsonOverlay<SecurityScheme> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            JsonOverlay<?> overlay = new SecuritySchemeImpl(json, parent, refReg);
+            Class<? extends SecurityScheme> subtype = getSubtypeOf(json);
+            IJsonOverlay<?> overlay;
+            if (subtype == null || subtype == SecurityScheme.class) {
+                overlay = new SecuritySchemeImpl(json, parent, refReg);
+            } else {
+                switch(subtype.getSimpleName()) {
+                    default:
+                        overlay = null;
+                }
+            }
             @SuppressWarnings("unchecked") JsonOverlay<SecurityScheme> castOverlay = (JsonOverlay<SecurityScheme>) overlay;
             return castOverlay;
         }
     };
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private static Class<? extends SecurityScheme> getSubtypeOf(SecurityScheme securityScheme) {
+        return SecurityScheme.class;
+    }
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private static Class<? extends SecurityScheme> getSubtypeOf(JsonNode json) {
+        return SecurityScheme.class;
+    }
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ServerImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ServerImpl.java
@@ -2,7 +2,6 @@ package com.reprezen.kaizen.oasparser.ovl3;
 
 import com.reprezen.kaizen.oasparser.jsonoverlay.ObjectOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.JsonOverlay;
-import com.reprezen.kaizen.oasparser.model3.Server;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ChildMapOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ChildListOverlay;
 import com.reprezen.kaizen.oasparser.ovl3.ServerVariableImpl;
@@ -10,10 +9,13 @@ import com.reprezen.kaizen.oasparser.jsonoverlay.ReferenceRegistry;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ListOverlay;
 import java.util.Collection;
 import com.reprezen.kaizen.oasparser.model3.ServerVariable;
+import java.util.stream.Collectors;
+import com.reprezen.kaizen.oasparser.model3.*;
 import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ChildOverlay;
 import javax.annotation.Generated;
 import com.reprezen.kaizen.oasparser.jsonoverlay.PropertiesOverlay;
+import com.fasterxml.jackson.core.JsonPointer;
 import java.util.Map;
 import com.reprezen.kaizen.oasparser.jsonoverlay.OverlayFactory;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -236,16 +238,44 @@ public class ServerImpl extends PropertiesOverlay<Server> implements Server {
 
         @Override
         public JsonOverlay<Server> _create(Server server, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            JsonOverlay<?> overlay = new ServerImpl(server, parent, refReg);
+            Class<? extends Server> subtype = getSubtypeOf(server);
+            IJsonOverlay<?> overlay;
+            if (subtype == null || subtype == Server.class) {
+                overlay = new ServerImpl(server, parent, refReg);
+            } else {
+                switch(subtype.getSimpleName()) {
+                    default:
+                        overlay = null;
+                }
+            }
             @SuppressWarnings("unchecked") JsonOverlay<Server> castOverlay = (JsonOverlay<Server>) overlay;
             return castOverlay;
         }
 
         @Override
         public JsonOverlay<Server> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            JsonOverlay<?> overlay = new ServerImpl(json, parent, refReg);
+            Class<? extends Server> subtype = getSubtypeOf(json);
+            IJsonOverlay<?> overlay;
+            if (subtype == null || subtype == Server.class) {
+                overlay = new ServerImpl(json, parent, refReg);
+            } else {
+                switch(subtype.getSimpleName()) {
+                    default:
+                        overlay = null;
+                }
+            }
             @SuppressWarnings("unchecked") JsonOverlay<Server> castOverlay = (JsonOverlay<Server>) overlay;
             return castOverlay;
         }
     };
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private static Class<? extends Server> getSubtypeOf(Server server) {
+        return Server.class;
+    }
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private static Class<? extends Server> getSubtypeOf(JsonNode json) {
+        return Server.class;
+    }
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ServerVariableImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ServerVariableImpl.java
@@ -8,11 +8,13 @@ import com.reprezen.kaizen.oasparser.jsonoverlay.ReferenceRegistry;
 import com.reprezen.kaizen.oasparser.jsonoverlay.PrimitiveOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ListOverlay;
 import java.util.Collection;
-import com.reprezen.kaizen.oasparser.model3.ServerVariable;
+import java.util.stream.Collectors;
+import com.reprezen.kaizen.oasparser.model3.*;
 import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ChildOverlay;
 import javax.annotation.Generated;
 import com.reprezen.kaizen.oasparser.jsonoverlay.PropertiesOverlay;
+import com.fasterxml.jackson.core.JsonPointer;
 import java.util.Map;
 import com.reprezen.kaizen.oasparser.jsonoverlay.OverlayFactory;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -200,16 +202,44 @@ public class ServerVariableImpl extends PropertiesOverlay<ServerVariable> implem
 
         @Override
         public JsonOverlay<ServerVariable> _create(ServerVariable serverVariable, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            JsonOverlay<?> overlay = new ServerVariableImpl(serverVariable, parent, refReg);
+            Class<? extends ServerVariable> subtype = getSubtypeOf(serverVariable);
+            IJsonOverlay<?> overlay;
+            if (subtype == null || subtype == ServerVariable.class) {
+                overlay = new ServerVariableImpl(serverVariable, parent, refReg);
+            } else {
+                switch(subtype.getSimpleName()) {
+                    default:
+                        overlay = null;
+                }
+            }
             @SuppressWarnings("unchecked") JsonOverlay<ServerVariable> castOverlay = (JsonOverlay<ServerVariable>) overlay;
             return castOverlay;
         }
 
         @Override
         public JsonOverlay<ServerVariable> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            JsonOverlay<?> overlay = new ServerVariableImpl(json, parent, refReg);
+            Class<? extends ServerVariable> subtype = getSubtypeOf(json);
+            IJsonOverlay<?> overlay;
+            if (subtype == null || subtype == ServerVariable.class) {
+                overlay = new ServerVariableImpl(json, parent, refReg);
+            } else {
+                switch(subtype.getSimpleName()) {
+                    default:
+                        overlay = null;
+                }
+            }
             @SuppressWarnings("unchecked") JsonOverlay<ServerVariable> castOverlay = (JsonOverlay<ServerVariable>) overlay;
             return castOverlay;
         }
     };
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private static Class<? extends ServerVariable> getSubtypeOf(ServerVariable serverVariable) {
+        return ServerVariable.class;
+    }
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private static Class<? extends ServerVariable> getSubtypeOf(JsonNode json) {
+        return ServerVariable.class;
+    }
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/TagImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/TagImpl.java
@@ -7,12 +7,14 @@ import com.reprezen.kaizen.oasparser.jsonoverlay.ChildListOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ReferenceRegistry;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ListOverlay;
 import java.util.Collection;
+import java.util.stream.Collectors;
+import com.reprezen.kaizen.oasparser.model3.*;
 import com.reprezen.kaizen.oasparser.ovl3.ExternalDocsImpl;
 import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ChildOverlay;
 import javax.annotation.Generated;
 import com.reprezen.kaizen.oasparser.jsonoverlay.PropertiesOverlay;
-import com.reprezen.kaizen.oasparser.model3.Tag;
+import com.fasterxml.jackson.core.JsonPointer;
 import java.util.Map;
 import com.reprezen.kaizen.oasparser.jsonoverlay.OverlayFactory;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -165,16 +167,44 @@ public class TagImpl extends PropertiesOverlay<Tag> implements Tag {
 
         @Override
         public JsonOverlay<Tag> _create(Tag tag, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            JsonOverlay<?> overlay = new TagImpl(tag, parent, refReg);
+            Class<? extends Tag> subtype = getSubtypeOf(tag);
+            IJsonOverlay<?> overlay;
+            if (subtype == null || subtype == Tag.class) {
+                overlay = new TagImpl(tag, parent, refReg);
+            } else {
+                switch(subtype.getSimpleName()) {
+                    default:
+                        overlay = null;
+                }
+            }
             @SuppressWarnings("unchecked") JsonOverlay<Tag> castOverlay = (JsonOverlay<Tag>) overlay;
             return castOverlay;
         }
 
         @Override
         public JsonOverlay<Tag> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            JsonOverlay<?> overlay = new TagImpl(json, parent, refReg);
+            Class<? extends Tag> subtype = getSubtypeOf(json);
+            IJsonOverlay<?> overlay;
+            if (subtype == null || subtype == Tag.class) {
+                overlay = new TagImpl(json, parent, refReg);
+            } else {
+                switch(subtype.getSimpleName()) {
+                    default:
+                        overlay = null;
+                }
+            }
             @SuppressWarnings("unchecked") JsonOverlay<Tag> castOverlay = (JsonOverlay<Tag>) overlay;
             return castOverlay;
         }
     };
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private static Class<? extends Tag> getSubtypeOf(Tag tag) {
+        return Tag.class;
+    }
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private static Class<? extends Tag> getSubtypeOf(JsonNode json) {
+        return Tag.class;
+    }
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/XmlImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/XmlImpl.java
@@ -7,12 +7,14 @@ import com.reprezen.kaizen.oasparser.jsonoverlay.ChildListOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ReferenceRegistry;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ListOverlay;
 import java.util.Collection;
+import java.util.stream.Collectors;
+import com.reprezen.kaizen.oasparser.model3.*;
 import com.reprezen.kaizen.oasparser.jsonoverlay.BooleanOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ChildOverlay;
-import com.reprezen.kaizen.oasparser.model3.Xml;
 import javax.annotation.Generated;
 import com.reprezen.kaizen.oasparser.jsonoverlay.PropertiesOverlay;
+import com.fasterxml.jackson.core.JsonPointer;
 import java.util.Map;
 import com.reprezen.kaizen.oasparser.jsonoverlay.OverlayFactory;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -222,16 +224,44 @@ public class XmlImpl extends PropertiesOverlay<Xml> implements Xml {
 
         @Override
         public JsonOverlay<Xml> _create(Xml xml, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            JsonOverlay<?> overlay = new XmlImpl(xml, parent, refReg);
+            Class<? extends Xml> subtype = getSubtypeOf(xml);
+            IJsonOverlay<?> overlay;
+            if (subtype == null || subtype == Xml.class) {
+                overlay = new XmlImpl(xml, parent, refReg);
+            } else {
+                switch(subtype.getSimpleName()) {
+                    default:
+                        overlay = null;
+                }
+            }
             @SuppressWarnings("unchecked") JsonOverlay<Xml> castOverlay = (JsonOverlay<Xml>) overlay;
             return castOverlay;
         }
 
         @Override
         public JsonOverlay<Xml> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            JsonOverlay<?> overlay = new XmlImpl(json, parent, refReg);
+            Class<? extends Xml> subtype = getSubtypeOf(json);
+            IJsonOverlay<?> overlay;
+            if (subtype == null || subtype == Xml.class) {
+                overlay = new XmlImpl(json, parent, refReg);
+            } else {
+                switch(subtype.getSimpleName()) {
+                    default:
+                        overlay = null;
+                }
+            }
             @SuppressWarnings("unchecked") JsonOverlay<Xml> castOverlay = (JsonOverlay<Xml>) overlay;
             return castOverlay;
         }
     };
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private static Class<? extends Xml> getSubtypeOf(Xml xml) {
+        return Xml.class;
+    }
+
+    @Generated("com.reprezen.kaizen.oasparser.jsonoverlay.gen.CodeGenerator")
+    private static Class<? extends Xml> getSubtypeOf(JsonNode json) {
+        return Xml.class;
+    }
 }


### PR DESCRIPTION
Generated factories are now subtype-aware. If type A extends type B,
then B's factory will determine the intended actual type to be created,
and, if that's not B, delegate to the intended type's factory.

Subtypes are determined by examining `extensionOf` properties in type
data.

When JSON is being parsed to create the object, the JSON structure must
include a "discriminator" that identifies the intended type. This is
managed via new `discriminator` and `discriminatorValue` properties in
type specifications. The `discriminator` should be a path from the JSON
from which the (supertype) is being instantiated (without initial
slash). The discriminator can be declared at top-level in type data, and
that will be the default for all types. The discriminator must provide a
string value from the JSON structure.

The `discriminatorValue` property in a (sub-)type is the value of the
discriminator obtained by the supertype factory, that will identify this
subtype as the intended type. Discriminator value defaults to the type's
name.