### PR TITLE
 disable custom classloader of guice

### DIFF
--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/OpenApiParser.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/OpenApiParser.java
@@ -39,6 +39,7 @@ public class OpenApiParser {
 	}
 
 	public OpenApiParser(ValidationConfigurator validationConfigurator) {
+	    System.setProperty("guice_custom_class_loading", "OFF");
 		this.injector = Guice.createInjector(validationConfigurator);
 	}
 


### PR DESCRIPTION
It seems, that disabling the custom classloader of guice resolves some of the performance issues reported in #66.
You may want to check, whether you need this custom class loader for anything you intended to use. Otherwise, it might be a good option to skip it for DI initialization.