### PR TITLE
Taks/115 Preserve key order in map overlays

### DIFF
--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/ChildOverlay.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/ChildOverlay.java
@@ -19,160 +19,160 @@ import com.reprezen.kaizen.oasparser.jsonoverlay.SerializationOptions.Option;
 
 public class ChildOverlay<V> implements IJsonOverlay<V> {
 
-    private JsonPath path;
-    protected JsonOverlay<V> overlay;
-    private JsonOverlay<?> parent;
-    private Reference reference = null;
-    protected OverlayFactory<V> factory;
+	private JsonPath path;
+	protected JsonOverlay<V> overlay;
+	private JsonOverlay<?> parent;
+	private Reference reference = null;
+	protected OverlayFactory<V> factory;
 
-    public ChildOverlay(String path, V value, JsonOverlay<?> parent, OverlayFactory<V> factory,
-            ReferenceRegistry refReg) {
-        this.path = new JsonPath(path);
-        this.parent = parent;
-        this.factory = factory;
-        this.overlay = factory.create(value, parent, refReg, null);
-    }
+	public ChildOverlay(String path, V value, JsonOverlay<?> parent, OverlayFactory<V> factory,
+			ReferenceRegistry refReg) {
+		this.path = new JsonPath(path);
+		this.parent = parent;
+		this.factory = factory;
+		this.overlay = factory.create(value, parent, refReg, null);
+	}
 
-    public ChildOverlay(String path, JsonNode json, JsonOverlay<?> parent, OverlayFactory<V> factory,
-            ReferenceRegistry refReg) {
-        this.path = new JsonPath(path);
-        this.parent = parent;
-        this.factory = factory;
-        if (isReferenceNode(json)) {
-            this.reference = refReg.getRef(json);
-            JsonNode resolved = reference.resolve();
-            if (reference.isValid()) {
-                if (refReg.hasOverlay(resolved)) {
-                    IJsonOverlay<?> overlay = refReg.getOverlay(resolved);
-                    if (factory.isCompatible(overlay)) {
-                        @SuppressWarnings("unchecked")
-                        JsonOverlay<V> castOverlay = (JsonOverlay<V>) overlay;
-                        this.overlay = castOverlay;
-                    } else {
-                        // TODO don't make this a parse killer - it's really a model error
-                        throw new IllegalStateException("Referenced object is not compatible with referencing site");
-                    }
-                } else {
-                    // note - since this is a reference, we don't set parent. If there's a way to
-                    // navigate to the object directly, that will determine its parent
-                    this.overlay = (JsonOverlay<V>) factory.create(resolved, null, refReg, reference);
-                    refReg.setOverlay(resolved, overlay);
-                }
-            } else {
-                this.overlay = null;
-            }
-        } else {
-            this.overlay = (JsonOverlay<V>) factory.create(json, parent, isPartial(), refReg);
-        }
-    }
+	public ChildOverlay(String path, JsonNode json, JsonOverlay<?> parent, OverlayFactory<V> factory,
+			ReferenceRegistry refReg) {
+		this.path = new JsonPath(path);
+		this.parent = parent;
+		this.factory = factory;
+		if (isReferenceNode(json)) {
+			this.reference = refReg.getRef(json);
+			JsonNode resolved = reference.resolve();
+			if (reference.isValid()) {
+				if (refReg.hasOverlay(resolved)) {
+					IJsonOverlay<?> overlay = refReg.getOverlay(resolved);
+					if (factory.isCompatible(overlay)) {
+						@SuppressWarnings("unchecked")
+						JsonOverlay<V> castOverlay = (JsonOverlay<V>) overlay;
+						this.overlay = castOverlay;
+					} else {
+						// TODO don't make this a parse killer - it's really a model error
+						throw new IllegalStateException("Referenced object is not compatible with referencing site");
+					}
+				} else {
+					// note - since this is a reference, we don't set parent. If there's a way to
+					// navigate to the object directly, that will determine its parent
+					this.overlay = (JsonOverlay<V>) factory.create(resolved, null, refReg, reference);
+					refReg.setOverlay(resolved, overlay);
+				}
+			} else {
+				this.overlay = null;
+			}
+		} else {
+			this.overlay = (JsonOverlay<V>) factory.create(json, parent, isPartial(), refReg);
+		}
+	}
 
-    protected boolean isPartial() {
-        return false;
-    }
+	protected boolean isPartial() {
+		return false;
+	}
 
-    protected boolean matchesPath(JsonPointer path) {
-        return this.path.matchesPath(path);
-    }
+	protected boolean matchesPath(JsonPointer path) {
+		return this.path.matchesPath(path);
+	}
 
-    protected JsonPointer tailPath(JsonPointer path) {
-        return this.path.tailPath(path);
-    }
+	protected JsonPointer tailPath(JsonPointer path) {
+		return this.path.tailPath(path);
+	}
 
-    private boolean isReferenceNode(JsonNode node) {
-        return node.isObject() && node.has("$ref");
-    }
+	private boolean isReferenceNode(JsonNode node) {
+		return node.isObject() && node.has("$ref");
+	}
 
-    public boolean isPresent() {
-        return overlay.isPresent();
-    }
+	public boolean isPresent() {
+		return overlay.isPresent();
+	}
 
-    public V get() {
-        return overlay.get();
-    }
+	public V get() {
+		return overlay.get();
+	}
 
-    public V get(boolean complete) {
-        return overlay.get(complete);
-    }
+	public V get(boolean complete) {
+		return overlay.get(complete);
+	}
 
-    public IJsonOverlay<?> find(JsonPointer path) {
-        return overlay.find(path);
-    }
+	public IJsonOverlay<?> find(JsonPointer path) {
+		return overlay.find(path);
+	}
 
-    public IJsonOverlay<?> find(String path) {
-        return overlay.find(path);
-    }
+	public IJsonOverlay<?> find(String path) {
+		return overlay.find(path);
+	}
 
-    public void set(V value) {
-        overlay.set(value);
-    }
+	public void set(V value) {
+		overlay.set(value);
+	}
 
-    public IJsonOverlay<?> getParent() {
-        // Note: here we return the creator of the childnode, which for a reference is
-        // the holder of the reference. This may not be the same as the parent of the
-        // referenced object, which is available via getOverlay().getParent().
-        return parent;
-    }
+	public IJsonOverlay<?> getParent() {
+		// Note: here we return the creator of the childnode, which for a reference is
+		// the holder of the reference. This may not be the same as the parent of the
+		// referenced object, which is available via getOverlay().getParent().
+		return parent;
+	}
 
-    public String getPathInParent() {
-        return overlay.getPathInParent();
-    }
+	public String getPathInParent() {
+		return overlay.getPathInParent();
+	}
 
-    public IJsonOverlay<?> getRoot() {
-        return parent != null ? parent.getParent() : overlay.getRoot();
-    }
+	public IJsonOverlay<?> getRoot() {
+		return parent != null ? parent.getParent() : overlay.getRoot();
+	}
 
-    private static final SerializationOptions emptyOptions = new SerializationOptions();
+	private static final SerializationOptions emptyOptions = new SerializationOptions();
 
-    public JsonNode toJson() {
-        return toJson(emptyOptions);
-    }
+	public JsonNode toJson() {
+		return toJson(emptyOptions);
+	}
 
-    public JsonNode toJson(Option... options) {
-        return toJson(new SerializationOptions(options));
-    }
+	public JsonNode toJson(Option... options) {
+		return toJson(new SerializationOptions(options));
+	}
 
-    public JsonNode toJson(SerializationOptions options) {
-        if (isReference() && (!options.isFollowRefs() || getReference().isInvalid())) {
-            ObjectNode obj = JsonOverlay.jsonObject();
-            obj.put("$ref", reference.getRefString());
-            return obj;
-        } else {
-            return overlay.toJson(options);
-        }
-    }
+	public JsonNode toJson(SerializationOptions options) {
+		if (isReference() && (!options.isFollowRefs() || getReference().isInvalid())) {
+			ObjectNode obj = JsonOverlay.jsonObject();
+			obj.put("$ref", reference.getRefString());
+			return obj;
+		} else {
+			return overlay != null ? overlay.toJson(options) : JsonOverlay.jsonNull();
+		}
+	}
 
-    @Override
-    public boolean isElaborated() {
-        return overlay.isElaborated();
-    }
+	@Override
+	public boolean isElaborated() {
+		return overlay.isElaborated();
+	}
 
-    public JsonPath getPath() {
-        return path;
-    }
+	public JsonPath getPath() {
+		return path;
+	}
 
-    public boolean isReference() {
-        return reference != null;
-    }
+	public boolean isReference() {
+		return reference != null;
+	}
 
-    public Reference getReference() {
-        return reference;
-    }
+	public Reference getReference() {
+		return reference;
+	}
 
-    public JsonOverlay<V> getOverlay() {
-        return overlay;
-    }
+	public JsonOverlay<V> getOverlay() {
+		return overlay;
+	}
 
-    public String getPathFromRoot() {
-        return overlay.getPathFromRoot();
-    }
+	public String getPathFromRoot() {
+		return overlay.getPathFromRoot();
+	}
 
-    public URL getJsonReference() {
-        return overlay.getJsonReference();
-    }
+	public URL getJsonReference() {
+		return overlay.getJsonReference();
+	}
 
-    @Override
-    public String toString() {
-        String refString = reference != null ? String.format("<%s>", reference.getRefString()) : "";
-        return String.format("Child@%s%s: %s", path, refString, overlay);
-    }
+	@Override
+	public String toString() {
+		String refString = reference != null ? String.format("<%s>", reference.getRefString()) : "";
+		return String.format("Child@%s%s: %s", path, refString, overlay);
+	}
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/JsonOverlay.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/JsonOverlay.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.MissingNode;
+import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 import com.fasterxml.jackson.databind.node.ValueNode;
@@ -203,6 +204,10 @@ public abstract class JsonOverlay<V> implements IJsonOverlay<V> {
 
 	protected static MissingNode jsonMissing() {
 		return MissingNode.getInstance();
+	}
+
+	protected static NullNode jsonNull() {
+		return JsonNodeFactory.instance.nullNode();
 	}
 
 	protected static final <T> Iterable<T> iterable(final Iterator<T> iterator) {

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/MapOverlay.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/MapOverlay.java
@@ -78,7 +78,7 @@ public class MapOverlay<V> extends JsonOverlay<Map<String, V>> {
 
     @Override
     protected Map<String, V> fromJson(JsonNode json) {
-        return Maps.newHashMap();
+        return Maps.newLinkedHashMap();
     }
 
     @Override

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/ReferenceRegistry.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/ReferenceRegistry.java
@@ -90,7 +90,7 @@ public class ReferenceRegistry {
 	}
 
 	public void setOverlay(JsonNode node, IJsonOverlay<?> overlay) {
-		if (!node.isMissingNode()) {
+		if (!node.isMissingNode() && overlay != null) {
 			overlays.put(node, overlay);
 		}
 	}


### PR DESCRIPTION
Also fixed an issue with null overlay values produced by supertypes when discriminator is unavailable (e.g. when the property is missing in the parent).