### PR TITLE
[#128] Added simple enum support

### DIFF
--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/EnumOverlay.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/EnumOverlay.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ *  Copyright (c) 2017 ModelSolv, Inc. and others.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *
+ *  Contributors:
+ *     ModelSolv, Inc. - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package com.reprezen.kaizen.oasparser.jsonoverlay;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+public abstract class EnumOverlay<V extends Enum<V>> extends ScalarOverlay<V> {
+
+	private Class<V> enumClass = null;
+
+	public EnumOverlay(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+		super(json, parent, refReg);
+	}
+
+	public EnumOverlay(V value, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+		super(value, parent, refReg);
+		this.enumClass = getEnumClass();
+	}
+
+	@Override
+	protected V fromJson(JsonNode json) {
+		if (!json.isTextual()) {
+			return null;
+		}
+		if (enumClass == null) {
+			enumClass = getEnumClass();
+		}
+		try {
+			return Enum.valueOf(enumClass, json.asText());
+		} catch (IllegalArgumentException e) {
+			return null;
+		}
+	}
+
+	@Override
+	public JsonNode toJson(SerializationOptions options) {
+		return value != null ? jsonScalar(value.name()) : jsonMissing();
+	}
+
+	protected abstract Class<V> getEnumClass();
+}

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/gen/SimpleJavaGenerator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/gen/SimpleJavaGenerator.java
@@ -23,10 +23,10 @@ import com.github.javaparser.JavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.NodeList;
 import com.github.javaparser.ast.body.BodyDeclaration;
-import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.ConstructorDeclaration;
 import com.github.javaparser.ast.body.FieldDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.body.TypeDeclaration;
 import com.github.javaparser.ast.body.VariableDeclarator;
 import com.github.javaparser.ast.comments.JavadocComment;
 import com.github.javaparser.ast.expr.Expression;
@@ -38,12 +38,12 @@ public class SimpleJavaGenerator {
 
 	private String pkg;
 	private Set<String> imports = Sets.newHashSet();
-	private ClassOrInterfaceDeclaration type;
+	private TypeDeclaration<?> type;
 	private List<Member> members = Lists.newArrayList();
 	private String fileComment;
 	private static int indentation = 4;
 
-	public SimpleJavaGenerator(String pkg, ClassOrInterfaceDeclaration type) {
+	public SimpleJavaGenerator(String pkg, TypeDeclaration<?> type) {
 		this.pkg = pkg;
 		this.type = type;
 	}
@@ -142,7 +142,7 @@ public class SimpleJavaGenerator {
 		}
 
 		public Member(String code) {
-			 this(JavaParser.parseBodyDeclaration(code));
+			this(JavaParser.parseBodyDeclaration(code));
 		}
 
 		public Member generated() {
@@ -209,6 +209,14 @@ public class SimpleJavaGenerator {
 		}
 
 		public String getName() {
+			if (declaration instanceof MethodDeclaration) {
+				return ((MethodDeclaration) declaration).getNameAsString();
+			} else if (declaration instanceof FieldDeclaration) {
+				NodeList<VariableDeclarator> vars = ((FieldDeclaration) declaration).getVariables();
+				if (vars.size() == 1) {
+					return vars.get(0).getNameAsString();
+				}
+			}
 			return null;
 		}
 	}

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/gen/TypeData.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/gen/TypeData.java
@@ -93,6 +93,7 @@ public class TypeData {
 		private boolean abstractType = false;
 		private String discriminator = null;
 		private String discriminatorValue = null;
+		private List<String> enumValues = Lists.newArrayList();
 
 		private TypeData typeData;
 
@@ -107,20 +108,16 @@ public class TypeData {
 			return typeData;
 		}
 
-		public Collection<String> getRequiredImports(String moduleType) {
+		public Collection<String> getRequiredImports(String... moduleTypes) {
 			Set<String> results = Sets.newLinkedHashSet();
 			Collection<String> interfaces = extendInterfaces != null ? extendInterfaces
 					: typeData.defaultExtendInterfaces;
 			if (interfaces != null) {
-				for (String intf : interfaces) {
-					if (typeData.imports.containsKey(intf)) {
-						results.add(typeData.imports.get(intf));
-					}
-				}
+				results.addAll(interfaces);
 			}
-			if (imports.get(moduleType) != null) {
-				for (String imp : imports.get(moduleType)) {
-					results.add(imp);
+			for (String moduleType : moduleTypes) {
+				if (imports.get(moduleType) != null) {
+					results.addAll(imports.get(moduleType));
 				}
 			}
 			return results;
@@ -178,6 +175,10 @@ public class TypeData {
 
 		public String getDiscriminatorValue() {
 			return discriminatorValue != null ? discriminatorValue : name;
+		}
+
+		public List<String> getEnumValues() {
+			return enumValues;
 		}
 
 		public String getImplType() {

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/gen/TypeGenerator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/jsonoverlay/gen/TypeGenerator.java
@@ -33,7 +33,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.github.javaparser.JavaParser;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.body.BodyDeclaration;
-import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.ConstructorDeclaration;
 import com.github.javaparser.ast.body.FieldDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
@@ -51,6 +50,7 @@ import com.reprezen.kaizen.oasparser.jsonoverlay.BooleanOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ChildListOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ChildMapOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.ChildOverlay;
+import com.reprezen.kaizen.oasparser.jsonoverlay.EnumOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.IJsonOverlay;
 import com.reprezen.kaizen.oasparser.jsonoverlay.IModelPart;
 import com.reprezen.kaizen.oasparser.jsonoverlay.IPropertiesOverlay;
@@ -88,13 +88,13 @@ public abstract class TypeGenerator {
 		this.preserve = preserve;
 	}
 
-	protected abstract ClassOrInterfaceDeclaration getTypeDeclaration(Type type, String suffix);
+	protected abstract TypeDeclaration<?> getTypeDeclaration(Type type, String suffix);
 
 	public void generate(Type type) throws IOException {
 		File javaFile = new File(dir, t("${name}${0}.java", type, suffix));
 		System.out.println("Generating " + javaFile.getCanonicalFile());
 		CompilationUnit existing = preserve && javaFile.exists() ? tryParse(javaFile) : null;
-		ClassOrInterfaceDeclaration declaration = getTypeDeclaration(type, suffix);
+		TypeDeclaration<?> declaration = getTypeDeclaration(type, suffix);
 		SimpleJavaGenerator gen = new SimpleJavaGenerator(getPackage(), declaration);
 		if (existing != null) {
 			copyFileComment(gen, existing);
@@ -204,6 +204,7 @@ public abstract class TypeGenerator {
 				IntegerOverlay.class, //
 				NumberOverlay.class, //
 				BooleanOverlay.class, //
+				EnumOverlay.class, //
 				PrimitiveOverlay.class, //
 				ObjectOverlay.class, //
 				ListOverlay.class, //
@@ -342,7 +343,7 @@ public abstract class TypeGenerator {
 	protected static class Members extends ArrayList<Member> {
 
 		private static final long serialVersionUID = 1L;
- 
+
 		public Member addMember(String code) {
 			return addMember(new Member(code));
 		}

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/OpenApi3Impl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/OpenApi3Impl.java
@@ -36,6 +36,7 @@ import com.reprezen.kaizen.oasparser.ovl3.ParameterImpl;
 import com.reprezen.kaizen.oasparser.ovl3.PathImpl;
 import com.reprezen.kaizen.oasparser.model3.Link;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.reprezen.kaizen.oasparser.OpenApi;
 import com.reprezen.kaizen.oasparser.jsonoverlay.MapOverlay;
 import com.reprezen.kaizen.oasparser.model3.Callback;
 import com.reprezen.kaizen.oasparser.val.Validator;


### PR DESCRIPTION
A type configured with an `enumValues` property (a list of enum constant
names) is generated as follows:

* In the `models` directory, an enum class named for the type and with
  the given member constants
* In the `impl` directory, an impl class that extends `EnumOverlay<E>`,
  where `E` is the generated enum type.

All other properties of such a type in the type config are ignored. It's
probably possible to add manual members to the enum class that will be
preserved during regen, but adding constructor args is not currently
supported, so there's probably not much of use that can be gained.