### PR TITLE
[#151] Move to new version of JsonOverlay

### DIFF
--- a/kaizen-openapi-parser/pom.xml
+++ b/kaizen-openapi-parser/pom.xml
@@ -45,11 +45,6 @@
     </scm>
     <dependencies>
         <dependency>
-            <groupId>com.reprezen.jsonoverlay</groupId>
-            <artifactId>jsonoverlay</artifactId>
-            <version>${json-overlay-version}</version>
-        </dependency>
-        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.12</version>
@@ -99,6 +94,11 @@
             <artifactId>jsonassert</artifactId>
             <version>1.5.0</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.reprezen.jsonoverlay</groupId>
+            <artifactId>jsonoverlay</artifactId>
+            <version>${json-overlay-version}</version>
         </dependency>
     </dependencies>
     <profiles>
@@ -249,8 +249,8 @@
         </plugins>
     </build>
     <properties>
-        <openapi-parser-version>0.0.3-SNAPSHOT</openapi-parser-version>
-        <json-overlay-version>0.0.1.201803210221</json-overlay-version>
+        <openapi-parser-version>1.0.0-SNAPSHOT</openapi-parser-version>
+        <json-overlay-version>[1.0,2.0)</json-overlay-version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/OpenApiParser.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/OpenApiParser.java
@@ -98,12 +98,12 @@ public class OpenApiParser {
 			Reference topRef = referenceRegistry.getRef(resolutionBase.toString(), base, true);
 			JsonNode tree = topRef.getJson();
 			if (isVersion3(tree)) {
-				OpenApi3 model = OpenApi3Impl.factory.create(tree, null, referenceRegistry, topRef).get();
-				injector.injectMembers(model.get());
+				OpenApi3 model = (OpenApi3) OpenApi3Impl.factory.create(tree, null, referenceRegistry, topRef);
+				injector.injectMembers(model);
 				if (validate) {
-					model.get().validate();
+					model.validate();
 				}
-				return model.get();
+				return model;
 			} else {
 				throw new SwaggerParserException(
 						"Could not determine OpenApi version - missing or invalid 'openapi' or 'swagger' property");

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Callback.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Callback.java
@@ -1,54 +1,55 @@
 package com.reprezen.kaizen.oasparser.model3;
 
-import com.reprezen.jsonoverlay.IPropertiesOverlay;
-import com.reprezen.jsonoverlay.IModelPart;
-import javax.annotation.Generated;
-import com.reprezen.kaizen.oasparser.model3.Path;
 import java.util.Map;
 
-public interface Callback extends IPropertiesOverlay<Callback>, IModelPart<OpenApi3, Callback> {
+import javax.annotation.Generated;
 
-    // CallbackPath
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Path> getCallbackPaths();
+import com.reprezen.jsonoverlay.IJsonOverlay;
+import com.reprezen.jsonoverlay.IModelPart;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Path> getCallbackPaths(boolean elaborate);
+public interface Callback extends IJsonOverlay<Callback>, IModelPart<OpenApi3, Callback> {
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasCallbackPath(String expression);
+	// CallbackPath
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Path> getCallbackPaths();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Path getCallbackPath(String expression);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Path> getCallbackPaths(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setCallbackPaths(Map<String, Path> callbackPaths);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasCallbackPath(String expression);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setCallbackPath(String expression, Path callbackPath);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Path getCallbackPath(String expression);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeCallbackPath(String expression);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setCallbackPaths(Map<String, Path> callbackPaths);
 
-    // Extension
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Object> getExtensions();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setCallbackPath(String expression, Path callbackPath);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Object> getExtensions(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeCallbackPath(String expression);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasExtension(String name);
+	// Extension
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Object> getExtensions();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Object getExtension(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Object> getExtensions(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setExtensions(Map<String, Object> extensions);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasExtension(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setExtension(String name, Object extension);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Object getExtension(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeExtension(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setExtensions(Map<String, Object> extensions);
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setExtension(String name, Object extension);
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeExtension(String name);
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Contact.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Contact.java
@@ -1,61 +1,63 @@
 package com.reprezen.kaizen.oasparser.model3;
 
-import com.reprezen.jsonoverlay.IPropertiesOverlay;
-import com.reprezen.jsonoverlay.IModelPart;
-import javax.annotation.Generated;
 import java.util.Map;
 
-public interface Contact extends IPropertiesOverlay<Contact>, IModelPart<OpenApi3, Contact> {
+import javax.annotation.Generated;
 
-    // Name
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getName();
+import com.reprezen.jsonoverlay.IJsonOverlay;
+import com.reprezen.jsonoverlay.IModelPart;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getName(boolean elaborate);
+public interface Contact extends IJsonOverlay<Contact>, IModelPart<OpenApi3, Contact> {
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setName(String name);
+	// Name
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getName();
 
-    // Url
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getUrl();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getName(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getUrl(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setName(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setUrl(String url);
+	// Url
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getUrl();
 
-    // Email
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getEmail();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getUrl(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getEmail(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setUrl(String url);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setEmail(String email);
+	// Email
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getEmail();
 
-    // Extension
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Object> getExtensions();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getEmail(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Object> getExtensions(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setEmail(String email);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasExtension(String name);
+	// Extension
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Object> getExtensions();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Object getExtension(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Object> getExtensions(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setExtensions(Map<String, Object> extensions);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasExtension(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setExtension(String name, Object extension);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Object getExtension(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeExtension(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setExtensions(Map<String, Object> extensions);
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setExtension(String name, Object extension);
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeExtension(String name);
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/EncodingProperty.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/EncodingProperty.java
@@ -1,93 +1,88 @@
 package com.reprezen.kaizen.oasparser.model3;
 
-import com.reprezen.jsonoverlay.IPropertiesOverlay;
-import com.reprezen.jsonoverlay.IModelPart;
-import javax.annotation.Generated;
 import java.util.Map;
-import com.reprezen.jsonoverlay.Reference;
 
-public interface EncodingProperty extends IPropertiesOverlay<EncodingProperty>, IModelPart<OpenApi3, EncodingProperty> {
+import javax.annotation.Generated;
 
-    // ContentType
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getContentType();
+import com.reprezen.jsonoverlay.IJsonOverlay;
+import com.reprezen.jsonoverlay.IModelPart;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getContentType(boolean elaborate);
+public interface EncodingProperty extends IJsonOverlay<EncodingProperty>, IModelPart<OpenApi3, EncodingProperty> {
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setContentType(String contentType);
+	// ContentType
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getContentType();
 
-    // Header
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, String> getHeaders();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getContentType(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, String> getHeaders(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setContentType(String contentType);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasHeader(String name);
+	// Header
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, String> getHeaders();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getHeader(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, String> getHeaders(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setHeaders(Map<String, String> headers);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasHeader(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setHeader(String name, String header);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getHeader(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeHeader(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setHeaders(Map<String, String> headers);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean isHeaderReference(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setHeader(String name, String header);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Reference getHeaderReference(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeHeader(String name);
 
-    // Style
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getStyle();
+	// Style
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getStyle();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getStyle(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getStyle(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setStyle(String style);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setStyle(String style);
 
-    // Explode
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Boolean getExplode();
+	// Explode
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Boolean getExplode();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Boolean getExplode(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Boolean getExplode(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean isExplode();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean isExplode();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setExplode(Boolean explode);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setExplode(Boolean explode);
 
-    // Extension
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Object> getExtensions();
+	// Extension
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Object> getExtensions();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Object> getExtensions(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Object> getExtensions(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasExtension(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasExtension(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Object getExtension(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Object getExtension(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setExtensions(Map<String, Object> extensions);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setExtensions(Map<String, Object> extensions);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setExtension(String name, Object extension);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setExtension(String name, Object extension);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeExtension(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeExtension(String name);
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Example.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Example.java
@@ -1,71 +1,73 @@
 package com.reprezen.kaizen.oasparser.model3;
 
-import com.reprezen.jsonoverlay.IPropertiesOverlay;
-import com.reprezen.jsonoverlay.IModelPart;
-import javax.annotation.Generated;
 import java.util.Map;
 
-public interface Example extends IPropertiesOverlay<Example>, IModelPart<OpenApi3, Example> {
+import javax.annotation.Generated;
 
-    // Summary
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getSummary();
+import com.reprezen.jsonoverlay.IJsonOverlay;
+import com.reprezen.jsonoverlay.IModelPart;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getSummary(boolean elaborate);
+public interface Example extends IJsonOverlay<Example>, IModelPart<OpenApi3, Example> {
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setSummary(String summary);
+	// Summary
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getSummary();
 
-    // Description
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getDescription();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getSummary(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getDescription(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setSummary(String summary);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setDescription(String description);
+	// Description
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getDescription();
 
-    // Value
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Object getValue();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getDescription(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Object getValue(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setDescription(String description);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setValue(Object value);
+	// Value
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Object getValue();
 
-    // ExternalValue
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getExternalValue();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Object getValue(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getExternalValue(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setValue(Object value);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setExternalValue(String externalValue);
+	// ExternalValue
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getExternalValue();
 
-    // Extension
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Object> getExtensions();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getExternalValue(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Object> getExtensions(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setExternalValue(String externalValue);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasExtension(String name);
+	// Extension
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Object> getExtensions();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Object getExtension(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Object> getExtensions(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setExtensions(Map<String, Object> extensions);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasExtension(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setExtension(String name, Object extension);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Object getExtension(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeExtension(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setExtensions(Map<String, Object> extensions);
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setExtension(String name, Object extension);
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeExtension(String name);
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/ExternalDocs.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/ExternalDocs.java
@@ -1,51 +1,53 @@
 package com.reprezen.kaizen.oasparser.model3;
 
-import com.reprezen.jsonoverlay.IPropertiesOverlay;
-import com.reprezen.jsonoverlay.IModelPart;
-import javax.annotation.Generated;
 import java.util.Map;
 
-public interface ExternalDocs extends IPropertiesOverlay<ExternalDocs>, IModelPart<OpenApi3, ExternalDocs> {
+import javax.annotation.Generated;
 
-    // Description
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getDescription();
+import com.reprezen.jsonoverlay.IJsonOverlay;
+import com.reprezen.jsonoverlay.IModelPart;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getDescription(boolean elaborate);
+public interface ExternalDocs extends IJsonOverlay<ExternalDocs>, IModelPart<OpenApi3, ExternalDocs> {
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setDescription(String description);
+	// Description
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getDescription();
 
-    // Url
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getUrl();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getDescription(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getUrl(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setDescription(String description);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setUrl(String url);
+	// Url
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getUrl();
 
-    // Extension
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Object> getExtensions();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getUrl(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Object> getExtensions(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setUrl(String url);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasExtension(String name);
+	// Extension
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Object> getExtensions();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Object getExtension(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Object> getExtensions(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setExtensions(Map<String, Object> extensions);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasExtension(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setExtension(String name, Object extension);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Object getExtension(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeExtension(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setExtensions(Map<String, Object> extensions);
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setExtension(String name, Object extension);
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeExtension(String name);
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Header.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Header.java
@@ -1,216 +1,202 @@
 package com.reprezen.kaizen.oasparser.model3;
 
-import com.reprezen.jsonoverlay.IPropertiesOverlay;
-import com.reprezen.kaizen.oasparser.model3.Schema;
-import com.reprezen.jsonoverlay.IModelPart;
-import javax.annotation.Generated;
-import com.reprezen.kaizen.oasparser.model3.MediaType;
-import com.reprezen.kaizen.oasparser.model3.Example;
 import java.util.Map;
-import com.reprezen.jsonoverlay.Reference;
 
-public interface Header extends IPropertiesOverlay<Header>, IModelPart<OpenApi3, Header> {
+import javax.annotation.Generated;
 
-    // Name
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getName();
+import com.reprezen.jsonoverlay.IJsonOverlay;
+import com.reprezen.jsonoverlay.IModelPart;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getName(boolean elaborate);
+public interface Header extends IJsonOverlay<Header>, IModelPart<OpenApi3, Header> {
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setName(String name);
+	// Name
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getName();
 
-    // In
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getIn();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getName(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getIn(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setName(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setIn(String in);
+	// In
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getIn();
 
-    // Description
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getDescription();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getIn(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getDescription(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setIn(String in);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setDescription(String description);
+	// Description
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getDescription();
 
-    // Required
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Boolean getRequired();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getDescription(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Boolean getRequired(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setDescription(String description);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean isRequired();
+	// Required
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Boolean getRequired();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setRequired(Boolean required);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Boolean getRequired(boolean elaborate);
 
-    // Deprecated
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Boolean getDeprecated();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean isRequired();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Boolean getDeprecated(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setRequired(Boolean required);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean isDeprecated();
+	// Deprecated
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Boolean getDeprecated();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setDeprecated(Boolean deprecated);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Boolean getDeprecated(boolean elaborate);
 
-    // AllowEmptyValue
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Boolean getAllowEmptyValue();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean isDeprecated();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Boolean getAllowEmptyValue(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setDeprecated(Boolean deprecated);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean isAllowEmptyValue();
+	// AllowEmptyValue
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Boolean getAllowEmptyValue();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setAllowEmptyValue(Boolean allowEmptyValue);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Boolean getAllowEmptyValue(boolean elaborate);
 
-    // Style
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getStyle();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean isAllowEmptyValue();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getStyle(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setAllowEmptyValue(Boolean allowEmptyValue);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setStyle(String style);
+	// Style
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getStyle();
 
-    // Explode
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Boolean getExplode();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getStyle(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Boolean getExplode(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setStyle(String style);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean isExplode();
+	// Explode
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Boolean getExplode();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setExplode(Boolean explode);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Boolean getExplode(boolean elaborate);
 
-    // AllowReserved
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Boolean getAllowReserved();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean isExplode();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Boolean getAllowReserved(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setExplode(Boolean explode);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean isAllowReserved();
+	// AllowReserved
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Boolean getAllowReserved();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setAllowReserved(Boolean allowReserved);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Boolean getAllowReserved(boolean elaborate);
 
-    // Schema
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Schema getSchema();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean isAllowReserved();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Schema getSchema(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setAllowReserved(Boolean allowReserved);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setSchema(Schema schema);
+	// Schema
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Schema getSchema();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean isSchemaReference();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Schema getSchema(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Reference getSchemaReference();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setSchema(Schema schema);
 
-    // Example
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Object getExample();
+	// Example
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Object getExample();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Object getExample(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Object getExample(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setExample(Object example);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setExample(Object example);
 
-    // Example
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Example> getExamples();
+	// Example
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Example> getExamples();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Example> getExamples(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Example> getExamples(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasExample(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasExample(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Example getExample(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Example getExample(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setExamples(Map<String, Example> examples);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setExamples(Map<String, Example> examples);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setExample(String name, Example example);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setExample(String name, Example example);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeExample(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeExample(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean isExampleReference(String name);
+	// ContentMediaType
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, MediaType> getContentMediaTypes();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Reference getExampleReference(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, MediaType> getContentMediaTypes(boolean elaborate);
 
-    // ContentMediaType
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, MediaType> getContentMediaTypes();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasContentMediaType(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, MediaType> getContentMediaTypes(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	MediaType getContentMediaType(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasContentMediaType(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setContentMediaTypes(Map<String, MediaType> contentMediaTypes);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    MediaType getContentMediaType(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setContentMediaType(String name, MediaType contentMediaType);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setContentMediaTypes(Map<String, MediaType> contentMediaTypes);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeContentMediaType(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setContentMediaType(String name, MediaType contentMediaType);
+	// Extension
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Object> getExtensions();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeContentMediaType(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Object> getExtensions(boolean elaborate);
 
-    // Extension
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Object> getExtensions();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasExtension(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Object> getExtensions(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Object getExtension(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasExtension(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setExtensions(Map<String, Object> extensions);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Object getExtension(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setExtension(String name, Object extension);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setExtensions(Map<String, Object> extensions);
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setExtension(String name, Object extension);
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeExtension(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeExtension(String name);
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Info.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Info.java
@@ -1,93 +1,93 @@
 package com.reprezen.kaizen.oasparser.model3;
 
-import com.reprezen.jsonoverlay.IPropertiesOverlay;
-import com.reprezen.jsonoverlay.IModelPart;
-import javax.annotation.Generated;
-import com.reprezen.kaizen.oasparser.model3.License;
 import java.util.Map;
-import com.reprezen.kaizen.oasparser.model3.Contact;
 
-public interface Info extends IPropertiesOverlay<Info>, IModelPart<OpenApi3, Info> {
+import javax.annotation.Generated;
 
-    // Title
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getTitle();
+import com.reprezen.jsonoverlay.IJsonOverlay;
+import com.reprezen.jsonoverlay.IModelPart;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getTitle(boolean elaborate);
+public interface Info extends IJsonOverlay<Info>, IModelPart<OpenApi3, Info> {
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setTitle(String title);
+	// Title
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getTitle();
 
-    // Description
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getDescription();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getTitle(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getDescription(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setTitle(String title);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setDescription(String description);
+	// Description
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getDescription();
 
-    // TermsOfService
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getTermsOfService();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getDescription(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getTermsOfService(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setDescription(String description);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setTermsOfService(String termsOfService);
+	// TermsOfService
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getTermsOfService();
 
-    // Contact
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Contact getContact();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getTermsOfService(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Contact getContact(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setTermsOfService(String termsOfService);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setContact(Contact contact);
+	// Contact
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Contact getContact();
 
-    // License
-    @Generated("com.reprezen.gen.CodeGenerator")
-    License getLicense();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Contact getContact(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    License getLicense(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setContact(Contact contact);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setLicense(License license);
+	// License
+	@Generated("com.reprezen.gen.CodeGenerator")
+	License getLicense();
 
-    // Version
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getVersion();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	License getLicense(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getVersion(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setLicense(License license);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setVersion(String version);
+	// Version
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getVersion();
 
-    // Extension
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Object> getExtensions();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getVersion(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Object> getExtensions(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setVersion(String version);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasExtension(String name);
+	// Extension
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Object> getExtensions();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Object getExtension(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Object> getExtensions(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setExtensions(Map<String, Object> extensions);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasExtension(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setExtension(String name, Object extension);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Object getExtension(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeExtension(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setExtensions(Map<String, Object> extensions);
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setExtension(String name, Object extension);
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeExtension(String name);
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/License.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/License.java
@@ -1,51 +1,53 @@
 package com.reprezen.kaizen.oasparser.model3;
 
-import com.reprezen.jsonoverlay.IPropertiesOverlay;
-import com.reprezen.jsonoverlay.IModelPart;
-import javax.annotation.Generated;
 import java.util.Map;
 
-public interface License extends IPropertiesOverlay<License>, IModelPart<OpenApi3, License> {
+import javax.annotation.Generated;
 
-    // Name
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getName();
+import com.reprezen.jsonoverlay.IJsonOverlay;
+import com.reprezen.jsonoverlay.IModelPart;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getName(boolean elaborate);
+public interface License extends IJsonOverlay<License>, IModelPart<OpenApi3, License> {
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setName(String name);
+	// Name
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getName();
 
-    // Url
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getUrl();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getName(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getUrl(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setName(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setUrl(String url);
+	// Url
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getUrl();
 
-    // Extension
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Object> getExtensions();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getUrl(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Object> getExtensions(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setUrl(String url);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasExtension(String name);
+	// Extension
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Object> getExtensions();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Object getExtension(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Object> getExtensions(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setExtensions(Map<String, Object> extensions);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasExtension(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setExtension(String name, Object extension);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Object getExtension(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeExtension(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setExtensions(Map<String, Object> extensions);
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setExtension(String name, Object extension);
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeExtension(String name);
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Link.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Link.java
@@ -1,117 +1,117 @@
 package com.reprezen.kaizen.oasparser.model3;
 
-import com.reprezen.jsonoverlay.IPropertiesOverlay;
-import com.reprezen.jsonoverlay.IModelPart;
-import com.reprezen.kaizen.oasparser.model3.Server;
-import javax.annotation.Generated;
 import java.util.Map;
-import com.reprezen.kaizen.oasparser.model3.Header;
 
-public interface Link extends IPropertiesOverlay<Link>, IModelPart<OpenApi3, Link> {
+import javax.annotation.Generated;
 
-    // OperationId
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getOperationId();
+import com.reprezen.jsonoverlay.IJsonOverlay;
+import com.reprezen.jsonoverlay.IModelPart;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getOperationId(boolean elaborate);
+public interface Link extends IJsonOverlay<Link>, IModelPart<OpenApi3, Link> {
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setOperationId(String operationId);
+	// OperationId
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getOperationId();
 
-    // OperationRef
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getOperationRef();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getOperationId(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getOperationRef(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setOperationId(String operationId);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setOperationRef(String operationRef);
+	// OperationRef
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getOperationRef();
 
-    // Parameter
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, String> getParameters();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getOperationRef(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, String> getParameters(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setOperationRef(String operationRef);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasParameter(String name);
+	// Parameter
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, String> getParameters();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getParameter(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, String> getParameters(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setParameters(Map<String, String> parameters);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasParameter(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setParameter(String name, String parameter);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getParameter(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeParameter(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setParameters(Map<String, String> parameters);
 
-    // Header
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Header> getHeaders();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setParameter(String name, String parameter);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Header> getHeaders(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeParameter(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasHeader(String name);
+	// Header
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Header> getHeaders();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Header getHeader(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Header> getHeaders(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setHeaders(Map<String, Header> headers);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasHeader(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setHeader(String name, Header header);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Header getHeader(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeHeader(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setHeaders(Map<String, Header> headers);
 
-    // Description
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getDescription();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setHeader(String name, Header header);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getDescription(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeHeader(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setDescription(String description);
+	// Description
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getDescription();
 
-    // Server
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Server getServer();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getDescription(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Server getServer(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setDescription(String description);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setServer(Server server);
+	// Server
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Server getServer();
 
-    // Extension
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Object> getExtensions();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Server getServer(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Object> getExtensions(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setServer(Server server);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasExtension(String name);
+	// Extension
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Object> getExtensions();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Object getExtension(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Object> getExtensions(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setExtensions(Map<String, Object> extensions);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasExtension(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setExtension(String name, Object extension);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Object getExtension(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeExtension(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setExtensions(Map<String, Object> extensions);
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setExtension(String name, Object extension);
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeExtension(String name);
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/MediaType.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/MediaType.java
@@ -1,111 +1,97 @@
 package com.reprezen.kaizen.oasparser.model3;
 
-import com.reprezen.jsonoverlay.IPropertiesOverlay;
-import com.reprezen.kaizen.oasparser.model3.Schema;
-import com.reprezen.jsonoverlay.IModelPart;
-import javax.annotation.Generated;
-import com.reprezen.kaizen.oasparser.model3.Example;
 import java.util.Map;
-import com.reprezen.jsonoverlay.Reference;
-import com.reprezen.kaizen.oasparser.model3.EncodingProperty;
 
-public interface MediaType extends IPropertiesOverlay<MediaType>, IModelPart<OpenApi3, MediaType> {
+import javax.annotation.Generated;
 
-    // Schema
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Schema getSchema();
+import com.reprezen.jsonoverlay.IJsonOverlay;
+import com.reprezen.jsonoverlay.IModelPart;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Schema getSchema(boolean elaborate);
+public interface MediaType extends IJsonOverlay<MediaType>, IModelPart<OpenApi3, MediaType> {
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setSchema(Schema schema);
+	// Schema
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Schema getSchema();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean isSchemaReference();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Schema getSchema(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Reference getSchemaReference();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setSchema(Schema schema);
 
-    // Example
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Example> getExamples();
+	// Example
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Example> getExamples();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Example> getExamples(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Example> getExamples(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasExample(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasExample(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Example getExample(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Example getExample(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setExamples(Map<String, Example> examples);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setExamples(Map<String, Example> examples);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setExample(String name, Example example);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setExample(String name, Example example);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeExample(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeExample(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean isExampleReference(String name);
+	// Example
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Object getExample();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Reference getExampleReference(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Object getExample(boolean elaborate);
 
-    // Example
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Object getExample();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setExample(Object example);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Object getExample(boolean elaborate);
+	// EncodingProperty
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, EncodingProperty> getEncodingProperties();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setExample(Object example);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, EncodingProperty> getEncodingProperties(boolean elaborate);
 
-    // EncodingProperty
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, EncodingProperty> getEncodingProperties();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasEncodingProperty(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, EncodingProperty> getEncodingProperties(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	EncodingProperty getEncodingProperty(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasEncodingProperty(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setEncodingProperties(Map<String, EncodingProperty> encodingProperties);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    EncodingProperty getEncodingProperty(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setEncodingProperty(String name, EncodingProperty encodingProperty);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setEncodingProperties(Map<String, EncodingProperty> encodingProperties);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeEncodingProperty(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setEncodingProperty(String name, EncodingProperty encodingProperty);
+	// Extension
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Object> getExtensions();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeEncodingProperty(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Object> getExtensions(boolean elaborate);
 
-    // Extension
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Object> getExtensions();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasExtension(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Object> getExtensions(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Object getExtension(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasExtension(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setExtensions(Map<String, Object> extensions);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Object getExtension(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setExtension(String name, Object extension);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setExtensions(Map<String, Object> extensions);
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setExtension(String name, Object extension);
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeExtension(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeExtension(String name);
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/OAuthFlow.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/OAuthFlow.java
@@ -1,105 +1,107 @@
 package com.reprezen.kaizen.oasparser.model3;
 
-import com.reprezen.jsonoverlay.IPropertiesOverlay;
-import com.reprezen.jsonoverlay.IModelPart;
-import javax.annotation.Generated;
 import java.util.Map;
 
-public interface OAuthFlow extends IPropertiesOverlay<OAuthFlow>, IModelPart<OpenApi3, OAuthFlow> {
+import javax.annotation.Generated;
 
-    // AuthorizationUrl
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getAuthorizationUrl();
+import com.reprezen.jsonoverlay.IJsonOverlay;
+import com.reprezen.jsonoverlay.IModelPart;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getAuthorizationUrl(boolean elaborate);
+public interface OAuthFlow extends IJsonOverlay<OAuthFlow>, IModelPart<OpenApi3, OAuthFlow> {
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setAuthorizationUrl(String authorizationUrl);
+	// AuthorizationUrl
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getAuthorizationUrl();
 
-    // TokenUrl
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getTokenUrl();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getAuthorizationUrl(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getTokenUrl(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setAuthorizationUrl(String authorizationUrl);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setTokenUrl(String tokenUrl);
+	// TokenUrl
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getTokenUrl();
 
-    // RefreshUrl
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getRefreshUrl();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getTokenUrl(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getRefreshUrl(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setTokenUrl(String tokenUrl);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setRefreshUrl(String refreshUrl);
+	// RefreshUrl
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getRefreshUrl();
 
-    // Scope
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, String> getScopes();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getRefreshUrl(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, String> getScopes(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setRefreshUrl(String refreshUrl);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasScope(String name);
+	// Scope
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, String> getScopes();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getScope(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, String> getScopes(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setScopes(Map<String, String> scopes);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasScope(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setScope(String name, String scope);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getScope(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeScope(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setScopes(Map<String, String> scopes);
 
-    // ScopesExtension
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Object> getScopesExtensions();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setScope(String name, String scope);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Object> getScopesExtensions(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeScope(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasScopesExtension(String name);
+	// ScopesExtension
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Object> getScopesExtensions();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Object getScopesExtension(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Object> getScopesExtensions(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setScopesExtensions(Map<String, Object> scopesExtensions);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasScopesExtension(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setScopesExtension(String name, Object scopesExtension);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Object getScopesExtension(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeScopesExtension(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setScopesExtensions(Map<String, Object> scopesExtensions);
 
-    // Extension
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Object> getExtensions();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setScopesExtension(String name, Object scopesExtension);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Object> getExtensions(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeScopesExtension(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasExtension(String name);
+	// Extension
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Object> getExtensions();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Object getExtension(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Object> getExtensions(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setExtensions(Map<String, Object> extensions);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasExtension(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setExtension(String name, Object extension);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Object getExtension(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeExtension(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setExtensions(Map<String, Object> extensions);
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setExtension(String name, Object extension);
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeExtension(String name);
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/OpenApi3.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/OpenApi3.java
@@ -1,496 +1,422 @@
 package com.reprezen.kaizen.oasparser.model3;
 
-import com.reprezen.kaizen.oasparser.model3.Schema;
-import com.reprezen.jsonoverlay.IPropertiesOverlay;
-import com.reprezen.kaizen.oasparser.model3.Server;
-import com.reprezen.kaizen.oasparser.model3.Path;
-import com.reprezen.kaizen.oasparser.model3.SecurityRequirement;
 import java.util.Collection;
-import com.reprezen.jsonoverlay.Reference;
-import com.reprezen.kaizen.oasparser.model3.Header;
-import com.reprezen.kaizen.oasparser.model3.Link;
-import com.reprezen.jsonoverlay.IModelPart;
-import com.reprezen.kaizen.oasparser.model3.Callback;
-import com.reprezen.kaizen.oasparser.OpenApi;
-import javax.annotation.Generated;
-import com.reprezen.kaizen.oasparser.model3.Response;
-import com.reprezen.kaizen.oasparser.model3.RequestBody;
-import com.reprezen.kaizen.oasparser.model3.Tag;
-import com.reprezen.kaizen.oasparser.model3.Parameter;
-import com.reprezen.kaizen.oasparser.model3.Example;
-import com.reprezen.kaizen.oasparser.val.ValidationResults;
 import java.util.Map;
-import com.reprezen.kaizen.oasparser.model3.SecurityScheme;
-import com.reprezen.kaizen.oasparser.model3.Info;
-import com.reprezen.kaizen.oasparser.model3.ExternalDocs;
 
-public interface OpenApi3 extends IPropertiesOverlay<OpenApi3>, IModelPart<OpenApi3, OpenApi3>, OpenApi<OpenApi3> {
+import javax.annotation.Generated;
 
-    public void validate();
+import com.reprezen.jsonoverlay.IJsonOverlay;
+import com.reprezen.jsonoverlay.IModelPart;
+import com.reprezen.kaizen.oasparser.OpenApi;
+import com.reprezen.kaizen.oasparser.val.ValidationResults;
 
-    public boolean isValid();
+public interface OpenApi3 extends IJsonOverlay<OpenApi3>, IModelPart<OpenApi3, OpenApi3>, OpenApi<OpenApi3> {
 
-    public ValidationResults getValidationResults();
+	public void validate();
 
-    public Collection<ValidationResults.ValidationItem> getValidationItems();
+	public boolean isValid();
 
-    // OpenApi
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getOpenApi();
+	public ValidationResults getValidationResults();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getOpenApi(boolean elaborate);
+	public Collection<ValidationResults.ValidationItem> getValidationItems();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setOpenApi(String openApi);
+	// OpenApi
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getOpenApi();
 
-    // Info
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Info getInfo();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getOpenApi(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Info getInfo(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setOpenApi(String openApi);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setInfo(Info info);
+	// Info
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Info getInfo();
 
-    // Server
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Collection<Server> getServers();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Info getInfo(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Collection<Server> getServers(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setInfo(Info info);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasServers();
+	// Server
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Collection<Server> getServers();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Server getServer(int index);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Collection<Server> getServers(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setServers(Collection<Server> servers);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasServers();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setServer(int index, Server server);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Server getServer(int index);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void addServer(Server server);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setServers(Collection<Server> servers);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void insertServer(int index, Server server);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setServer(int index, Server server);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeServer(int index);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void addServer(Server server);
 
-    // Path
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Path> getPaths();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void insertServer(int index, Server server);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Path> getPaths(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeServer(int index);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasPath(String name);
+	// Path
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Path> getPaths();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Path getPath(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Path> getPaths(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setPaths(Map<String, Path> paths);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasPath(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setPath(String name, Path path);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Path getPath(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removePath(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setPaths(Map<String, Path> paths);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean isPathReference(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setPath(String name, Path path);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Reference getPathReference(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removePath(String name);
 
-    // PathsExtension
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Object> getPathsExtensions();
+	// PathsExtension
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Object> getPathsExtensions();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Object> getPathsExtensions(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Object> getPathsExtensions(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasPathsExtension(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasPathsExtension(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Object getPathsExtension(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Object getPathsExtension(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setPathsExtensions(Map<String, Object> pathsExtensions);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setPathsExtensions(Map<String, Object> pathsExtensions);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setPathsExtension(String name, Object pathsExtension);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setPathsExtension(String name, Object pathsExtension);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removePathsExtension(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removePathsExtension(String name);
 
-    // Schema
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Schema> getSchemas();
+	// Schema
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Schema> getSchemas();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Schema> getSchemas(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Schema> getSchemas(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasSchema(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasSchema(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Schema getSchema(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Schema getSchema(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setSchemas(Map<String, Schema> schemas);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setSchemas(Map<String, Schema> schemas);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setSchema(String name, Schema schema);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setSchema(String name, Schema schema);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeSchema(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeSchema(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean isSchemaReference(String name);
+	// Response
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Response> getResponses();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Reference getSchemaReference(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Response> getResponses(boolean elaborate);
 
-    // Response
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Response> getResponses();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasResponse(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Response> getResponses(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Response getResponse(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasResponse(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setResponses(Map<String, Response> responses);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Response getResponse(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setResponse(String name, Response response);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setResponses(Map<String, Response> responses);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeResponse(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setResponse(String name, Response response);
+	// Parameter
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Parameter> getParameters();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeResponse(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Parameter> getParameters(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean isResponseReference(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasParameter(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Reference getResponseReference(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Parameter getParameter(String name);
 
-    // Parameter
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Parameter> getParameters();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setParameters(Map<String, Parameter> parameters);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Parameter> getParameters(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setParameter(String name, Parameter parameter);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasParameter(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeParameter(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Parameter getParameter(String name);
+	// Example
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Example> getExamples();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setParameters(Map<String, Parameter> parameters);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Example> getExamples(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setParameter(String name, Parameter parameter);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasExample(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeParameter(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Example getExample(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean isParameterReference(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setExamples(Map<String, Example> examples);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Reference getParameterReference(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setExample(String name, Example example);
 
-    // Example
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Example> getExamples();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeExample(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Example> getExamples(boolean elaborate);
+	// RequestBody
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, RequestBody> getRequestBodies();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasExample(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, RequestBody> getRequestBodies(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Example getExample(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasRequestBody(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setExamples(Map<String, Example> examples);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	RequestBody getRequestBody(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setExample(String name, Example example);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setRequestBodies(Map<String, RequestBody> requestBodies);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeExample(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setRequestBody(String name, RequestBody requestBody);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean isExampleReference(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeRequestBody(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Reference getExampleReference(String name);
+	// Header
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Header> getHeaders();
 
-    // RequestBody
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, RequestBody> getRequestBodies();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Header> getHeaders(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, RequestBody> getRequestBodies(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasHeader(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasRequestBody(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Header getHeader(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    RequestBody getRequestBody(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setHeaders(Map<String, Header> headers);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setRequestBodies(Map<String, RequestBody> requestBodies);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setHeader(String name, Header header);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setRequestBody(String name, RequestBody requestBody);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeHeader(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeRequestBody(String name);
+	// SecurityScheme
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, SecurityScheme> getSecuritySchemes();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean isRequestBodyReference(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, SecurityScheme> getSecuritySchemes(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Reference getRequestBodyReference(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasSecurityScheme(String name);
 
-    // Header
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Header> getHeaders();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	SecurityScheme getSecurityScheme(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Header> getHeaders(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setSecuritySchemes(Map<String, SecurityScheme> securitySchemes);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasHeader(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setSecurityScheme(String name, SecurityScheme securityScheme);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Header getHeader(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeSecurityScheme(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setHeaders(Map<String, Header> headers);
+	// Link
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Link> getLinks();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setHeader(String name, Header header);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Link> getLinks(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeHeader(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasLink(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean isHeaderReference(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Link getLink(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Reference getHeaderReference(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setLinks(Map<String, Link> links);
 
-    // SecurityScheme
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, SecurityScheme> getSecuritySchemes();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setLink(String name, Link link);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, SecurityScheme> getSecuritySchemes(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeLink(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasSecurityScheme(String name);
+	// Callback
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Callback> getCallbacks();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    SecurityScheme getSecurityScheme(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Callback> getCallbacks(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setSecuritySchemes(Map<String, SecurityScheme> securitySchemes);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasCallback(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setSecurityScheme(String name, SecurityScheme securityScheme);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Callback getCallback(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeSecurityScheme(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setCallbacks(Map<String, Callback> callbacks);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean isSecuritySchemeReference(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setCallback(String name, Callback callback);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Reference getSecuritySchemeReference(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeCallback(String name);
 
-    // Link
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Link> getLinks();
+	// ComponentsExtension
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Object> getComponentsExtensions();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Link> getLinks(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Object> getComponentsExtensions(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasLink(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasComponentsExtension(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Link getLink(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Object getComponentsExtension(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setLinks(Map<String, Link> links);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setComponentsExtensions(Map<String, Object> componentsExtensions);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setLink(String name, Link link);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setComponentsExtension(String name, Object componentsExtension);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeLink(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeComponentsExtension(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean isLinkReference(String name);
+	// SecurityRequirement
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Collection<SecurityRequirement> getSecurityRequirements();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Reference getLinkReference(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Collection<SecurityRequirement> getSecurityRequirements(boolean elaborate);
 
-    // Callback
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Callback> getCallbacks();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasSecurityRequirements();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Callback> getCallbacks(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	SecurityRequirement getSecurityRequirement(int index);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasCallback(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setSecurityRequirements(Collection<SecurityRequirement> securityRequirements);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Callback getCallback(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setSecurityRequirement(int index, SecurityRequirement securityRequirement);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setCallbacks(Map<String, Callback> callbacks);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void addSecurityRequirement(SecurityRequirement securityRequirement);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setCallback(String name, Callback callback);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void insertSecurityRequirement(int index, SecurityRequirement securityRequirement);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeCallback(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeSecurityRequirement(int index);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean isCallbackReference(String name);
+	// Tag
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Collection<Tag> getTags();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Reference getCallbackReference(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Collection<Tag> getTags(boolean elaborate);
 
-    // ComponentsExtension
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Object> getComponentsExtensions();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasTags();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Object> getComponentsExtensions(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Tag getTag(int index);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasComponentsExtension(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setTags(Collection<Tag> tags);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Object getComponentsExtension(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setTag(int index, Tag tag);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setComponentsExtensions(Map<String, Object> componentsExtensions);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void addTag(Tag tag);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setComponentsExtension(String name, Object componentsExtension);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void insertTag(int index, Tag tag);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeComponentsExtension(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeTag(int index);
 
-    // SecurityRequirement
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Collection<SecurityRequirement> getSecurityRequirements();
+	// ExternalDocs
+	@Generated("com.reprezen.gen.CodeGenerator")
+	ExternalDocs getExternalDocs();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Collection<SecurityRequirement> getSecurityRequirements(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	ExternalDocs getExternalDocs(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasSecurityRequirements();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setExternalDocs(ExternalDocs externalDocs);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    SecurityRequirement getSecurityRequirement(int index);
+	// Extension
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Object> getExtensions();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setSecurityRequirements(Collection<SecurityRequirement> securityRequirements);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Object> getExtensions(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setSecurityRequirement(int index, SecurityRequirement securityRequirement);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasExtension(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void addSecurityRequirement(SecurityRequirement securityRequirement);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Object getExtension(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void insertSecurityRequirement(int index, SecurityRequirement securityRequirement);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setExtensions(Map<String, Object> extensions);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeSecurityRequirement(int index);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setExtension(String name, Object extension);
 
-    // Tag
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Collection<Tag> getTags();
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Collection<Tag> getTags(boolean elaborate);
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasTags();
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Tag getTag(int index);
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setTags(Collection<Tag> tags);
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setTag(int index, Tag tag);
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void addTag(Tag tag);
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void insertTag(int index, Tag tag);
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeTag(int index);
-
-    // ExternalDocs
-    @Generated("com.reprezen.gen.CodeGenerator")
-    ExternalDocs getExternalDocs();
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    ExternalDocs getExternalDocs(boolean elaborate);
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setExternalDocs(ExternalDocs externalDocs);
-
-    // Extension
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Object> getExtensions();
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Object> getExtensions(boolean elaborate);
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasExtension(String name);
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Object getExtension(String name);
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setExtensions(Map<String, Object> extensions);
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setExtension(String name, Object extension);
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeExtension(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeExtension(String name);
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Operation.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Operation.java
@@ -1,327 +1,297 @@
 package com.reprezen.kaizen.oasparser.model3;
 
-import com.reprezen.jsonoverlay.IPropertiesOverlay;
-import com.reprezen.kaizen.oasparser.model3.Server;
-import com.reprezen.kaizen.oasparser.model3.SecurityRequirement;
 import java.util.Collection;
-import com.reprezen.jsonoverlay.Reference;
-import com.reprezen.jsonoverlay.IModelPart;
-import com.reprezen.kaizen.oasparser.model3.Callback;
-import javax.annotation.Generated;
-import com.reprezen.kaizen.oasparser.model3.Response;
-import com.reprezen.kaizen.oasparser.model3.RequestBody;
-import com.reprezen.kaizen.oasparser.model3.Parameter;
 import java.util.Map;
-import com.reprezen.kaizen.oasparser.model3.ExternalDocs;
 
-public interface Operation extends IPropertiesOverlay<Operation>, IModelPart<OpenApi3, Operation> {
+import javax.annotation.Generated;
 
-    // Tag
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Collection<String> getTags();
+import com.reprezen.jsonoverlay.IJsonOverlay;
+import com.reprezen.jsonoverlay.IModelPart;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Collection<String> getTags(boolean elaborate);
+public interface Operation extends IJsonOverlay<Operation>, IModelPart<OpenApi3, Operation> {
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasTags();
+	// Tag
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Collection<String> getTags();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getTag(int index);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Collection<String> getTags(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setTags(Collection<String> tags);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasTags();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setTag(int index, String tag);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getTag(int index);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void addTag(String tag);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setTags(Collection<String> tags);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void insertTag(int index, String tag);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setTag(int index, String tag);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeTag(int index);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void addTag(String tag);
 
-    // Summary
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getSummary();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void insertTag(int index, String tag);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getSummary(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeTag(int index);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setSummary(String summary);
+	// Summary
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getSummary();
 
-    // Description
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getDescription();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getSummary(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getDescription(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setSummary(String summary);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setDescription(String description);
+	// Description
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getDescription();
 
-    // ExternalDocs
-    @Generated("com.reprezen.gen.CodeGenerator")
-    ExternalDocs getExternalDocs();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getDescription(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    ExternalDocs getExternalDocs(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setDescription(String description);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setExternalDocs(ExternalDocs externalDocs);
+	// ExternalDocs
+	@Generated("com.reprezen.gen.CodeGenerator")
+	ExternalDocs getExternalDocs();
 
-    // OperationId
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getOperationId();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	ExternalDocs getExternalDocs(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getOperationId(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setExternalDocs(ExternalDocs externalDocs);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setOperationId(String operationId);
+	// OperationId
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getOperationId();
 
-    // Parameter
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Collection<Parameter> getParameters();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getOperationId(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Collection<Parameter> getParameters(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setOperationId(String operationId);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasParameters();
+	// Parameter
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Collection<Parameter> getParameters();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Parameter getParameter(int index);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Collection<Parameter> getParameters(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setParameters(Collection<Parameter> parameters);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasParameters();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setParameter(int index, Parameter parameter);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Parameter getParameter(int index);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void addParameter(Parameter parameter);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setParameters(Collection<Parameter> parameters);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void insertParameter(int index, Parameter parameter);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setParameter(int index, Parameter parameter);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeParameter(int index);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void addParameter(Parameter parameter);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean isParameterReference(int index);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void insertParameter(int index, Parameter parameter);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Reference getParameterReference(int index);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeParameter(int index);
 
-    // RequestBody
-    @Generated("com.reprezen.gen.CodeGenerator")
-    RequestBody getRequestBody();
+	// RequestBody
+	@Generated("com.reprezen.gen.CodeGenerator")
+	RequestBody getRequestBody();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    RequestBody getRequestBody(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	RequestBody getRequestBody(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setRequestBody(RequestBody requestBody);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setRequestBody(RequestBody requestBody);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean isRequestBodyReference();
+	// Response
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Response> getResponses();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Reference getRequestBodyReference();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Response> getResponses(boolean elaborate);
 
-    // Response
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Response> getResponses();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasResponse(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Response> getResponses(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Response getResponse(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasResponse(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setResponses(Map<String, Response> responses);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Response getResponse(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setResponse(String name, Response response);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setResponses(Map<String, Response> responses);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeResponse(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setResponse(String name, Response response);
+	// ResponsesExtension
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Object> getResponsesExtensions();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeResponse(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Object> getResponsesExtensions(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean isResponseReference(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasResponsesExtension(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Reference getResponseReference(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Object getResponsesExtension(String name);
 
-    // ResponsesExtension
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Object> getResponsesExtensions();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setResponsesExtensions(Map<String, Object> responsesExtensions);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Object> getResponsesExtensions(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setResponsesExtension(String name, Object responsesExtension);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasResponsesExtension(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeResponsesExtension(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Object getResponsesExtension(String name);
+	// Callback
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Callback> getCallbacks();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setResponsesExtensions(Map<String, Object> responsesExtensions);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Callback> getCallbacks(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setResponsesExtension(String name, Object responsesExtension);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasCallback(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeResponsesExtension(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Callback getCallback(String name);
 
-    // Callback
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Callback> getCallbacks();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setCallbacks(Map<String, Callback> callbacks);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Callback> getCallbacks(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setCallback(String name, Callback callback);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasCallback(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeCallback(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Callback getCallback(String name);
+	// CallbacksExtension
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Object> getCallbacksExtensions();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setCallbacks(Map<String, Callback> callbacks);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Object> getCallbacksExtensions(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setCallback(String name, Callback callback);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasCallbacksExtension(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeCallback(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Object getCallbacksExtension(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean isCallbackReference(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setCallbacksExtensions(Map<String, Object> callbacksExtensions);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Reference getCallbackReference(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setCallbacksExtension(String name, Object callbacksExtension);
 
-    // CallbacksExtension
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Object> getCallbacksExtensions();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeCallbacksExtension(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Object> getCallbacksExtensions(boolean elaborate);
+	// Deprecated
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Boolean getDeprecated();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasCallbacksExtension(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Boolean getDeprecated(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Object getCallbacksExtension(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean isDeprecated();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setCallbacksExtensions(Map<String, Object> callbacksExtensions);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setDeprecated(Boolean deprecated);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setCallbacksExtension(String name, Object callbacksExtension);
+	// SecurityRequirement
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Collection<SecurityRequirement> getSecurityRequirements();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeCallbacksExtension(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Collection<SecurityRequirement> getSecurityRequirements(boolean elaborate);
 
-    // Deprecated
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Boolean getDeprecated();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasSecurityRequirements();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Boolean getDeprecated(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	SecurityRequirement getSecurityRequirement(int index);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean isDeprecated();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setSecurityRequirements(Collection<SecurityRequirement> securityRequirements);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setDeprecated(Boolean deprecated);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setSecurityRequirement(int index, SecurityRequirement securityRequirement);
 
-    // SecurityRequirement
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Collection<SecurityRequirement> getSecurityRequirements();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void addSecurityRequirement(SecurityRequirement securityRequirement);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Collection<SecurityRequirement> getSecurityRequirements(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void insertSecurityRequirement(int index, SecurityRequirement securityRequirement);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasSecurityRequirements();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeSecurityRequirement(int index);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    SecurityRequirement getSecurityRequirement(int index);
+	// Server
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Collection<Server> getServers();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setSecurityRequirements(Collection<SecurityRequirement> securityRequirements);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Collection<Server> getServers(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setSecurityRequirement(int index, SecurityRequirement securityRequirement);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasServers();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void addSecurityRequirement(SecurityRequirement securityRequirement);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Server getServer(int index);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void insertSecurityRequirement(int index, SecurityRequirement securityRequirement);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setServers(Collection<Server> servers);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeSecurityRequirement(int index);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setServer(int index, Server server);
 
-    // Server
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Collection<Server> getServers();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void addServer(Server server);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Collection<Server> getServers(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void insertServer(int index, Server server);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasServers();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeServer(int index);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Server getServer(int index);
+	// Extension
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Object> getExtensions();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setServers(Collection<Server> servers);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Object> getExtensions(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setServer(int index, Server server);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasExtension(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void addServer(Server server);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Object getExtension(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void insertServer(int index, Server server);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setExtensions(Map<String, Object> extensions);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeServer(int index);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setExtension(String name, Object extension);
 
-    // Extension
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Object> getExtensions();
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Object> getExtensions(boolean elaborate);
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasExtension(String name);
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Object getExtension(String name);
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setExtensions(Map<String, Object> extensions);
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setExtension(String name, Object extension);
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeExtension(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeExtension(String name);
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Parameter.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Parameter.java
@@ -1,216 +1,202 @@
 package com.reprezen.kaizen.oasparser.model3;
 
-import com.reprezen.jsonoverlay.IPropertiesOverlay;
-import com.reprezen.kaizen.oasparser.model3.Schema;
-import com.reprezen.jsonoverlay.IModelPart;
-import javax.annotation.Generated;
-import com.reprezen.kaizen.oasparser.model3.MediaType;
-import com.reprezen.kaizen.oasparser.model3.Example;
 import java.util.Map;
-import com.reprezen.jsonoverlay.Reference;
 
-public interface Parameter extends IPropertiesOverlay<Parameter>, IModelPart<OpenApi3, Parameter> {
+import javax.annotation.Generated;
 
-    // Name
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getName();
+import com.reprezen.jsonoverlay.IJsonOverlay;
+import com.reprezen.jsonoverlay.IModelPart;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getName(boolean elaborate);
+public interface Parameter extends IJsonOverlay<Parameter>, IModelPart<OpenApi3, Parameter> {
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setName(String name);
+	// Name
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getName();
 
-    // In
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getIn();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getName(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getIn(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setName(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setIn(String in);
+	// In
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getIn();
 
-    // Description
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getDescription();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getIn(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getDescription(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setIn(String in);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setDescription(String description);
+	// Description
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getDescription();
 
-    // Required
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Boolean getRequired();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getDescription(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Boolean getRequired(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setDescription(String description);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean isRequired();
+	// Required
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Boolean getRequired();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setRequired(Boolean required);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Boolean getRequired(boolean elaborate);
 
-    // Deprecated
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Boolean getDeprecated();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean isRequired();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Boolean getDeprecated(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setRequired(Boolean required);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean isDeprecated();
+	// Deprecated
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Boolean getDeprecated();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setDeprecated(Boolean deprecated);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Boolean getDeprecated(boolean elaborate);
 
-    // AllowEmptyValue
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Boolean getAllowEmptyValue();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean isDeprecated();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Boolean getAllowEmptyValue(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setDeprecated(Boolean deprecated);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean isAllowEmptyValue();
+	// AllowEmptyValue
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Boolean getAllowEmptyValue();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setAllowEmptyValue(Boolean allowEmptyValue);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Boolean getAllowEmptyValue(boolean elaborate);
 
-    // Style
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getStyle();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean isAllowEmptyValue();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getStyle(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setAllowEmptyValue(Boolean allowEmptyValue);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setStyle(String style);
+	// Style
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getStyle();
 
-    // Explode
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Boolean getExplode();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getStyle(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Boolean getExplode(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setStyle(String style);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean isExplode();
+	// Explode
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Boolean getExplode();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setExplode(Boolean explode);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Boolean getExplode(boolean elaborate);
 
-    // AllowReserved
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Boolean getAllowReserved();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean isExplode();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Boolean getAllowReserved(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setExplode(Boolean explode);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean isAllowReserved();
+	// AllowReserved
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Boolean getAllowReserved();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setAllowReserved(Boolean allowReserved);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Boolean getAllowReserved(boolean elaborate);
 
-    // Schema
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Schema getSchema();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean isAllowReserved();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Schema getSchema(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setAllowReserved(Boolean allowReserved);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setSchema(Schema schema);
+	// Schema
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Schema getSchema();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean isSchemaReference();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Schema getSchema(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Reference getSchemaReference();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setSchema(Schema schema);
 
-    // Example
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Object getExample();
+	// Example
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Object getExample();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Object getExample(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Object getExample(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setExample(Object example);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setExample(Object example);
 
-    // Example
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Example> getExamples();
+	// Example
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Example> getExamples();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Example> getExamples(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Example> getExamples(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasExample(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasExample(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Example getExample(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Example getExample(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setExamples(Map<String, Example> examples);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setExamples(Map<String, Example> examples);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setExample(String name, Example example);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setExample(String name, Example example);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeExample(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeExample(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean isExampleReference(String name);
+	// ContentMediaType
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, MediaType> getContentMediaTypes();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Reference getExampleReference(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, MediaType> getContentMediaTypes(boolean elaborate);
 
-    // ContentMediaType
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, MediaType> getContentMediaTypes();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasContentMediaType(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, MediaType> getContentMediaTypes(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	MediaType getContentMediaType(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasContentMediaType(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setContentMediaTypes(Map<String, MediaType> contentMediaTypes);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    MediaType getContentMediaType(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setContentMediaType(String name, MediaType contentMediaType);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setContentMediaTypes(Map<String, MediaType> contentMediaTypes);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeContentMediaType(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setContentMediaType(String name, MediaType contentMediaType);
+	// Extension
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Object> getExtensions();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeContentMediaType(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Object> getExtensions(boolean elaborate);
 
-    // Extension
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Object> getExtensions();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasExtension(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Object> getExtensions(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Object getExtension(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasExtension(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setExtensions(Map<String, Object> extensions);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Object getExtension(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setExtension(String name, Object extension);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setExtensions(Map<String, Object> extensions);
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setExtension(String name, Object extension);
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeExtension(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeExtension(String name);
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Path.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Path.java
@@ -1,220 +1,212 @@
 package com.reprezen.kaizen.oasparser.model3;
 
-import com.reprezen.jsonoverlay.IPropertiesOverlay;
-import com.reprezen.jsonoverlay.IModelPart;
-import com.reprezen.kaizen.oasparser.model3.Server;
-import javax.annotation.Generated;
-import com.reprezen.kaizen.oasparser.model3.Operation;
-import com.reprezen.kaizen.oasparser.model3.Parameter;
 import java.util.Collection;
 import java.util.Map;
-import com.reprezen.jsonoverlay.Reference;
 
-public interface Path extends IPropertiesOverlay<Path>, IModelPart<OpenApi3, Path> {
+import javax.annotation.Generated;
 
-    // Summary
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getSummary();
+import com.reprezen.jsonoverlay.IJsonOverlay;
+import com.reprezen.jsonoverlay.IModelPart;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getSummary(boolean elaborate);
+public interface Path extends IJsonOverlay<Path>, IModelPart<OpenApi3, Path> {
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setSummary(String summary);
+	// Summary
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getSummary();
 
-    // Description
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getDescription();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getSummary(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getDescription(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setSummary(String summary);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setDescription(String description);
+	// Description
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getDescription();
 
-    // Operation
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Operation> getOperations();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getDescription(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Operation> getOperations(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setDescription(String description);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasOperation(String name);
+	// Operation
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Operation> getOperations();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Operation getOperation(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Operation> getOperations(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setOperations(Map<String, Operation> operations);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasOperation(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setOperation(String name, Operation operation);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Operation getOperation(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeOperation(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setOperations(Map<String, Operation> operations);
 
-    // Get
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Operation getGet();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setOperation(String name, Operation operation);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Operation getGet(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeOperation(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setGet(Operation get);
+	// Get
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Operation getGet();
 
-    // Put
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Operation getPut();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Operation getGet(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Operation getPut(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setGet(Operation get);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setPut(Operation put);
+	// Put
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Operation getPut();
 
-    // Post
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Operation getPost();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Operation getPut(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Operation getPost(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setPut(Operation put);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setPost(Operation post);
+	// Post
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Operation getPost();
 
-    // Delete
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Operation getDelete();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Operation getPost(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Operation getDelete(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setPost(Operation post);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setDelete(Operation delete);
+	// Delete
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Operation getDelete();
 
-    // Options
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Operation getOptions();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Operation getDelete(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Operation getOptions(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setDelete(Operation delete);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setOptions(Operation options);
+	// Options
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Operation getOptions();
 
-    // Head
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Operation getHead();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Operation getOptions(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Operation getHead(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setOptions(Operation options);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setHead(Operation head);
+	// Head
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Operation getHead();
 
-    // Patch
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Operation getPatch();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Operation getHead(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Operation getPatch(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setHead(Operation head);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setPatch(Operation patch);
+	// Patch
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Operation getPatch();
 
-    // Trace
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Operation getTrace();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Operation getPatch(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Operation getTrace(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setPatch(Operation patch);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setTrace(Operation trace);
+	// Trace
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Operation getTrace();
 
-    // Server
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Collection<Server> getServers();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Operation getTrace(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Collection<Server> getServers(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setTrace(Operation trace);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasServers();
+	// Server
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Collection<Server> getServers();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Server getServer(int index);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Collection<Server> getServers(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setServers(Collection<Server> servers);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasServers();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setServer(int index, Server server);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Server getServer(int index);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void addServer(Server server);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setServers(Collection<Server> servers);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void insertServer(int index, Server server);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setServer(int index, Server server);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeServer(int index);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void addServer(Server server);
 
-    // Parameter
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Collection<Parameter> getParameters();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void insertServer(int index, Server server);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Collection<Parameter> getParameters(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeServer(int index);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasParameters();
+	// Parameter
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Collection<Parameter> getParameters();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Parameter getParameter(int index);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Collection<Parameter> getParameters(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setParameters(Collection<Parameter> parameters);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasParameters();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setParameter(int index, Parameter parameter);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Parameter getParameter(int index);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void addParameter(Parameter parameter);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setParameters(Collection<Parameter> parameters);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void insertParameter(int index, Parameter parameter);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setParameter(int index, Parameter parameter);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeParameter(int index);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void addParameter(Parameter parameter);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean isParameterReference(int index);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void insertParameter(int index, Parameter parameter);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Reference getParameterReference(int index);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeParameter(int index);
 
-    // Extension
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Object> getExtensions();
+	// Extension
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Object> getExtensions();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Object> getExtensions(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Object> getExtensions(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasExtension(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasExtension(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Object getExtension(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Object getExtension(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setExtensions(Map<String, Object> extensions);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setExtensions(Map<String, Object> extensions);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setExtension(String name, Object extension);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setExtension(String name, Object extension);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeExtension(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeExtension(String name);
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/RequestBody.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/RequestBody.java
@@ -1,77 +1,78 @@
 package com.reprezen.kaizen.oasparser.model3;
 
-import com.reprezen.jsonoverlay.IPropertiesOverlay;
-import com.reprezen.jsonoverlay.IModelPart;
-import javax.annotation.Generated;
-import com.reprezen.kaizen.oasparser.model3.MediaType;
 import java.util.Map;
 
-public interface RequestBody extends IPropertiesOverlay<RequestBody>, IModelPart<OpenApi3, RequestBody> {
+import javax.annotation.Generated;
 
-    // Description
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getDescription();
+import com.reprezen.jsonoverlay.IJsonOverlay;
+import com.reprezen.jsonoverlay.IModelPart;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getDescription(boolean elaborate);
+public interface RequestBody extends IJsonOverlay<RequestBody>, IModelPart<OpenApi3, RequestBody> {
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setDescription(String description);
+	// Description
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getDescription();
 
-    // ContentMediaType
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, MediaType> getContentMediaTypes();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getDescription(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, MediaType> getContentMediaTypes(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setDescription(String description);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasContentMediaType(String name);
+	// ContentMediaType
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, MediaType> getContentMediaTypes();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    MediaType getContentMediaType(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, MediaType> getContentMediaTypes(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setContentMediaTypes(Map<String, MediaType> contentMediaTypes);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasContentMediaType(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setContentMediaType(String name, MediaType contentMediaType);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	MediaType getContentMediaType(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeContentMediaType(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setContentMediaTypes(Map<String, MediaType> contentMediaTypes);
 
-    // Required
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Boolean getRequired();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setContentMediaType(String name, MediaType contentMediaType);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Boolean getRequired(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeContentMediaType(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean isRequired();
+	// Required
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Boolean getRequired();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setRequired(Boolean required);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Boolean getRequired(boolean elaborate);
 
-    // Extension
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Object> getExtensions();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean isRequired();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Object> getExtensions(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setRequired(Boolean required);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasExtension(String name);
+	// Extension
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Object> getExtensions();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Object getExtension(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Object> getExtensions(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setExtensions(Map<String, Object> extensions);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasExtension(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setExtension(String name, Object extension);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Object getExtension(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeExtension(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setExtensions(Map<String, Object> extensions);
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setExtension(String name, Object extension);
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeExtension(String name);
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Response.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Response.java
@@ -1,123 +1,109 @@
 package com.reprezen.kaizen.oasparser.model3;
 
-import com.reprezen.jsonoverlay.IPropertiesOverlay;
-import com.reprezen.jsonoverlay.IModelPart;
-import javax.annotation.Generated;
-import com.reprezen.kaizen.oasparser.model3.MediaType;
 import java.util.Map;
-import com.reprezen.kaizen.oasparser.model3.Header;
-import com.reprezen.jsonoverlay.Reference;
-import com.reprezen.kaizen.oasparser.model3.Link;
 
-public interface Response extends IPropertiesOverlay<Response>, IModelPart<OpenApi3, Response> {
+import javax.annotation.Generated;
 
-    // Description
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getDescription();
+import com.reprezen.jsonoverlay.IJsonOverlay;
+import com.reprezen.jsonoverlay.IModelPart;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getDescription(boolean elaborate);
+public interface Response extends IJsonOverlay<Response>, IModelPart<OpenApi3, Response> {
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setDescription(String description);
+	// Description
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getDescription();
 
-    // Header
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Header> getHeaders();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getDescription(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Header> getHeaders(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setDescription(String description);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasHeader(String name);
+	// Header
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Header> getHeaders();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Header getHeader(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Header> getHeaders(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setHeaders(Map<String, Header> headers);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasHeader(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setHeader(String name, Header header);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Header getHeader(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeHeader(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setHeaders(Map<String, Header> headers);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean isHeaderReference(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setHeader(String name, Header header);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Reference getHeaderReference(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeHeader(String name);
 
-    // ContentMediaType
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, MediaType> getContentMediaTypes();
+	// ContentMediaType
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, MediaType> getContentMediaTypes();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, MediaType> getContentMediaTypes(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, MediaType> getContentMediaTypes(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasContentMediaType(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasContentMediaType(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    MediaType getContentMediaType(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	MediaType getContentMediaType(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setContentMediaTypes(Map<String, MediaType> contentMediaTypes);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setContentMediaTypes(Map<String, MediaType> contentMediaTypes);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setContentMediaType(String name, MediaType contentMediaType);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setContentMediaType(String name, MediaType contentMediaType);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeContentMediaType(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeContentMediaType(String name);
 
-    // Link
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Link> getLinks();
+	// Link
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Link> getLinks();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Link> getLinks(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Link> getLinks(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasLink(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasLink(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Link getLink(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Link getLink(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setLinks(Map<String, Link> links);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setLinks(Map<String, Link> links);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setLink(String name, Link link);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setLink(String name, Link link);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeLink(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeLink(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean isLinkReference(String name);
+	// Extension
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Object> getExtensions();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Reference getLinkReference(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Object> getExtensions(boolean elaborate);
 
-    // Extension
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Object> getExtensions();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasExtension(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Object> getExtensions(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Object getExtension(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasExtension(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setExtensions(Map<String, Object> extensions);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Object getExtension(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setExtension(String name, Object extension);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setExtensions(Map<String, Object> extensions);
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setExtension(String name, Object extension);
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeExtension(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeExtension(String name);
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Schema.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Schema.java
@@ -1,587 +1,542 @@
 package com.reprezen.kaizen.oasparser.model3;
 
-import com.reprezen.jsonoverlay.IPropertiesOverlay;
-import com.reprezen.kaizen.oasparser.model3.Schema;
-import com.reprezen.jsonoverlay.IModelPart;
-import com.reprezen.kaizen.oasparser.model3.Xml;
-import javax.annotation.Generated;
-import com.reprezen.kaizen.oasparser.model3.Example;
 import java.util.Collection;
 import java.util.Map;
-import com.reprezen.jsonoverlay.Reference;
-import com.reprezen.kaizen.oasparser.model3.ExternalDocs;
 
-public interface Schema extends IPropertiesOverlay<Schema>, IModelPart<OpenApi3, Schema> {
+import javax.annotation.Generated;
 
-    // Title
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getTitle();
+import com.reprezen.jsonoverlay.IJsonOverlay;
+import com.reprezen.jsonoverlay.IModelPart;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getTitle(boolean elaborate);
+public interface Schema extends IJsonOverlay<Schema>, IModelPart<OpenApi3, Schema> {
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setTitle(String title);
+	// Title
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getTitle();
 
-    // MultipleOf
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Number getMultipleOf();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getTitle(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Number getMultipleOf(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setTitle(String title);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setMultipleOf(Number multipleOf);
+	// MultipleOf
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Number getMultipleOf();
 
-    // Maximum
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Number getMaximum();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Number getMultipleOf(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Number getMaximum(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setMultipleOf(Number multipleOf);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setMaximum(Number maximum);
+	// Maximum
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Number getMaximum();
 
-    // ExclusiveMaximum
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Boolean getExclusiveMaximum();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Number getMaximum(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Boolean getExclusiveMaximum(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setMaximum(Number maximum);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean isExclusiveMaximum();
+	// ExclusiveMaximum
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Boolean getExclusiveMaximum();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setExclusiveMaximum(Boolean exclusiveMaximum);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Boolean getExclusiveMaximum(boolean elaborate);
 
-    // Minimum
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Number getMinimum();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean isExclusiveMaximum();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Number getMinimum(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setExclusiveMaximum(Boolean exclusiveMaximum);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setMinimum(Number minimum);
+	// Minimum
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Number getMinimum();
 
-    // ExclusiveMinimum
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Boolean getExclusiveMinimum();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Number getMinimum(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Boolean getExclusiveMinimum(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setMinimum(Number minimum);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean isExclusiveMinimum();
+	// ExclusiveMinimum
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Boolean getExclusiveMinimum();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setExclusiveMinimum(Boolean exclusiveMinimum);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Boolean getExclusiveMinimum(boolean elaborate);
 
-    // MaxLength
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Integer getMaxLength();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean isExclusiveMinimum();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Integer getMaxLength(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setExclusiveMinimum(Boolean exclusiveMinimum);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setMaxLength(Integer maxLength);
+	// MaxLength
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Integer getMaxLength();
 
-    // MinLength
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Integer getMinLength();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Integer getMaxLength(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Integer getMinLength(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setMaxLength(Integer maxLength);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setMinLength(Integer minLength);
+	// MinLength
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Integer getMinLength();
 
-    // Pattern
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getPattern();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Integer getMinLength(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getPattern(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setMinLength(Integer minLength);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setPattern(String pattern);
+	// Pattern
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getPattern();
 
-    // MaxItems
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Integer getMaxItems();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getPattern(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Integer getMaxItems(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setPattern(String pattern);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setMaxItems(Integer maxItems);
+	// MaxItems
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Integer getMaxItems();
 
-    // MinItems
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Integer getMinItems();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Integer getMaxItems(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Integer getMinItems(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setMaxItems(Integer maxItems);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setMinItems(Integer minItems);
+	// MinItems
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Integer getMinItems();
 
-    // UniqueItems
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Boolean getUniqueItems();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Integer getMinItems(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Boolean getUniqueItems(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setMinItems(Integer minItems);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean isUniqueItems();
+	// UniqueItems
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Boolean getUniqueItems();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setUniqueItems(Boolean uniqueItems);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Boolean getUniqueItems(boolean elaborate);
 
-    // MaxProperties
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Integer getMaxProperties();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean isUniqueItems();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Integer getMaxProperties(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setUniqueItems(Boolean uniqueItems);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setMaxProperties(Integer maxProperties);
+	// MaxProperties
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Integer getMaxProperties();
 
-    // MinProperties
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Integer getMinProperties();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Integer getMaxProperties(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Integer getMinProperties(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setMaxProperties(Integer maxProperties);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setMinProperties(Integer minProperties);
+	// MinProperties
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Integer getMinProperties();
 
-    // RequiredField
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Collection<String> getRequiredFields();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Integer getMinProperties(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Collection<String> getRequiredFields(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setMinProperties(Integer minProperties);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasRequiredFields();
+	// RequiredField
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Collection<String> getRequiredFields();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getRequiredField(int index);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Collection<String> getRequiredFields(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setRequiredFields(Collection<String> requiredFields);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasRequiredFields();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setRequiredField(int index, String requiredField);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getRequiredField(int index);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void addRequiredField(String requiredField);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setRequiredFields(Collection<String> requiredFields);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void insertRequiredField(int index, String requiredField);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setRequiredField(int index, String requiredField);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeRequiredField(int index);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void addRequiredField(String requiredField);
 
-    // Enum
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Collection<Object> getEnums();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void insertRequiredField(int index, String requiredField);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Collection<Object> getEnums(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeRequiredField(int index);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasEnums();
+	// Enum
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Collection<Object> getEnums();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Object getEnum(int index);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Collection<Object> getEnums(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setEnums(Collection<Object> enums);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasEnums();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setEnum(int index, Object enumValue);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Object getEnum(int index);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void addEnum(Object enumValue);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setEnums(Collection<Object> enums);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void insertEnum(int index, Object enumValue);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setEnum(int index, Object enumValue);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeEnum(int index);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void addEnum(Object enumValue);
 
-    // Type
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getType();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void insertEnum(int index, Object enumValue);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getType(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeEnum(int index);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setType(String type);
+	// Type
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getType();
 
-    // AllOfSchema
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Collection<Schema> getAllOfSchemas();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getType(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Collection<Schema> getAllOfSchemas(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setType(String type);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasAllOfSchemas();
+	// AllOfSchema
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Collection<Schema> getAllOfSchemas();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Schema getAllOfSchema(int index);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Collection<Schema> getAllOfSchemas(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setAllOfSchemas(Collection<Schema> allOfSchemas);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasAllOfSchemas();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setAllOfSchema(int index, Schema allOfSchema);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Schema getAllOfSchema(int index);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void addAllOfSchema(Schema allOfSchema);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setAllOfSchemas(Collection<Schema> allOfSchemas);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void insertAllOfSchema(int index, Schema allOfSchema);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setAllOfSchema(int index, Schema allOfSchema);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeAllOfSchema(int index);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void addAllOfSchema(Schema allOfSchema);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean isAllOfSchemaReference(int index);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void insertAllOfSchema(int index, Schema allOfSchema);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Reference getAllOfSchemaReference(int index);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeAllOfSchema(int index);
 
-    // OneOfSchema
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Collection<Schema> getOneOfSchemas();
+	// OneOfSchema
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Collection<Schema> getOneOfSchemas();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Collection<Schema> getOneOfSchemas(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Collection<Schema> getOneOfSchemas(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasOneOfSchemas();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasOneOfSchemas();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Schema getOneOfSchema(int index);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Schema getOneOfSchema(int index);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setOneOfSchemas(Collection<Schema> oneOfSchemas);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setOneOfSchemas(Collection<Schema> oneOfSchemas);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setOneOfSchema(int index, Schema oneOfSchema);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setOneOfSchema(int index, Schema oneOfSchema);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void addOneOfSchema(Schema oneOfSchema);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void addOneOfSchema(Schema oneOfSchema);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void insertOneOfSchema(int index, Schema oneOfSchema);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void insertOneOfSchema(int index, Schema oneOfSchema);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeOneOfSchema(int index);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeOneOfSchema(int index);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean isOneOfSchemaReference(int index);
+	// AnyOfSchema
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Collection<Schema> getAnyOfSchemas();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Reference getOneOfSchemaReference(int index);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Collection<Schema> getAnyOfSchemas(boolean elaborate);
 
-    // AnyOfSchema
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Collection<Schema> getAnyOfSchemas();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasAnyOfSchemas();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Collection<Schema> getAnyOfSchemas(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Schema getAnyOfSchema(int index);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasAnyOfSchemas();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setAnyOfSchemas(Collection<Schema> anyOfSchemas);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Schema getAnyOfSchema(int index);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setAnyOfSchema(int index, Schema anyOfSchema);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setAnyOfSchemas(Collection<Schema> anyOfSchemas);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void addAnyOfSchema(Schema anyOfSchema);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setAnyOfSchema(int index, Schema anyOfSchema);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void insertAnyOfSchema(int index, Schema anyOfSchema);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void addAnyOfSchema(Schema anyOfSchema);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeAnyOfSchema(int index);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void insertAnyOfSchema(int index, Schema anyOfSchema);
+	// NotSchema
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Schema getNotSchema();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeAnyOfSchema(int index);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Schema getNotSchema(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean isAnyOfSchemaReference(int index);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setNotSchema(Schema notSchema);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Reference getAnyOfSchemaReference(int index);
+	// ItemsSchema
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Schema getItemsSchema();
 
-    // NotSchema
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Schema getNotSchema();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Schema getItemsSchema(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Schema getNotSchema(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setItemsSchema(Schema itemsSchema);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setNotSchema(Schema notSchema);
+	// Property
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Schema> getProperties();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean isNotSchemaReference();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Schema> getProperties(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Reference getNotSchemaReference();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasProperty(String name);
 
-    // ItemsSchema
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Schema getItemsSchema();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Schema getProperty(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Schema getItemsSchema(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setProperties(Map<String, Schema> properties);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setItemsSchema(Schema itemsSchema);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setProperty(String name, Schema property);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean isItemsSchemaReference();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeProperty(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Reference getItemsSchemaReference();
+	// AdditionalPropertiesSchema
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Schema getAdditionalPropertiesSchema();
 
-    // Property
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Schema> getProperties();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Schema getAdditionalPropertiesSchema(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Schema> getProperties(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setAdditionalPropertiesSchema(Schema additionalPropertiesSchema);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasProperty(String name);
+	// AdditionalProperties
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Boolean getAdditionalProperties();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Schema getProperty(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Boolean getAdditionalProperties(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setProperties(Map<String, Schema> properties);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean isAdditionalProperties();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setProperty(String name, Schema property);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setAdditionalProperties(Boolean additionalProperties);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeProperty(String name);
+	// Description
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getDescription();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean isPropertyReference(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getDescription(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Reference getPropertyReference(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setDescription(String description);
 
-    // AdditionalPropertiesSchema
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Schema getAdditionalPropertiesSchema();
+	// Format
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getFormat();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Schema getAdditionalPropertiesSchema(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getFormat(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setAdditionalPropertiesSchema(Schema additionalPropertiesSchema);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setFormat(String format);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean isAdditionalPropertiesSchemaReference();
+	// Default
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Object getDefault();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Reference getAdditionalPropertiesSchemaReference();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Object getDefault(boolean elaborate);
 
-    // AdditionalProperties
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Boolean getAdditionalProperties();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setDefault(Object defaultValue);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Boolean getAdditionalProperties(boolean elaborate);
+	// Nullable
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Boolean getNullable();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean isAdditionalProperties();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Boolean getNullable(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setAdditionalProperties(Boolean additionalProperties);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean isNullable();
 
-    // Description
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getDescription();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setNullable(Boolean nullable);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getDescription(boolean elaborate);
+	// Discriminator
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getDiscriminator();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setDescription(String description);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getDiscriminator(boolean elaborate);
 
-    // Format
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getFormat();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setDiscriminator(String discriminator);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getFormat(boolean elaborate);
+	// ReadOnly
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Boolean getReadOnly();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setFormat(String format);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Boolean getReadOnly(boolean elaborate);
 
-    // Default
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Object getDefault();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean isReadOnly();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Object getDefault(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setReadOnly(Boolean readOnly);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setDefault(Object defaultValue);
+	// WriteOnly
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Boolean getWriteOnly();
 
-    // Nullable
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Boolean getNullable();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Boolean getWriteOnly(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Boolean getNullable(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean isWriteOnly();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean isNullable();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setWriteOnly(Boolean writeOnly);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setNullable(Boolean nullable);
+	// Xml
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Xml getXml();
 
-    // Discriminator
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getDiscriminator();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Xml getXml(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getDiscriminator(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setXml(Xml xml);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setDiscriminator(String discriminator);
+	// ExternalDocs
+	@Generated("com.reprezen.gen.CodeGenerator")
+	ExternalDocs getExternalDocs();
 
-    // ReadOnly
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Boolean getReadOnly();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	ExternalDocs getExternalDocs(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Boolean getReadOnly(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setExternalDocs(ExternalDocs externalDocs);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean isReadOnly();
+	// Example
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Example> getExamples();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setReadOnly(Boolean readOnly);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Example> getExamples(boolean elaborate);
 
-    // WriteOnly
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Boolean getWriteOnly();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasExample(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Boolean getWriteOnly(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Example getExample(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean isWriteOnly();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setExamples(Map<String, Example> examples);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setWriteOnly(Boolean writeOnly);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setExample(String name, Example example);
 
-    // Xml
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Xml getXml();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeExample(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Xml getXml(boolean elaborate);
+	// Example
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Object getExample();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setXml(Xml xml);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Object getExample(boolean elaborate);
 
-    // ExternalDocs
-    @Generated("com.reprezen.gen.CodeGenerator")
-    ExternalDocs getExternalDocs();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setExample(Object example);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    ExternalDocs getExternalDocs(boolean elaborate);
+	// Deprecated
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Boolean getDeprecated();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setExternalDocs(ExternalDocs externalDocs);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Boolean getDeprecated(boolean elaborate);
 
-    // Example
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Example> getExamples();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean isDeprecated();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Example> getExamples(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setDeprecated(Boolean deprecated);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasExample(String name);
+	// Extension
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Object> getExtensions();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Example getExample(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Object> getExtensions(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setExamples(Map<String, Example> examples);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasExtension(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setExample(String name, Example example);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Object getExtension(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeExample(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setExtensions(Map<String, Object> extensions);
 
-    // Example
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Object getExample();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setExtension(String name, Object extension);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Object getExample(boolean elaborate);
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setExample(Object example);
-
-    // Deprecated
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Boolean getDeprecated();
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Boolean getDeprecated(boolean elaborate);
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean isDeprecated();
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setDeprecated(Boolean deprecated);
-
-    // Extension
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Object> getExtensions();
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Object> getExtensions(boolean elaborate);
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasExtension(String name);
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Object getExtension(String name);
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setExtensions(Map<String, Object> extensions);
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setExtension(String name, Object extension);
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeExtension(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeExtension(String name);
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/SecurityParameter.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/SecurityParameter.java
@@ -1,37 +1,39 @@
 package com.reprezen.kaizen.oasparser.model3;
 
-import com.reprezen.jsonoverlay.IPropertiesOverlay;
-import com.reprezen.jsonoverlay.IModelPart;
-import javax.annotation.Generated;
 import java.util.Collection;
 
-public interface SecurityParameter extends IPropertiesOverlay<SecurityParameter>, IModelPart<OpenApi3, SecurityParameter> {
+import javax.annotation.Generated;
 
-    // Parameter
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Collection<String> getParameters();
+import com.reprezen.jsonoverlay.IJsonOverlay;
+import com.reprezen.jsonoverlay.IModelPart;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Collection<String> getParameters(boolean elaborate);
+public interface SecurityParameter extends IJsonOverlay<SecurityParameter>, IModelPart<OpenApi3, SecurityParameter> {
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasParameters();
+	// Parameter
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Collection<String> getParameters();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getParameter(int index);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Collection<String> getParameters(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setParameters(Collection<String> parameters);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasParameters();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setParameter(int index, String parameter);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getParameter(int index);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void addParameter(String parameter);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setParameters(Collection<String> parameters);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void insertParameter(int index, String parameter);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setParameter(int index, String parameter);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeParameter(int index);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void addParameter(String parameter);
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void insertParameter(int index, String parameter);
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeParameter(int index);
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/SecurityRequirement.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/SecurityRequirement.java
@@ -1,32 +1,34 @@
 package com.reprezen.kaizen.oasparser.model3;
 
-import com.reprezen.jsonoverlay.IPropertiesOverlay;
-import com.reprezen.jsonoverlay.IModelPart;
-import javax.annotation.Generated;
 import java.util.Map;
-import com.reprezen.kaizen.oasparser.model3.SecurityParameter;
 
-public interface SecurityRequirement extends IPropertiesOverlay<SecurityRequirement>, IModelPart<OpenApi3, SecurityRequirement> {
+import javax.annotation.Generated;
 
-    // Requirement
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, SecurityParameter> getRequirements();
+import com.reprezen.jsonoverlay.IJsonOverlay;
+import com.reprezen.jsonoverlay.IModelPart;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, SecurityParameter> getRequirements(boolean elaborate);
+public interface SecurityRequirement
+		extends IJsonOverlay<SecurityRequirement>, IModelPart<OpenApi3, SecurityRequirement> {
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasRequirement(String name);
+	// Requirement
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, SecurityParameter> getRequirements();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    SecurityParameter getRequirement(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, SecurityParameter> getRequirements(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setRequirements(Map<String, SecurityParameter> requirements);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasRequirement(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setRequirement(String name, SecurityParameter requirement);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	SecurityParameter getRequirement(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeRequirement(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setRequirements(Map<String, SecurityParameter> requirements);
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setRequirement(String name, SecurityParameter requirement);
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeRequirement(String name);
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/SecurityScheme.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/SecurityScheme.java
@@ -1,164 +1,165 @@
 package com.reprezen.kaizen.oasparser.model3;
 
-import com.reprezen.jsonoverlay.IPropertiesOverlay;
-import com.reprezen.jsonoverlay.IModelPart;
-import javax.annotation.Generated;
 import java.util.Map;
-import com.reprezen.kaizen.oasparser.model3.OAuthFlow;
 
-public interface SecurityScheme extends IPropertiesOverlay<SecurityScheme>, IModelPart<OpenApi3, SecurityScheme> {
+import javax.annotation.Generated;
 
-    // Type
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getType();
+import com.reprezen.jsonoverlay.IJsonOverlay;
+import com.reprezen.jsonoverlay.IModelPart;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getType(boolean elaborate);
+public interface SecurityScheme extends IJsonOverlay<SecurityScheme>, IModelPart<OpenApi3, SecurityScheme> {
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setType(String type);
+	// Type
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getType();
 
-    // Description
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getDescription();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getType(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getDescription(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setType(String type);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setDescription(String description);
+	// Description
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getDescription();
 
-    // Name
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getName();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getDescription(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getName(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setDescription(String description);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setName(String name);
+	// Name
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getName();
 
-    // In
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getIn();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getName(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getIn(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setName(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setIn(String in);
+	// In
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getIn();
 
-    // Scheme
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getScheme();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getIn(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getScheme(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setIn(String in);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setScheme(String scheme);
+	// Scheme
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getScheme();
 
-    // BearerFormat
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getBearerFormat();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getScheme(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getBearerFormat(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setScheme(String scheme);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setBearerFormat(String bearerFormat);
+	// BearerFormat
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getBearerFormat();
 
-    // ImplicitOAuthFlow
-    @Generated("com.reprezen.gen.CodeGenerator")
-    OAuthFlow getImplicitOAuthFlow();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getBearerFormat(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    OAuthFlow getImplicitOAuthFlow(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setBearerFormat(String bearerFormat);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setImplicitOAuthFlow(OAuthFlow implicitOAuthFlow);
+	// ImplicitOAuthFlow
+	@Generated("com.reprezen.gen.CodeGenerator")
+	OAuthFlow getImplicitOAuthFlow();
 
-    // PasswordOAuthFlow
-    @Generated("com.reprezen.gen.CodeGenerator")
-    OAuthFlow getPasswordOAuthFlow();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	OAuthFlow getImplicitOAuthFlow(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    OAuthFlow getPasswordOAuthFlow(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setImplicitOAuthFlow(OAuthFlow implicitOAuthFlow);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setPasswordOAuthFlow(OAuthFlow passwordOAuthFlow);
+	// PasswordOAuthFlow
+	@Generated("com.reprezen.gen.CodeGenerator")
+	OAuthFlow getPasswordOAuthFlow();
 
-    // ClientCredentialsOAuthFlow
-    @Generated("com.reprezen.gen.CodeGenerator")
-    OAuthFlow getClientCredentialsOAuthFlow();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	OAuthFlow getPasswordOAuthFlow(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    OAuthFlow getClientCredentialsOAuthFlow(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setPasswordOAuthFlow(OAuthFlow passwordOAuthFlow);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setClientCredentialsOAuthFlow(OAuthFlow clientCredentialsOAuthFlow);
+	// ClientCredentialsOAuthFlow
+	@Generated("com.reprezen.gen.CodeGenerator")
+	OAuthFlow getClientCredentialsOAuthFlow();
 
-    // AuthorizationCodeOAuthFlow
-    @Generated("com.reprezen.gen.CodeGenerator")
-    OAuthFlow getAuthorizationCodeOAuthFlow();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	OAuthFlow getClientCredentialsOAuthFlow(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    OAuthFlow getAuthorizationCodeOAuthFlow(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setClientCredentialsOAuthFlow(OAuthFlow clientCredentialsOAuthFlow);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setAuthorizationCodeOAuthFlow(OAuthFlow authorizationCodeOAuthFlow);
+	// AuthorizationCodeOAuthFlow
+	@Generated("com.reprezen.gen.CodeGenerator")
+	OAuthFlow getAuthorizationCodeOAuthFlow();
 
-    // OAuthFlowsExtension
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Object> getOAuthFlowsExtensions();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	OAuthFlow getAuthorizationCodeOAuthFlow(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Object> getOAuthFlowsExtensions(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setAuthorizationCodeOAuthFlow(OAuthFlow authorizationCodeOAuthFlow);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasOAuthFlowsExtension(String name);
+	// OAuthFlowsExtension
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Object> getOAuthFlowsExtensions();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Object getOAuthFlowsExtension(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Object> getOAuthFlowsExtensions(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setOAuthFlowsExtensions(Map<String, Object> oAuthFlowsExtensions);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasOAuthFlowsExtension(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setOAuthFlowsExtension(String name, Object oAuthFlowsExtension);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Object getOAuthFlowsExtension(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeOAuthFlowsExtension(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setOAuthFlowsExtensions(Map<String, Object> oAuthFlowsExtensions);
 
-    // OpenIdConnectUrl
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getOpenIdConnectUrl();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setOAuthFlowsExtension(String name, Object oAuthFlowsExtension);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getOpenIdConnectUrl(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeOAuthFlowsExtension(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setOpenIdConnectUrl(String openIdConnectUrl);
+	// OpenIdConnectUrl
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getOpenIdConnectUrl();
 
-    // Extension
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Object> getExtensions();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getOpenIdConnectUrl(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Object> getExtensions(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setOpenIdConnectUrl(String openIdConnectUrl);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasExtension(String name);
+	// Extension
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Object> getExtensions();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Object getExtension(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Object> getExtensions(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setExtensions(Map<String, Object> extensions);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasExtension(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setExtension(String name, Object extension);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Object getExtension(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeExtension(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setExtensions(Map<String, Object> extensions);
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setExtension(String name, Object extension);
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeExtension(String name);
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Server.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Server.java
@@ -1,96 +1,97 @@
 package com.reprezen.kaizen.oasparser.model3;
 
-import com.reprezen.jsonoverlay.IPropertiesOverlay;
-import com.reprezen.jsonoverlay.IModelPart;
-import javax.annotation.Generated;
 import java.util.Map;
-import com.reprezen.kaizen.oasparser.model3.ServerVariable;
 
-public interface Server extends IPropertiesOverlay<Server>, IModelPart<OpenApi3, Server> {
+import javax.annotation.Generated;
 
-    // Url
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getUrl();
+import com.reprezen.jsonoverlay.IJsonOverlay;
+import com.reprezen.jsonoverlay.IModelPart;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getUrl(boolean elaborate);
+public interface Server extends IJsonOverlay<Server>, IModelPart<OpenApi3, Server> {
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setUrl(String url);
+	// Url
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getUrl();
 
-    // Description
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getDescription();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getUrl(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getDescription(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setUrl(String url);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setDescription(String description);
+	// Description
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getDescription();
 
-    // ServerVariable
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, ServerVariable> getServerVariables();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getDescription(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, ServerVariable> getServerVariables(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setDescription(String description);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasServerVariable(String name);
+	// ServerVariable
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, ServerVariable> getServerVariables();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    ServerVariable getServerVariable(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, ServerVariable> getServerVariables(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setServerVariables(Map<String, ServerVariable> serverVariables);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasServerVariable(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setServerVariable(String name, ServerVariable serverVariable);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	ServerVariable getServerVariable(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeServerVariable(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setServerVariables(Map<String, ServerVariable> serverVariables);
 
-    // VariablesExtension
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Object> getVariablesExtensions();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setServerVariable(String name, ServerVariable serverVariable);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Object> getVariablesExtensions(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeServerVariable(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasVariablesExtension(String name);
+	// VariablesExtension
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Object> getVariablesExtensions();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Object getVariablesExtension(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Object> getVariablesExtensions(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setVariablesExtensions(Map<String, Object> variablesExtensions);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasVariablesExtension(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setVariablesExtension(String name, Object variablesExtension);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Object getVariablesExtension(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeVariablesExtension(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setVariablesExtensions(Map<String, Object> variablesExtensions);
 
-    // Extension
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Object> getExtensions();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setVariablesExtension(String name, Object variablesExtension);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Object> getExtensions(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeVariablesExtension(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasExtension(String name);
+	// Extension
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Object> getExtensions();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Object getExtension(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Object> getExtensions(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setExtensions(Map<String, Object> extensions);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasExtension(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setExtension(String name, Object extension);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Object getExtension(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeExtension(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setExtensions(Map<String, Object> extensions);
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setExtension(String name, Object extension);
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeExtension(String name);
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/ServerVariable.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/ServerVariable.java
@@ -1,80 +1,82 @@
 package com.reprezen.kaizen.oasparser.model3;
 
-import com.reprezen.jsonoverlay.IPropertiesOverlay;
-import com.reprezen.jsonoverlay.IModelPart;
-import javax.annotation.Generated;
 import java.util.Collection;
 import java.util.Map;
 
-public interface ServerVariable extends IPropertiesOverlay<ServerVariable>, IModelPart<OpenApi3, ServerVariable> {
+import javax.annotation.Generated;
 
-    // EnumValue
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Collection<Object> getEnumValues();
+import com.reprezen.jsonoverlay.IJsonOverlay;
+import com.reprezen.jsonoverlay.IModelPart;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Collection<Object> getEnumValues(boolean elaborate);
+public interface ServerVariable extends IJsonOverlay<ServerVariable>, IModelPart<OpenApi3, ServerVariable> {
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasEnumValues();
+	// EnumValue
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Collection<Object> getEnumValues();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Object getEnumValue(int index);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Collection<Object> getEnumValues(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setEnumValues(Collection<Object> enumValues);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasEnumValues();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setEnumValue(int index, Object enumValue);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Object getEnumValue(int index);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void addEnumValue(Object enumValue);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setEnumValues(Collection<Object> enumValues);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void insertEnumValue(int index, Object enumValue);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setEnumValue(int index, Object enumValue);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeEnumValue(int index);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void addEnumValue(Object enumValue);
 
-    // Default
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Object getDefault();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void insertEnumValue(int index, Object enumValue);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Object getDefault(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeEnumValue(int index);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setDefault(Object defaultValue);
+	// Default
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Object getDefault();
 
-    // Description
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getDescription();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Object getDefault(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getDescription(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setDefault(Object defaultValue);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setDescription(String description);
+	// Description
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getDescription();
 
-    // Extension
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Object> getExtensions();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getDescription(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Object> getExtensions(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setDescription(String description);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasExtension(String name);
+	// Extension
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Object> getExtensions();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Object getExtension(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Object> getExtensions(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setExtensions(Map<String, Object> extensions);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasExtension(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setExtension(String name, Object extension);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Object getExtension(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeExtension(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setExtensions(Map<String, Object> extensions);
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setExtension(String name, Object extension);
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeExtension(String name);
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Tag.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Tag.java
@@ -1,62 +1,63 @@
 package com.reprezen.kaizen.oasparser.model3;
 
-import com.reprezen.jsonoverlay.IPropertiesOverlay;
-import com.reprezen.jsonoverlay.IModelPart;
-import javax.annotation.Generated;
 import java.util.Map;
-import com.reprezen.kaizen.oasparser.model3.ExternalDocs;
 
-public interface Tag extends IPropertiesOverlay<Tag>, IModelPart<OpenApi3, Tag> {
+import javax.annotation.Generated;
 
-    // Name
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getName();
+import com.reprezen.jsonoverlay.IJsonOverlay;
+import com.reprezen.jsonoverlay.IModelPart;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getName(boolean elaborate);
+public interface Tag extends IJsonOverlay<Tag>, IModelPart<OpenApi3, Tag> {
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setName(String name);
+	// Name
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getName();
 
-    // Description
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getDescription();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getName(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getDescription(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setName(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setDescription(String description);
+	// Description
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getDescription();
 
-    // ExternalDocs
-    @Generated("com.reprezen.gen.CodeGenerator")
-    ExternalDocs getExternalDocs();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getDescription(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    ExternalDocs getExternalDocs(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setDescription(String description);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setExternalDocs(ExternalDocs externalDocs);
+	// ExternalDocs
+	@Generated("com.reprezen.gen.CodeGenerator")
+	ExternalDocs getExternalDocs();
 
-    // Extension
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Object> getExtensions();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	ExternalDocs getExternalDocs(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Object> getExtensions(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setExternalDocs(ExternalDocs externalDocs);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasExtension(String name);
+	// Extension
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Object> getExtensions();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Object getExtension(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Object> getExtensions(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setExtensions(Map<String, Object> extensions);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasExtension(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setExtension(String name, Object extension);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Object getExtension(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeExtension(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setExtensions(Map<String, Object> extensions);
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setExtension(String name, Object extension);
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeExtension(String name);
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Xml.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Xml.java
@@ -1,87 +1,89 @@
 package com.reprezen.kaizen.oasparser.model3;
 
-import com.reprezen.jsonoverlay.IPropertiesOverlay;
-import com.reprezen.jsonoverlay.IModelPart;
-import javax.annotation.Generated;
 import java.util.Map;
 
-public interface Xml extends IPropertiesOverlay<Xml>, IModelPart<OpenApi3, Xml> {
+import javax.annotation.Generated;
 
-    // Name
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getName();
+import com.reprezen.jsonoverlay.IJsonOverlay;
+import com.reprezen.jsonoverlay.IModelPart;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getName(boolean elaborate);
+public interface Xml extends IJsonOverlay<Xml>, IModelPart<OpenApi3, Xml> {
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setName(String name);
+	// Name
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getName();
 
-    // Namespace
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getNamespace();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getName(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getNamespace(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setName(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setNamespace(String namespace);
+	// Namespace
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getNamespace();
 
-    // Prefix
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getPrefix();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getNamespace(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    String getPrefix(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setNamespace(String namespace);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setPrefix(String prefix);
+	// Prefix
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getPrefix();
 
-    // Attribute
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Boolean getAttribute();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	String getPrefix(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Boolean getAttribute(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setPrefix(String prefix);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean isAttribute();
+	// Attribute
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Boolean getAttribute();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setAttribute(Boolean attribute);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Boolean getAttribute(boolean elaborate);
 
-    // Wrapped
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Boolean getWrapped();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean isAttribute();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Boolean getWrapped(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setAttribute(Boolean attribute);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean isWrapped();
+	// Wrapped
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Boolean getWrapped();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setWrapped(Boolean wrapped);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Boolean getWrapped(boolean elaborate);
 
-    // Extension
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Object> getExtensions();
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean isWrapped();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Map<String, Object> getExtensions(boolean elaborate);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setWrapped(Boolean wrapped);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    boolean hasExtension(String name);
+	// Extension
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Object> getExtensions();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    Object getExtension(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Map<String, Object> getExtensions(boolean elaborate);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setExtensions(Map<String, Object> extensions);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	boolean hasExtension(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void setExtension(String name, Object extension);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	Object getExtension(String name);
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    void removeExtension(String name);
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setExtensions(Map<String, Object> extensions);
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void setExtension(String name, Object extension);
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	void removeExtension(String name);
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/CallbackImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/CallbackImpl.java
@@ -1,166 +1,166 @@
 package com.reprezen.kaizen.oasparser.ovl3;
 
-import com.reprezen.jsonoverlay.ReferenceRegistry;
-import com.reprezen.kaizen.oasparser.model3.Path;
+import java.util.Map;
+
+import javax.annotation.Generated;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.reprezen.jsonoverlay.AbstractJsonOverlay;
 import com.reprezen.jsonoverlay.ChildMapOverlay;
+import com.reprezen.jsonoverlay.JsonOverlay;
 import com.reprezen.jsonoverlay.ObjectOverlay;
-import com.reprezen.jsonoverlay.MapOverlay;
-import com.reprezen.kaizen.oasparser.ovl3.PathImpl;
-import java.util.stream.Collectors;
-import com.reprezen.kaizen.oasparser.model3.*;
 import com.reprezen.jsonoverlay.OverlayFactory;
 import com.reprezen.jsonoverlay.PropertiesOverlay;
-import javax.annotation.Generated;
-import com.fasterxml.jackson.core.JsonPointer;
-import com.reprezen.jsonoverlay.IJsonOverlay;
-import com.reprezen.jsonoverlay.JsonOverlay;
-import java.util.Map;
-import com.fasterxml.jackson.databind.JsonNode;
+import com.reprezen.jsonoverlay.ReferenceRegistry;
+import com.reprezen.kaizen.oasparser.model3.Callback;
+import com.reprezen.kaizen.oasparser.model3.Path;
 
 public class CallbackImpl extends PropertiesOverlay<Callback> implements Callback {
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public CallbackImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        super(json, parent, refReg);
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public CallbackImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+		super(json, parent, refReg);
+	}
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public CallbackImpl(Callback callback, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        super(callback, parent, refReg);
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public CallbackImpl(Callback callback, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+		super(callback, parent, refReg);
+	}
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildMapOverlay<Path> callbackPaths;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildMapOverlay<Path> callbackPaths;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildMapOverlay<Object> extensions;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildMapOverlay<Object> extensions;
 
-    // CallbackPath
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Path> getCallbackPaths() {
-        return callbackPaths.get();
-    }
+	// CallbackPath
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Path> getCallbackPaths() {
+		return callbackPaths._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Path> getCallbackPaths(boolean elaborate) {
-        return callbackPaths.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Path> getCallbackPaths(boolean elaborate) {
+		return callbackPaths._get(elaborate);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasCallbackPath(String expression) {
-        return callbackPaths.containsKey(expression);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasCallbackPath(String expression) {
+		return callbackPaths.containsKey(expression);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Path getCallbackPath(String expression) {
-        return callbackPaths.get(expression);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Path getCallbackPath(String expression) {
+		return callbackPaths._get(expression);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setCallbackPaths(Map<String, Path> callbackPaths) {
-        this.callbackPaths.set(callbackPaths);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setCallbackPaths(Map<String, Path> callbackPaths) {
+		this.callbackPaths._set(callbackPaths);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setCallbackPath(String expression, Path callbackPath) {
-        callbackPaths.set(expression, callbackPath);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setCallbackPath(String expression, Path callbackPath) {
+		callbackPaths._set(expression, callbackPath);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeCallbackPath(String expression) {
-        callbackPaths.remove(expression);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeCallbackPath(String expression) {
+		callbackPaths._remove(expression);
+	}
 
-    // Extension
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Object> getExtensions() {
-        return extensions.get();
-    }
+	// Extension
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Object> getExtensions() {
+		return extensions._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Object> getExtensions(boolean elaborate) {
-        return extensions.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Object> getExtensions(boolean elaborate) {
+		return extensions._get(elaborate);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasExtension(String name) {
-        return extensions.containsKey(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasExtension(String name) {
+		return extensions.containsKey(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Object getExtension(String name) {
-        return extensions.get(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Object getExtension(String name) {
+		return extensions._get(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setExtensions(Map<String, Object> extensions) {
-        this.extensions.set(extensions);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setExtensions(Map<String, Object> extensions) {
+		this.extensions._set(extensions);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setExtension(String name, Object extension) {
-        extensions.set(name, extension);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setExtension(String name, Object extension) {
+		extensions._set(name, extension);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeExtension(String name) {
-        extensions.remove(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeExtension(String name) {
+		extensions._remove(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    protected void elaborateChildren() {
-        super.elaborateChildren();
-        callbackPaths = createChildMap("", this, PathImpl.factory, "(?!x-).*");
-        extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	protected void elaborateChildren() {
+		super.elaborateChildren();
+		callbackPaths = createChildMap("", this, PathImpl.factory, "(?!x-).*");
+		extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
+	}
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public static OverlayFactory<Callback> factory = new OverlayFactory<Callback>() {
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public static OverlayFactory<Callback> factory = new OverlayFactory<Callback>() {
 
-        @Override
-        protected Class<? extends IJsonOverlay<? super Callback>> getOverlayClass() {
-            return CallbackImpl.class;
-        }
+		@Override
+		protected Class<? extends AbstractJsonOverlay<? super Callback>> getOverlayClass() {
+			return CallbackImpl.class;
+		}
 
-        @Override
-        public JsonOverlay<Callback> _create(Callback callback, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            IJsonOverlay<?> overlay;
-            overlay = new CallbackImpl(callback, parent, refReg);
-            @SuppressWarnings("unchecked") JsonOverlay<Callback> castOverlay = (JsonOverlay<Callback>) overlay;
-            return castOverlay;
-        }
+		@Override
+		public JsonOverlay<Callback> _create(Callback callback, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+			AbstractJsonOverlay<?> overlay;
+			overlay = new CallbackImpl(callback, parent, refReg);
+			@SuppressWarnings("unchecked")
+			JsonOverlay<Callback> castOverlay = (JsonOverlay<Callback>) overlay;
+			return castOverlay;
+		}
 
-        @Override
-        public JsonOverlay<Callback> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            IJsonOverlay<?> overlay;
-            overlay = new CallbackImpl(json, parent, refReg);
-            @SuppressWarnings("unchecked") JsonOverlay<Callback> castOverlay = (JsonOverlay<Callback>) overlay;
-            return castOverlay;
-        }
-    };
+		@Override
+		public JsonOverlay<Callback> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+			AbstractJsonOverlay<?> overlay;
+			overlay = new CallbackImpl(json, parent, refReg);
+			@SuppressWarnings("unchecked")
+			JsonOverlay<Callback> castOverlay = (JsonOverlay<Callback>) overlay;
+			return castOverlay;
+		}
+	};
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private static Class<? extends Callback> getSubtypeOf(Callback callback) {
-        return Callback.class;
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private static Class<? extends Callback> getSubtypeOf(Callback callback) {
+		return Callback.class;
+	}
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private static Class<? extends Callback> getSubtypeOf(JsonNode json) {
-        return Callback.class;
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private static Class<? extends Callback> getSubtypeOf(JsonNode json) {
+		return Callback.class;
+	}
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ContactImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ContactImpl.java
@@ -1,188 +1,189 @@
 package com.reprezen.kaizen.oasparser.ovl3;
 
-import com.reprezen.jsonoverlay.StringOverlay;
-import com.reprezen.jsonoverlay.ReferenceRegistry;
+import java.util.Map;
+
+import javax.annotation.Generated;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.reprezen.jsonoverlay.AbstractJsonOverlay;
 import com.reprezen.jsonoverlay.ChildMapOverlay;
+import com.reprezen.jsonoverlay.ChildOverlay;
+import com.reprezen.jsonoverlay.JsonOverlay;
 import com.reprezen.jsonoverlay.ObjectOverlay;
-import com.reprezen.jsonoverlay.MapOverlay;
-import java.util.stream.Collectors;
-import com.reprezen.kaizen.oasparser.model3.*;
 import com.reprezen.jsonoverlay.OverlayFactory;
 import com.reprezen.jsonoverlay.PropertiesOverlay;
-import javax.annotation.Generated;
-import com.fasterxml.jackson.core.JsonPointer;
-import com.reprezen.jsonoverlay.IJsonOverlay;
-import com.reprezen.jsonoverlay.JsonOverlay;
-import java.util.Map;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.reprezen.jsonoverlay.ChildOverlay;
+import com.reprezen.jsonoverlay.ReferenceRegistry;
+import com.reprezen.jsonoverlay.StringOverlay;
+import com.reprezen.kaizen.oasparser.model3.Contact;
 
 public class ContactImpl extends PropertiesOverlay<Contact> implements Contact {
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public ContactImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        super(json, parent, refReg);
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public ContactImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+		super(json, parent, refReg);
+	}
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public ContactImpl(Contact contact, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        super(contact, parent, refReg);
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public ContactImpl(Contact contact, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+		super(contact, parent, refReg);
+	}
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<String> name;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<String> name;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<String> url;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<String> url;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<String> email;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<String> email;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildMapOverlay<Object> extensions;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildMapOverlay<Object> extensions;
 
-    // Name
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getName() {
-        return name.get();
-    }
+	// Name
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getName() {
+		return name._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getName(boolean elaborate) {
-        return name.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getName(boolean elaborate) {
+		return name._get(elaborate);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setName(String name) {
-        this.name.set(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setName(String name) {
+		this.name._set(name);
+	}
 
-    // Url
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getUrl() {
-        return url.get();
-    }
+	// Url
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getUrl() {
+		return url._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getUrl(boolean elaborate) {
-        return url.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getUrl(boolean elaborate) {
+		return url._get(elaborate);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setUrl(String url) {
-        this.url.set(url);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setUrl(String url) {
+		this.url._set(url);
+	}
 
-    // Email
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getEmail() {
-        return email.get();
-    }
+	// Email
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getEmail() {
+		return email._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getEmail(boolean elaborate) {
-        return email.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getEmail(boolean elaborate) {
+		return email._get(elaborate);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setEmail(String email) {
-        this.email.set(email);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setEmail(String email) {
+		this.email._set(email);
+	}
 
-    // Extension
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Object> getExtensions() {
-        return extensions.get();
-    }
+	// Extension
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Object> getExtensions() {
+		return extensions._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Object> getExtensions(boolean elaborate) {
-        return extensions.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Object> getExtensions(boolean elaborate) {
+		return extensions._get(elaborate);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasExtension(String name) {
-        return extensions.containsKey(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasExtension(String name) {
+		return extensions.containsKey(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Object getExtension(String name) {
-        return extensions.get(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Object getExtension(String name) {
+		return extensions._get(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setExtensions(Map<String, Object> extensions) {
-        this.extensions.set(extensions);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setExtensions(Map<String, Object> extensions) {
+		this.extensions._set(extensions);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setExtension(String name, Object extension) {
-        extensions.set(name, extension);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setExtension(String name, Object extension) {
+		extensions._set(name, extension);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeExtension(String name) {
-        extensions.remove(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeExtension(String name) {
+		extensions._remove(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    protected void elaborateChildren() {
-        super.elaborateChildren();
-        name = createChild("name", this, StringOverlay.factory);
-        url = createChild("url", this, StringOverlay.factory);
-        email = createChild("email", this, StringOverlay.factory);
-        extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	protected void elaborateChildren() {
+		super.elaborateChildren();
+		name = createChild("name", this, StringOverlay.factory);
+		url = createChild("url", this, StringOverlay.factory);
+		email = createChild("email", this, StringOverlay.factory);
+		extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
+	}
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public static OverlayFactory<Contact> factory = new OverlayFactory<Contact>() {
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public static OverlayFactory<Contact> factory = new OverlayFactory<Contact>() {
 
-        @Override
-        protected Class<? extends IJsonOverlay<? super Contact>> getOverlayClass() {
-            return ContactImpl.class;
-        }
+		@Override
+		protected Class<? extends AbstractJsonOverlay<? super Contact>> getOverlayClass() {
+			return ContactImpl.class;
+		}
 
-        @Override
-        public JsonOverlay<Contact> _create(Contact contact, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            IJsonOverlay<?> overlay;
-            overlay = new ContactImpl(contact, parent, refReg);
-            @SuppressWarnings("unchecked") JsonOverlay<Contact> castOverlay = (JsonOverlay<Contact>) overlay;
-            return castOverlay;
-        }
+		@Override
+		public JsonOverlay<Contact> _create(Contact contact, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+			AbstractJsonOverlay<?> overlay;
+			overlay = new ContactImpl(contact, parent, refReg);
+			@SuppressWarnings("unchecked")
+			JsonOverlay<Contact> castOverlay = (JsonOverlay<Contact>) overlay;
+			return castOverlay;
+		}
 
-        @Override
-        public JsonOverlay<Contact> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            IJsonOverlay<?> overlay;
-            overlay = new ContactImpl(json, parent, refReg);
-            @SuppressWarnings("unchecked") JsonOverlay<Contact> castOverlay = (JsonOverlay<Contact>) overlay;
-            return castOverlay;
-        }
-    };
+		@Override
+		public JsonOverlay<Contact> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+			AbstractJsonOverlay<?> overlay;
+			overlay = new ContactImpl(json, parent, refReg);
+			@SuppressWarnings("unchecked")
+			JsonOverlay<Contact> castOverlay = (JsonOverlay<Contact>) overlay;
+			return castOverlay;
+		}
+	};
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private static Class<? extends Contact> getSubtypeOf(Contact contact) {
-        return Contact.class;
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private static Class<? extends Contact> getSubtypeOf(Contact contact) {
+		return Contact.class;
+	}
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private static Class<? extends Contact> getSubtypeOf(JsonNode json) {
-        return Contact.class;
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private static Class<? extends Contact> getSubtypeOf(JsonNode json) {
+		return Contact.class;
+	}
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/EncodingPropertyImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/EncodingPropertyImpl.java
@@ -1,258 +1,244 @@
 package com.reprezen.kaizen.oasparser.ovl3;
 
-import com.reprezen.jsonoverlay.StringOverlay;
-import com.reprezen.jsonoverlay.ReferenceRegistry;
-import com.reprezen.jsonoverlay.ChildMapOverlay;
-import com.reprezen.jsonoverlay.Reference;
-import com.reprezen.jsonoverlay.ObjectOverlay;
+import java.util.Map;
+
+import javax.annotation.Generated;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.reprezen.jsonoverlay.AbstractJsonOverlay;
 import com.reprezen.jsonoverlay.BooleanOverlay;
-import com.reprezen.jsonoverlay.MapOverlay;
-import java.util.stream.Collectors;
-import com.reprezen.kaizen.oasparser.model3.*;
+import com.reprezen.jsonoverlay.ChildMapOverlay;
+import com.reprezen.jsonoverlay.ChildOverlay;
+import com.reprezen.jsonoverlay.JsonOverlay;
+import com.reprezen.jsonoverlay.ObjectOverlay;
 import com.reprezen.jsonoverlay.OverlayFactory;
 import com.reprezen.jsonoverlay.PropertiesOverlay;
-import javax.annotation.Generated;
-import com.fasterxml.jackson.core.JsonPointer;
-import com.reprezen.jsonoverlay.IJsonOverlay;
-import com.reprezen.jsonoverlay.JsonOverlay;
-import java.util.Map;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.reprezen.jsonoverlay.ChildOverlay;
+import com.reprezen.jsonoverlay.ReferenceRegistry;
+import com.reprezen.jsonoverlay.StringOverlay;
+import com.reprezen.kaizen.oasparser.model3.EncodingProperty;
 
 public class EncodingPropertyImpl extends PropertiesOverlay<EncodingProperty> implements EncodingProperty {
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public EncodingPropertyImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        super(json, parent, refReg);
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public EncodingPropertyImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+		super(json, parent, refReg);
+	}
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public EncodingPropertyImpl(EncodingProperty encodingProperty, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        super(encodingProperty, parent, refReg);
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public EncodingPropertyImpl(EncodingProperty encodingProperty, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+		super(encodingProperty, parent, refReg);
+	}
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<String> contentType;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<String> contentType;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildMapOverlay<String> headers;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildMapOverlay<String> headers;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<String> style;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<String> style;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<Boolean> explode;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<Boolean> explode;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildMapOverlay<Object> extensions;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildMapOverlay<Object> extensions;
 
-    // ContentType
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getContentType() {
-        return contentType.get();
-    }
+	// ContentType
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getContentType() {
+		return contentType._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getContentType(boolean elaborate) {
-        return contentType.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getContentType(boolean elaborate) {
+		return contentType._get(elaborate);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setContentType(String contentType) {
-        this.contentType.set(contentType);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setContentType(String contentType) {
+		this.contentType._set(contentType);
+	}
 
-    // Header
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, String> getHeaders() {
-        return headers.get();
-    }
+	// Header
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, String> getHeaders() {
+		return headers._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, String> getHeaders(boolean elaborate) {
-        return headers.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, String> getHeaders(boolean elaborate) {
+		return headers._get(elaborate);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasHeader(String name) {
-        return headers.containsKey(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasHeader(String name) {
+		return headers.containsKey(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getHeader(String name) {
-        return headers.get(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getHeader(String name) {
+		return headers._get(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setHeaders(Map<String, String> headers) {
-        this.headers.set(headers);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setHeaders(Map<String, String> headers) {
+		this.headers._set(headers);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setHeader(String name, String header) {
-        headers.set(name, header);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setHeader(String name, String header) {
+		headers._set(name, header);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeHeader(String name) {
-        headers.remove(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeHeader(String name) {
+		headers._remove(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean isHeaderReference(String name) {
-        ChildOverlay<String> child = headers.getChild(name);
-        return child != null ? child.isReference() : false;
-    }
+	// Style
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getStyle() {
+		return style._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Reference getHeaderReference(String name) {
-        ChildOverlay<String> child = headers.getChild(name);
-        return child != null ? child.getReference() : null;
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getStyle(boolean elaborate) {
+		return style._get(elaborate);
+	}
 
-    // Style
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getStyle() {
-        return style.get();
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setStyle(String style) {
+		this.style._set(style);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getStyle(boolean elaborate) {
-        return style.get(elaborate);
-    }
+	// Explode
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Boolean getExplode() {
+		return explode._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setStyle(String style) {
-        this.style.set(style);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Boolean getExplode(boolean elaborate) {
+		return explode._get(elaborate);
+	}
 
-    // Explode
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Boolean getExplode() {
-        return explode.get();
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean isExplode() {
+		return explode._get() != null ? explode._get() : false;
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Boolean getExplode(boolean elaborate) {
-        return explode.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setExplode(Boolean explode) {
+		this.explode._set(explode);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean isExplode() {
-        return explode.get() != null ? explode.get() : false;
-    }
+	// Extension
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Object> getExtensions() {
+		return extensions._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setExplode(Boolean explode) {
-        this.explode.set(explode);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Object> getExtensions(boolean elaborate) {
+		return extensions._get(elaborate);
+	}
 
-    // Extension
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Object> getExtensions() {
-        return extensions.get();
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasExtension(String name) {
+		return extensions.containsKey(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Object> getExtensions(boolean elaborate) {
-        return extensions.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Object getExtension(String name) {
+		return extensions._get(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasExtension(String name) {
-        return extensions.containsKey(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setExtensions(Map<String, Object> extensions) {
+		this.extensions._set(extensions);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Object getExtension(String name) {
-        return extensions.get(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setExtension(String name, Object extension) {
+		extensions._set(name, extension);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setExtensions(Map<String, Object> extensions) {
-        this.extensions.set(extensions);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeExtension(String name) {
+		extensions._remove(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setExtension(String name, Object extension) {
-        extensions.set(name, extension);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	protected void elaborateChildren() {
+		super.elaborateChildren();
+		contentType = createChild("contentType", this, StringOverlay.factory);
+		headers = createChildMap("headers", this, StringOverlay.factory, null);
+		style = createChild("style", this, StringOverlay.factory);
+		explode = createChild("explode", this, BooleanOverlay.factory);
+		extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeExtension(String name) {
-        extensions.remove(name);
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public static OverlayFactory<EncodingProperty> factory = new OverlayFactory<EncodingProperty>() {
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    protected void elaborateChildren() {
-        super.elaborateChildren();
-        contentType = createChild("contentType", this, StringOverlay.factory);
-        headers = createChildMap("headers", this, StringOverlay.factory, null);
-        refables.put("headers", headers);
-        style = createChild("style", this, StringOverlay.factory);
-        explode = createChild("explode", this, BooleanOverlay.factory);
-        extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
-    }
+		@Override
+		protected Class<? extends AbstractJsonOverlay<? super EncodingProperty>> getOverlayClass() {
+			return EncodingPropertyImpl.class;
+		}
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public static OverlayFactory<EncodingProperty> factory = new OverlayFactory<EncodingProperty>() {
+		@Override
+		public JsonOverlay<EncodingProperty> _create(EncodingProperty encodingProperty, JsonOverlay<?> parent,
+				ReferenceRegistry refReg) {
+			AbstractJsonOverlay<?> overlay;
+			overlay = new EncodingPropertyImpl(encodingProperty, parent, refReg);
+			@SuppressWarnings("unchecked")
+			JsonOverlay<EncodingProperty> castOverlay = (JsonOverlay<EncodingProperty>) overlay;
+			return castOverlay;
+		}
 
-        @Override
-        protected Class<? extends IJsonOverlay<? super EncodingProperty>> getOverlayClass() {
-            return EncodingPropertyImpl.class;
-        }
+		@Override
+		public JsonOverlay<EncodingProperty> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+			AbstractJsonOverlay<?> overlay;
+			overlay = new EncodingPropertyImpl(json, parent, refReg);
+			@SuppressWarnings("unchecked")
+			JsonOverlay<EncodingProperty> castOverlay = (JsonOverlay<EncodingProperty>) overlay;
+			return castOverlay;
+		}
+	};
 
-        @Override
-        public JsonOverlay<EncodingProperty> _create(EncodingProperty encodingProperty, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            IJsonOverlay<?> overlay;
-            overlay = new EncodingPropertyImpl(encodingProperty, parent, refReg);
-            @SuppressWarnings("unchecked") JsonOverlay<EncodingProperty> castOverlay = (JsonOverlay<EncodingProperty>) overlay;
-            return castOverlay;
-        }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private static Class<? extends EncodingProperty> getSubtypeOf(EncodingProperty encodingProperty) {
+		return EncodingProperty.class;
+	}
 
-        @Override
-        public JsonOverlay<EncodingProperty> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            IJsonOverlay<?> overlay;
-            overlay = new EncodingPropertyImpl(json, parent, refReg);
-            @SuppressWarnings("unchecked") JsonOverlay<EncodingProperty> castOverlay = (JsonOverlay<EncodingProperty>) overlay;
-            return castOverlay;
-        }
-    };
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private static Class<? extends EncodingProperty> getSubtypeOf(EncodingProperty encodingProperty) {
-        return EncodingProperty.class;
-    }
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private static Class<? extends EncodingProperty> getSubtypeOf(JsonNode json) {
-        return EncodingProperty.class;
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private static Class<? extends EncodingProperty> getSubtypeOf(JsonNode json) {
+		return EncodingProperty.class;
+	}
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ExampleImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ExampleImpl.java
@@ -1,211 +1,212 @@
 package com.reprezen.kaizen.oasparser.ovl3;
 
-import com.reprezen.jsonoverlay.StringOverlay;
-import com.reprezen.jsonoverlay.ReferenceRegistry;
+import java.util.Map;
+
+import javax.annotation.Generated;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.reprezen.jsonoverlay.AbstractJsonOverlay;
 import com.reprezen.jsonoverlay.ChildMapOverlay;
+import com.reprezen.jsonoverlay.ChildOverlay;
+import com.reprezen.jsonoverlay.JsonOverlay;
 import com.reprezen.jsonoverlay.ObjectOverlay;
-import com.reprezen.jsonoverlay.MapOverlay;
-import java.util.stream.Collectors;
-import com.reprezen.kaizen.oasparser.model3.*;
 import com.reprezen.jsonoverlay.OverlayFactory;
 import com.reprezen.jsonoverlay.PropertiesOverlay;
-import javax.annotation.Generated;
-import com.fasterxml.jackson.core.JsonPointer;
-import com.reprezen.jsonoverlay.IJsonOverlay;
-import com.reprezen.jsonoverlay.JsonOverlay;
-import java.util.Map;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.reprezen.jsonoverlay.ChildOverlay;
+import com.reprezen.jsonoverlay.ReferenceRegistry;
+import com.reprezen.jsonoverlay.StringOverlay;
+import com.reprezen.kaizen.oasparser.model3.Example;
 
 public class ExampleImpl extends PropertiesOverlay<Example> implements Example {
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public ExampleImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        super(json, parent, refReg);
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public ExampleImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+		super(json, parent, refReg);
+	}
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public ExampleImpl(Example example, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        super(example, parent, refReg);
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public ExampleImpl(Example example, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+		super(example, parent, refReg);
+	}
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<String> summary;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<String> summary;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<String> description;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<String> description;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<Object> value;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<Object> value;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<String> externalValue;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<String> externalValue;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildMapOverlay<Object> extensions;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildMapOverlay<Object> extensions;
 
-    // Summary
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getSummary() {
-        return summary.get();
-    }
+	// Summary
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getSummary() {
+		return summary._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getSummary(boolean elaborate) {
-        return summary.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getSummary(boolean elaborate) {
+		return summary._get(elaborate);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setSummary(String summary) {
-        this.summary.set(summary);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setSummary(String summary) {
+		this.summary._set(summary);
+	}
 
-    // Description
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getDescription() {
-        return description.get();
-    }
+	// Description
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getDescription() {
+		return description._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getDescription(boolean elaborate) {
-        return description.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getDescription(boolean elaborate) {
+		return description._get(elaborate);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setDescription(String description) {
-        this.description.set(description);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setDescription(String description) {
+		this.description._set(description);
+	}
 
-    // Value
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Object getValue() {
-        return value.get();
-    }
+	// Value
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Object getValue() {
+		return value._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Object getValue(boolean elaborate) {
-        return value.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Object getValue(boolean elaborate) {
+		return value._get(elaborate);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setValue(Object value) {
-        this.value.set(value);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setValue(Object value) {
+		this.value._set(value);
+	}
 
-    // ExternalValue
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getExternalValue() {
-        return externalValue.get();
-    }
+	// ExternalValue
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getExternalValue() {
+		return externalValue._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getExternalValue(boolean elaborate) {
-        return externalValue.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getExternalValue(boolean elaborate) {
+		return externalValue._get(elaborate);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setExternalValue(String externalValue) {
-        this.externalValue.set(externalValue);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setExternalValue(String externalValue) {
+		this.externalValue._set(externalValue);
+	}
 
-    // Extension
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Object> getExtensions() {
-        return extensions.get();
-    }
+	// Extension
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Object> getExtensions() {
+		return extensions._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Object> getExtensions(boolean elaborate) {
-        return extensions.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Object> getExtensions(boolean elaborate) {
+		return extensions._get(elaborate);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasExtension(String name) {
-        return extensions.containsKey(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasExtension(String name) {
+		return extensions.containsKey(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Object getExtension(String name) {
-        return extensions.get(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Object getExtension(String name) {
+		return extensions._get(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setExtensions(Map<String, Object> extensions) {
-        this.extensions.set(extensions);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setExtensions(Map<String, Object> extensions) {
+		this.extensions._set(extensions);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setExtension(String name, Object extension) {
-        extensions.set(name, extension);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setExtension(String name, Object extension) {
+		extensions._set(name, extension);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeExtension(String name) {
-        extensions.remove(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeExtension(String name) {
+		extensions._remove(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    protected void elaborateChildren() {
-        super.elaborateChildren();
-        summary = createChild("summary", this, StringOverlay.factory);
-        description = createChild("description", this, StringOverlay.factory);
-        value = createChild("value", this, ObjectOverlay.factory);
-        externalValue = createChild("externalValue", this, StringOverlay.factory);
-        extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	protected void elaborateChildren() {
+		super.elaborateChildren();
+		summary = createChild("summary", this, StringOverlay.factory);
+		description = createChild("description", this, StringOverlay.factory);
+		value = createChild("value", this, ObjectOverlay.factory);
+		externalValue = createChild("externalValue", this, StringOverlay.factory);
+		extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
+	}
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public static OverlayFactory<Example> factory = new OverlayFactory<Example>() {
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public static OverlayFactory<Example> factory = new OverlayFactory<Example>() {
 
-        @Override
-        protected Class<? extends IJsonOverlay<? super Example>> getOverlayClass() {
-            return ExampleImpl.class;
-        }
+		@Override
+		protected Class<? extends AbstractJsonOverlay<? super Example>> getOverlayClass() {
+			return ExampleImpl.class;
+		}
 
-        @Override
-        public JsonOverlay<Example> _create(Example example, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            IJsonOverlay<?> overlay;
-            overlay = new ExampleImpl(example, parent, refReg);
-            @SuppressWarnings("unchecked") JsonOverlay<Example> castOverlay = (JsonOverlay<Example>) overlay;
-            return castOverlay;
-        }
+		@Override
+		public JsonOverlay<Example> _create(Example example, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+			AbstractJsonOverlay<?> overlay;
+			overlay = new ExampleImpl(example, parent, refReg);
+			@SuppressWarnings("unchecked")
+			JsonOverlay<Example> castOverlay = (JsonOverlay<Example>) overlay;
+			return castOverlay;
+		}
 
-        @Override
-        public JsonOverlay<Example> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            IJsonOverlay<?> overlay;
-            overlay = new ExampleImpl(json, parent, refReg);
-            @SuppressWarnings("unchecked") JsonOverlay<Example> castOverlay = (JsonOverlay<Example>) overlay;
-            return castOverlay;
-        }
-    };
+		@Override
+		public JsonOverlay<Example> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+			AbstractJsonOverlay<?> overlay;
+			overlay = new ExampleImpl(json, parent, refReg);
+			@SuppressWarnings("unchecked")
+			JsonOverlay<Example> castOverlay = (JsonOverlay<Example>) overlay;
+			return castOverlay;
+		}
+	};
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private static Class<? extends Example> getSubtypeOf(Example example) {
-        return Example.class;
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private static Class<? extends Example> getSubtypeOf(Example example) {
+		return Example.class;
+	}
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private static Class<? extends Example> getSubtypeOf(JsonNode json) {
-        return Example.class;
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private static Class<? extends Example> getSubtypeOf(JsonNode json) {
+		return Example.class;
+	}
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ExternalDocsImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ExternalDocsImpl.java
@@ -1,165 +1,167 @@
 package com.reprezen.kaizen.oasparser.ovl3;
 
-import com.reprezen.jsonoverlay.StringOverlay;
-import com.reprezen.jsonoverlay.ReferenceRegistry;
+import java.util.Map;
+
+import javax.annotation.Generated;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.reprezen.jsonoverlay.AbstractJsonOverlay;
 import com.reprezen.jsonoverlay.ChildMapOverlay;
+import com.reprezen.jsonoverlay.ChildOverlay;
+import com.reprezen.jsonoverlay.JsonOverlay;
 import com.reprezen.jsonoverlay.ObjectOverlay;
-import com.reprezen.jsonoverlay.MapOverlay;
-import java.util.stream.Collectors;
-import com.reprezen.kaizen.oasparser.model3.*;
 import com.reprezen.jsonoverlay.OverlayFactory;
 import com.reprezen.jsonoverlay.PropertiesOverlay;
-import javax.annotation.Generated;
-import com.fasterxml.jackson.core.JsonPointer;
-import com.reprezen.jsonoverlay.IJsonOverlay;
-import com.reprezen.jsonoverlay.JsonOverlay;
-import java.util.Map;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.reprezen.jsonoverlay.ChildOverlay;
+import com.reprezen.jsonoverlay.ReferenceRegistry;
+import com.reprezen.jsonoverlay.StringOverlay;
+import com.reprezen.kaizen.oasparser.model3.ExternalDocs;
 
 public class ExternalDocsImpl extends PropertiesOverlay<ExternalDocs> implements ExternalDocs {
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public ExternalDocsImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        super(json, parent, refReg);
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public ExternalDocsImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+		super(json, parent, refReg);
+	}
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public ExternalDocsImpl(ExternalDocs externalDocs, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        super(externalDocs, parent, refReg);
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public ExternalDocsImpl(ExternalDocs externalDocs, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+		super(externalDocs, parent, refReg);
+	}
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<String> description;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<String> description;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<String> url;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<String> url;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildMapOverlay<Object> extensions;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildMapOverlay<Object> extensions;
 
-    // Description
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getDescription() {
-        return description.get();
-    }
+	// Description
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getDescription() {
+		return description._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getDescription(boolean elaborate) {
-        return description.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getDescription(boolean elaborate) {
+		return description._get(elaborate);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setDescription(String description) {
-        this.description.set(description);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setDescription(String description) {
+		this.description._set(description);
+	}
 
-    // Url
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getUrl() {
-        return url.get();
-    }
+	// Url
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getUrl() {
+		return url._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getUrl(boolean elaborate) {
-        return url.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getUrl(boolean elaborate) {
+		return url._get(elaborate);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setUrl(String url) {
-        this.url.set(url);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setUrl(String url) {
+		this.url._set(url);
+	}
 
-    // Extension
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Object> getExtensions() {
-        return extensions.get();
-    }
+	// Extension
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Object> getExtensions() {
+		return extensions._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Object> getExtensions(boolean elaborate) {
-        return extensions.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Object> getExtensions(boolean elaborate) {
+		return extensions._get(elaborate);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasExtension(String name) {
-        return extensions.containsKey(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasExtension(String name) {
+		return extensions.containsKey(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Object getExtension(String name) {
-        return extensions.get(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Object getExtension(String name) {
+		return extensions._get(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setExtensions(Map<String, Object> extensions) {
-        this.extensions.set(extensions);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setExtensions(Map<String, Object> extensions) {
+		this.extensions._set(extensions);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setExtension(String name, Object extension) {
-        extensions.set(name, extension);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setExtension(String name, Object extension) {
+		extensions._set(name, extension);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeExtension(String name) {
-        extensions.remove(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeExtension(String name) {
+		extensions._remove(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    protected void elaborateChildren() {
-        super.elaborateChildren();
-        description = createChild("description", this, StringOverlay.factory);
-        url = createChild("url", this, StringOverlay.factory);
-        extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	protected void elaborateChildren() {
+		super.elaborateChildren();
+		description = createChild("description", this, StringOverlay.factory);
+		url = createChild("url", this, StringOverlay.factory);
+		extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
+	}
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public static OverlayFactory<ExternalDocs> factory = new OverlayFactory<ExternalDocs>() {
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public static OverlayFactory<ExternalDocs> factory = new OverlayFactory<ExternalDocs>() {
 
-        @Override
-        protected Class<? extends IJsonOverlay<? super ExternalDocs>> getOverlayClass() {
-            return ExternalDocsImpl.class;
-        }
+		@Override
+		protected Class<? extends AbstractJsonOverlay<? super ExternalDocs>> getOverlayClass() {
+			return ExternalDocsImpl.class;
+		}
 
-        @Override
-        public JsonOverlay<ExternalDocs> _create(ExternalDocs externalDocs, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            IJsonOverlay<?> overlay;
-            overlay = new ExternalDocsImpl(externalDocs, parent, refReg);
-            @SuppressWarnings("unchecked") JsonOverlay<ExternalDocs> castOverlay = (JsonOverlay<ExternalDocs>) overlay;
-            return castOverlay;
-        }
+		@Override
+		public JsonOverlay<ExternalDocs> _create(ExternalDocs externalDocs, JsonOverlay<?> parent,
+				ReferenceRegistry refReg) {
+			AbstractJsonOverlay<?> overlay;
+			overlay = new ExternalDocsImpl(externalDocs, parent, refReg);
+			@SuppressWarnings("unchecked")
+			JsonOverlay<ExternalDocs> castOverlay = (JsonOverlay<ExternalDocs>) overlay;
+			return castOverlay;
+		}
 
-        @Override
-        public JsonOverlay<ExternalDocs> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            IJsonOverlay<?> overlay;
-            overlay = new ExternalDocsImpl(json, parent, refReg);
-            @SuppressWarnings("unchecked") JsonOverlay<ExternalDocs> castOverlay = (JsonOverlay<ExternalDocs>) overlay;
-            return castOverlay;
-        }
-    };
+		@Override
+		public JsonOverlay<ExternalDocs> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+			AbstractJsonOverlay<?> overlay;
+			overlay = new ExternalDocsImpl(json, parent, refReg);
+			@SuppressWarnings("unchecked")
+			JsonOverlay<ExternalDocs> castOverlay = (JsonOverlay<ExternalDocs>) overlay;
+			return castOverlay;
+		}
+	};
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private static Class<? extends ExternalDocs> getSubtypeOf(ExternalDocs externalDocs) {
-        return ExternalDocs.class;
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private static Class<? extends ExternalDocs> getSubtypeOf(ExternalDocs externalDocs) {
+		return ExternalDocs.class;
+	}
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private static Class<? extends ExternalDocs> getSubtypeOf(JsonNode json) {
-        return ExternalDocs.class;
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private static Class<? extends ExternalDocs> getSubtypeOf(JsonNode json) {
+		return ExternalDocs.class;
+	}
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/HeaderImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/HeaderImpl.java
@@ -1,532 +1,501 @@
 package com.reprezen.kaizen.oasparser.ovl3;
 
-import com.reprezen.jsonoverlay.StringOverlay;
-import com.reprezen.kaizen.oasparser.model3.Schema;
-import com.reprezen.jsonoverlay.ReferenceRegistry;
-import com.reprezen.jsonoverlay.ChildMapOverlay;
-import com.reprezen.kaizen.oasparser.ovl3.MediaTypeImpl;
-import com.reprezen.kaizen.oasparser.ovl3.ExampleImpl;
-import com.reprezen.jsonoverlay.Reference;
-import com.reprezen.jsonoverlay.ObjectOverlay;
+import java.util.Map;
+
+import javax.annotation.Generated;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.reprezen.jsonoverlay.AbstractJsonOverlay;
 import com.reprezen.jsonoverlay.BooleanOverlay;
-import com.reprezen.jsonoverlay.MapOverlay;
-import java.util.stream.Collectors;
-import com.reprezen.kaizen.oasparser.model3.*;
+import com.reprezen.jsonoverlay.ChildMapOverlay;
+import com.reprezen.jsonoverlay.ChildOverlay;
+import com.reprezen.jsonoverlay.JsonOverlay;
+import com.reprezen.jsonoverlay.ObjectOverlay;
 import com.reprezen.jsonoverlay.OverlayFactory;
 import com.reprezen.jsonoverlay.PropertiesOverlay;
-import com.fasterxml.jackson.core.JsonPointer;
-import javax.annotation.Generated;
-import com.reprezen.kaizen.oasparser.ovl3.SchemaImpl;
-import com.reprezen.kaizen.oasparser.model3.MediaType;
-import com.reprezen.jsonoverlay.IJsonOverlay;
+import com.reprezen.jsonoverlay.ReferenceRegistry;
+import com.reprezen.jsonoverlay.StringOverlay;
 import com.reprezen.kaizen.oasparser.model3.Example;
-import com.reprezen.jsonoverlay.JsonOverlay;
-import java.util.Map;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.reprezen.jsonoverlay.ChildOverlay;
+import com.reprezen.kaizen.oasparser.model3.Header;
+import com.reprezen.kaizen.oasparser.model3.MediaType;
+import com.reprezen.kaizen.oasparser.model3.Schema;
 
 public class HeaderImpl extends PropertiesOverlay<Header> implements Header {
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public HeaderImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        super(json, parent, refReg);
-    }
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public HeaderImpl(Header header, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        super(header, parent, refReg);
-    }
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<String> name;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<String> in;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<String> description;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<Boolean> required;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<Boolean> deprecated;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<Boolean> allowEmptyValue;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<String> style;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<Boolean> explode;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<Boolean> allowReserved;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<Schema> schema;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<Object> example;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildMapOverlay<Example> examples;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildMapOverlay<MediaType> contentMediaTypes;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildMapOverlay<Object> extensions;
-
-    // Name
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getName() {
-        return name.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getName(boolean elaborate) {
-        return name.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setName(String name) {
-        this.name.set(name);
-    }
-
-    // In
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getIn() {
-        return in.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getIn(boolean elaborate) {
-        return in.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setIn(String in) {
-        this.in.set(in);
-    }
-
-    // Description
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getDescription() {
-        return description.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getDescription(boolean elaborate) {
-        return description.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setDescription(String description) {
-        this.description.set(description);
-    }
-
-    // Required
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Boolean getRequired() {
-        return required.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Boolean getRequired(boolean elaborate) {
-        return required.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean isRequired() {
-        return required.get() != null ? required.get() : false;
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setRequired(Boolean required) {
-        this.required.set(required);
-    }
-
-    // Deprecated
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Boolean getDeprecated() {
-        return deprecated.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Boolean getDeprecated(boolean elaborate) {
-        return deprecated.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean isDeprecated() {
-        return deprecated.get() != null ? deprecated.get() : false;
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setDeprecated(Boolean deprecated) {
-        this.deprecated.set(deprecated);
-    }
-
-    // AllowEmptyValue
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Boolean getAllowEmptyValue() {
-        return allowEmptyValue.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Boolean getAllowEmptyValue(boolean elaborate) {
-        return allowEmptyValue.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean isAllowEmptyValue() {
-        return allowEmptyValue.get() != null ? allowEmptyValue.get() : false;
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setAllowEmptyValue(Boolean allowEmptyValue) {
-        this.allowEmptyValue.set(allowEmptyValue);
-    }
-
-    // Style
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getStyle() {
-        return style.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getStyle(boolean elaborate) {
-        return style.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setStyle(String style) {
-        this.style.set(style);
-    }
-
-    // Explode
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Boolean getExplode() {
-        return explode.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Boolean getExplode(boolean elaborate) {
-        return explode.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean isExplode() {
-        return explode.get() != null ? explode.get() : false;
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setExplode(Boolean explode) {
-        this.explode.set(explode);
-    }
-
-    // AllowReserved
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Boolean getAllowReserved() {
-        return allowReserved.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Boolean getAllowReserved(boolean elaborate) {
-        return allowReserved.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean isAllowReserved() {
-        return allowReserved.get() != null ? allowReserved.get() : false;
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setAllowReserved(Boolean allowReserved) {
-        this.allowReserved.set(allowReserved);
-    }
-
-    // Schema
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Schema getSchema() {
-        return schema.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Schema getSchema(boolean elaborate) {
-        return schema.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setSchema(Schema schema) {
-        this.schema.set(schema);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean isSchemaReference() {
-        return schema != null ? schema.isReference() : false;
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Reference getSchemaReference() {
-        return schema != null ? schema.getReference() : null;
-    }
-
-    // Example
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Object getExample() {
-        return example.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Object getExample(boolean elaborate) {
-        return example.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setExample(Object example) {
-        this.example.set(example);
-    }
-
-    // Example
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Example> getExamples() {
-        return examples.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Example> getExamples(boolean elaborate) {
-        return examples.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasExample(String name) {
-        return examples.containsKey(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Example getExample(String name) {
-        return examples.get(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setExamples(Map<String, Example> examples) {
-        this.examples.set(examples);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setExample(String name, Example example) {
-        examples.set(name, example);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeExample(String name) {
-        examples.remove(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean isExampleReference(String name) {
-        ChildOverlay<Example> child = examples.getChild(name);
-        return child != null ? child.isReference() : false;
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Reference getExampleReference(String name) {
-        ChildOverlay<Example> child = examples.getChild(name);
-        return child != null ? child.getReference() : null;
-    }
-
-    // ContentMediaType
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, MediaType> getContentMediaTypes() {
-        return contentMediaTypes.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, MediaType> getContentMediaTypes(boolean elaborate) {
-        return contentMediaTypes.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasContentMediaType(String name) {
-        return contentMediaTypes.containsKey(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public MediaType getContentMediaType(String name) {
-        return contentMediaTypes.get(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setContentMediaTypes(Map<String, MediaType> contentMediaTypes) {
-        this.contentMediaTypes.set(contentMediaTypes);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setContentMediaType(String name, MediaType contentMediaType) {
-        contentMediaTypes.set(name, contentMediaType);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeContentMediaType(String name) {
-        contentMediaTypes.remove(name);
-    }
-
-    // Extension
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Object> getExtensions() {
-        return extensions.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Object> getExtensions(boolean elaborate) {
-        return extensions.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasExtension(String name) {
-        return extensions.containsKey(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Object getExtension(String name) {
-        return extensions.get(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setExtensions(Map<String, Object> extensions) {
-        this.extensions.set(extensions);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setExtension(String name, Object extension) {
-        extensions.set(name, extension);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeExtension(String name) {
-        extensions.remove(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    protected void elaborateChildren() {
-        super.elaborateChildren();
-        name = createChild("name", this, StringOverlay.factory);
-        in = createChild("in", this, StringOverlay.factory);
-        description = createChild("description", this, StringOverlay.factory);
-        required = createChild("required", this, BooleanOverlay.factory);
-        deprecated = createChild("deprecated", this, BooleanOverlay.factory);
-        allowEmptyValue = createChild("allowEmptyValue", this, BooleanOverlay.factory);
-        style = createChild("style", this, StringOverlay.factory);
-        explode = createChild("explode", this, BooleanOverlay.factory);
-        allowReserved = createChild("allowReserved", this, BooleanOverlay.factory);
-        schema = createChild("schema", this, SchemaImpl.factory);
-        refables.put("schema", schema);
-        example = createChild("example", this, ObjectOverlay.factory);
-        examples = createChildMap("examples", this, ExampleImpl.factory, "[a-zA-Z0-9\\._-]+");
-        refables.put("examples", examples);
-        contentMediaTypes = createChildMap("content", this, MediaTypeImpl.factory, null);
-        extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
-    }
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public static OverlayFactory<Header> factory = new OverlayFactory<Header>() {
-
-        @Override
-        protected Class<? extends IJsonOverlay<? super Header>> getOverlayClass() {
-            return HeaderImpl.class;
-        }
-
-        @Override
-        public JsonOverlay<Header> _create(Header header, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            IJsonOverlay<?> overlay;
-            overlay = new HeaderImpl(header, parent, refReg);
-            @SuppressWarnings("unchecked") JsonOverlay<Header> castOverlay = (JsonOverlay<Header>) overlay;
-            return castOverlay;
-        }
-
-        @Override
-        public JsonOverlay<Header> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            IJsonOverlay<?> overlay;
-            overlay = new HeaderImpl(json, parent, refReg);
-            @SuppressWarnings("unchecked") JsonOverlay<Header> castOverlay = (JsonOverlay<Header>) overlay;
-            return castOverlay;
-        }
-    };
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private static Class<? extends Header> getSubtypeOf(Header header) {
-        return Header.class;
-    }
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private static Class<? extends Header> getSubtypeOf(JsonNode json) {
-        return Header.class;
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public HeaderImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+		super(json, parent, refReg);
+	}
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public HeaderImpl(Header header, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+		super(header, parent, refReg);
+	}
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<String> name;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<String> in;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<String> description;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<Boolean> required;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<Boolean> deprecated;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<Boolean> allowEmptyValue;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<String> style;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<Boolean> explode;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<Boolean> allowReserved;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<Schema> schema;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<Object> example;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildMapOverlay<Example> examples;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildMapOverlay<MediaType> contentMediaTypes;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildMapOverlay<Object> extensions;
+
+	// Name
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getName() {
+		return name._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getName(boolean elaborate) {
+		return name._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setName(String name) {
+		this.name._set(name);
+	}
+
+	// In
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getIn() {
+		return in._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getIn(boolean elaborate) {
+		return in._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setIn(String in) {
+		this.in._set(in);
+	}
+
+	// Description
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getDescription() {
+		return description._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getDescription(boolean elaborate) {
+		return description._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setDescription(String description) {
+		this.description._set(description);
+	}
+
+	// Required
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Boolean getRequired() {
+		return required._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Boolean getRequired(boolean elaborate) {
+		return required._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean isRequired() {
+		return required._get() != null ? required._get() : false;
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setRequired(Boolean required) {
+		this.required._set(required);
+	}
+
+	// Deprecated
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Boolean getDeprecated() {
+		return deprecated._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Boolean getDeprecated(boolean elaborate) {
+		return deprecated._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean isDeprecated() {
+		return deprecated._get() != null ? deprecated._get() : false;
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setDeprecated(Boolean deprecated) {
+		this.deprecated._set(deprecated);
+	}
+
+	// AllowEmptyValue
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Boolean getAllowEmptyValue() {
+		return allowEmptyValue._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Boolean getAllowEmptyValue(boolean elaborate) {
+		return allowEmptyValue._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean isAllowEmptyValue() {
+		return allowEmptyValue._get() != null ? allowEmptyValue._get() : false;
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setAllowEmptyValue(Boolean allowEmptyValue) {
+		this.allowEmptyValue._set(allowEmptyValue);
+	}
+
+	// Style
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getStyle() {
+		return style._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getStyle(boolean elaborate) {
+		return style._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setStyle(String style) {
+		this.style._set(style);
+	}
+
+	// Explode
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Boolean getExplode() {
+		return explode._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Boolean getExplode(boolean elaborate) {
+		return explode._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean isExplode() {
+		return explode._get() != null ? explode._get() : false;
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setExplode(Boolean explode) {
+		this.explode._set(explode);
+	}
+
+	// AllowReserved
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Boolean getAllowReserved() {
+		return allowReserved._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Boolean getAllowReserved(boolean elaborate) {
+		return allowReserved._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean isAllowReserved() {
+		return allowReserved._get() != null ? allowReserved._get() : false;
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setAllowReserved(Boolean allowReserved) {
+		this.allowReserved._set(allowReserved);
+	}
+
+	// Schema
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Schema getSchema() {
+		return schema._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Schema getSchema(boolean elaborate) {
+		return schema._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setSchema(Schema schema) {
+		this.schema._set(schema);
+	}
+
+	// Example
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Object getExample() {
+		return example._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Object getExample(boolean elaborate) {
+		return example._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setExample(Object example) {
+		this.example._set(example);
+	}
+
+	// Example
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Example> getExamples() {
+		return examples._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Example> getExamples(boolean elaborate) {
+		return examples._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasExample(String name) {
+		return examples.containsKey(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Example getExample(String name) {
+		return examples._get(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setExamples(Map<String, Example> examples) {
+		this.examples._set(examples);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setExample(String name, Example example) {
+		examples._set(name, example);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeExample(String name) {
+		examples._remove(name);
+	}
+
+	// ContentMediaType
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, MediaType> getContentMediaTypes() {
+		return contentMediaTypes._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, MediaType> getContentMediaTypes(boolean elaborate) {
+		return contentMediaTypes._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasContentMediaType(String name) {
+		return contentMediaTypes.containsKey(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public MediaType getContentMediaType(String name) {
+		return contentMediaTypes._get(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setContentMediaTypes(Map<String, MediaType> contentMediaTypes) {
+		this.contentMediaTypes._set(contentMediaTypes);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setContentMediaType(String name, MediaType contentMediaType) {
+		contentMediaTypes._set(name, contentMediaType);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeContentMediaType(String name) {
+		contentMediaTypes._remove(name);
+	}
+
+	// Extension
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Object> getExtensions() {
+		return extensions._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Object> getExtensions(boolean elaborate) {
+		return extensions._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasExtension(String name) {
+		return extensions.containsKey(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Object getExtension(String name) {
+		return extensions._get(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setExtensions(Map<String, Object> extensions) {
+		this.extensions._set(extensions);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setExtension(String name, Object extension) {
+		extensions._set(name, extension);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeExtension(String name) {
+		extensions._remove(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	protected void elaborateChildren() {
+		super.elaborateChildren();
+		name = createChild("name", this, StringOverlay.factory);
+		in = createChild("in", this, StringOverlay.factory);
+		description = createChild("description", this, StringOverlay.factory);
+		required = createChild("required", this, BooleanOverlay.factory);
+		deprecated = createChild("deprecated", this, BooleanOverlay.factory);
+		allowEmptyValue = createChild("allowEmptyValue", this, BooleanOverlay.factory);
+		style = createChild("style", this, StringOverlay.factory);
+		explode = createChild("explode", this, BooleanOverlay.factory);
+		allowReserved = createChild("allowReserved", this, BooleanOverlay.factory);
+		schema = createChild("schema", this, SchemaImpl.factory);
+		example = createChild("example", this, ObjectOverlay.factory);
+		examples = createChildMap("examples", this, ExampleImpl.factory, "[a-zA-Z0-9\\._-]+");
+		contentMediaTypes = createChildMap("content", this, MediaTypeImpl.factory, null);
+		extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
+	}
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public static OverlayFactory<Header> factory = new OverlayFactory<Header>() {
+
+		@Override
+		protected Class<? extends AbstractJsonOverlay<? super Header>> getOverlayClass() {
+			return HeaderImpl.class;
+		}
+
+		@Override
+		public JsonOverlay<Header> _create(Header header, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+			AbstractJsonOverlay<?> overlay;
+			overlay = new HeaderImpl(header, parent, refReg);
+			@SuppressWarnings("unchecked")
+			JsonOverlay<Header> castOverlay = (JsonOverlay<Header>) overlay;
+			return castOverlay;
+		}
+
+		@Override
+		public JsonOverlay<Header> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+			AbstractJsonOverlay<?> overlay;
+			overlay = new HeaderImpl(json, parent, refReg);
+			@SuppressWarnings("unchecked")
+			JsonOverlay<Header> castOverlay = (JsonOverlay<Header>) overlay;
+			return castOverlay;
+		}
+	};
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private static Class<? extends Header> getSubtypeOf(Header header) {
+		return Header.class;
+	}
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private static Class<? extends Header> getSubtypeOf(JsonNode json) {
+		return Header.class;
+	}
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/InfoImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/InfoImpl.java
@@ -1,261 +1,260 @@
 package com.reprezen.kaizen.oasparser.ovl3;
 
-import com.reprezen.jsonoverlay.StringOverlay;
-import com.reprezen.jsonoverlay.ReferenceRegistry;
+import java.util.Map;
+
+import javax.annotation.Generated;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.reprezen.jsonoverlay.AbstractJsonOverlay;
 import com.reprezen.jsonoverlay.ChildMapOverlay;
-import com.reprezen.kaizen.oasparser.model3.License;
+import com.reprezen.jsonoverlay.ChildOverlay;
+import com.reprezen.jsonoverlay.JsonOverlay;
 import com.reprezen.jsonoverlay.ObjectOverlay;
-import com.reprezen.jsonoverlay.MapOverlay;
-import java.util.stream.Collectors;
-import com.reprezen.kaizen.oasparser.model3.*;
 import com.reprezen.jsonoverlay.OverlayFactory;
 import com.reprezen.jsonoverlay.PropertiesOverlay;
-import javax.annotation.Generated;
-import com.fasterxml.jackson.core.JsonPointer;
-import com.reprezen.kaizen.oasparser.ovl3.ContactImpl;
-import com.reprezen.jsonoverlay.IJsonOverlay;
-import com.reprezen.jsonoverlay.JsonOverlay;
-import java.util.Map;
-import com.reprezen.kaizen.oasparser.ovl3.LicenseImpl;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.reprezen.jsonoverlay.ChildOverlay;
+import com.reprezen.jsonoverlay.ReferenceRegistry;
+import com.reprezen.jsonoverlay.StringOverlay;
 import com.reprezen.kaizen.oasparser.model3.Contact;
+import com.reprezen.kaizen.oasparser.model3.Info;
+import com.reprezen.kaizen.oasparser.model3.License;
 
 public class InfoImpl extends PropertiesOverlay<Info> implements Info {
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public InfoImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        super(json, parent, refReg);
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public InfoImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+		super(json, parent, refReg);
+	}
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public InfoImpl(Info info, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        super(info, parent, refReg);
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public InfoImpl(Info info, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+		super(info, parent, refReg);
+	}
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<String> title;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<String> title;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<String> description;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<String> description;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<String> termsOfService;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<String> termsOfService;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<Contact> contact;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<Contact> contact;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<License> license;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<License> license;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<String> version;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<String> version;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildMapOverlay<Object> extensions;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildMapOverlay<Object> extensions;
 
-    // Title
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getTitle() {
-        return title.get();
-    }
+	// Title
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getTitle() {
+		return title._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getTitle(boolean elaborate) {
-        return title.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getTitle(boolean elaborate) {
+		return title._get(elaborate);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setTitle(String title) {
-        this.title.set(title);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setTitle(String title) {
+		this.title._set(title);
+	}
 
-    // Description
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getDescription() {
-        return description.get();
-    }
+	// Description
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getDescription() {
+		return description._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getDescription(boolean elaborate) {
-        return description.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getDescription(boolean elaborate) {
+		return description._get(elaborate);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setDescription(String description) {
-        this.description.set(description);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setDescription(String description) {
+		this.description._set(description);
+	}
 
-    // TermsOfService
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getTermsOfService() {
-        return termsOfService.get();
-    }
+	// TermsOfService
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getTermsOfService() {
+		return termsOfService._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getTermsOfService(boolean elaborate) {
-        return termsOfService.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getTermsOfService(boolean elaborate) {
+		return termsOfService._get(elaborate);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setTermsOfService(String termsOfService) {
-        this.termsOfService.set(termsOfService);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setTermsOfService(String termsOfService) {
+		this.termsOfService._set(termsOfService);
+	}
 
-    // Contact
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Contact getContact() {
-        return contact.get();
-    }
+	// Contact
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Contact getContact() {
+		return contact._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Contact getContact(boolean elaborate) {
-        return contact.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Contact getContact(boolean elaborate) {
+		return contact._get(elaborate);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setContact(Contact contact) {
-        this.contact.set(contact);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setContact(Contact contact) {
+		this.contact._set(contact);
+	}
 
-    // License
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public License getLicense() {
-        return license.get();
-    }
+	// License
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public License getLicense() {
+		return license._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public License getLicense(boolean elaborate) {
-        return license.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public License getLicense(boolean elaborate) {
+		return license._get(elaborate);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setLicense(License license) {
-        this.license.set(license);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setLicense(License license) {
+		this.license._set(license);
+	}
 
-    // Version
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getVersion() {
-        return version.get();
-    }
+	// Version
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getVersion() {
+		return version._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getVersion(boolean elaborate) {
-        return version.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getVersion(boolean elaborate) {
+		return version._get(elaborate);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setVersion(String version) {
-        this.version.set(version);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setVersion(String version) {
+		this.version._set(version);
+	}
 
-    // Extension
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Object> getExtensions() {
-        return extensions.get();
-    }
+	// Extension
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Object> getExtensions() {
+		return extensions._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Object> getExtensions(boolean elaborate) {
-        return extensions.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Object> getExtensions(boolean elaborate) {
+		return extensions._get(elaborate);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasExtension(String name) {
-        return extensions.containsKey(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasExtension(String name) {
+		return extensions.containsKey(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Object getExtension(String name) {
-        return extensions.get(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Object getExtension(String name) {
+		return extensions._get(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setExtensions(Map<String, Object> extensions) {
-        this.extensions.set(extensions);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setExtensions(Map<String, Object> extensions) {
+		this.extensions._set(extensions);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setExtension(String name, Object extension) {
-        extensions.set(name, extension);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setExtension(String name, Object extension) {
+		extensions._set(name, extension);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeExtension(String name) {
-        extensions.remove(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeExtension(String name) {
+		extensions._remove(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    protected void elaborateChildren() {
-        super.elaborateChildren();
-        title = createChild("title", this, StringOverlay.factory);
-        description = createChild("description", this, StringOverlay.factory);
-        termsOfService = createChild("termsOfService", this, StringOverlay.factory);
-        contact = createChild("contact", this, ContactImpl.factory);
-        license = createChild("license", this, LicenseImpl.factory);
-        version = createChild("version", this, StringOverlay.factory);
-        extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	protected void elaborateChildren() {
+		super.elaborateChildren();
+		title = createChild("title", this, StringOverlay.factory);
+		description = createChild("description", this, StringOverlay.factory);
+		termsOfService = createChild("termsOfService", this, StringOverlay.factory);
+		contact = createChild("contact", this, ContactImpl.factory);
+		license = createChild("license", this, LicenseImpl.factory);
+		version = createChild("version", this, StringOverlay.factory);
+		extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
+	}
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public static OverlayFactory<Info> factory = new OverlayFactory<Info>() {
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public static OverlayFactory<Info> factory = new OverlayFactory<Info>() {
 
-        @Override
-        protected Class<? extends IJsonOverlay<? super Info>> getOverlayClass() {
-            return InfoImpl.class;
-        }
+		@Override
+		protected Class<? extends AbstractJsonOverlay<? super Info>> getOverlayClass() {
+			return InfoImpl.class;
+		}
 
-        @Override
-        public JsonOverlay<Info> _create(Info info, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            IJsonOverlay<?> overlay;
-            overlay = new InfoImpl(info, parent, refReg);
-            @SuppressWarnings("unchecked") JsonOverlay<Info> castOverlay = (JsonOverlay<Info>) overlay;
-            return castOverlay;
-        }
+		@Override
+		public JsonOverlay<Info> _create(Info info, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+			AbstractJsonOverlay<?> overlay;
+			overlay = new InfoImpl(info, parent, refReg);
+			@SuppressWarnings("unchecked")
+			JsonOverlay<Info> castOverlay = (JsonOverlay<Info>) overlay;
+			return castOverlay;
+		}
 
-        @Override
-        public JsonOverlay<Info> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            IJsonOverlay<?> overlay;
-            overlay = new InfoImpl(json, parent, refReg);
-            @SuppressWarnings("unchecked") JsonOverlay<Info> castOverlay = (JsonOverlay<Info>) overlay;
-            return castOverlay;
-        }
-    };
+		@Override
+		public JsonOverlay<Info> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+			AbstractJsonOverlay<?> overlay;
+			overlay = new InfoImpl(json, parent, refReg);
+			@SuppressWarnings("unchecked")
+			JsonOverlay<Info> castOverlay = (JsonOverlay<Info>) overlay;
+			return castOverlay;
+		}
+	};
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private static Class<? extends Info> getSubtypeOf(Info info) {
-        return Info.class;
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private static Class<? extends Info> getSubtypeOf(Info info) {
+		return Info.class;
+	}
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private static Class<? extends Info> getSubtypeOf(JsonNode json) {
-        return Info.class;
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private static Class<? extends Info> getSubtypeOf(JsonNode json) {
+		return Info.class;
+	}
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/LicenseImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/LicenseImpl.java
@@ -1,167 +1,168 @@
 package com.reprezen.kaizen.oasparser.ovl3;
 
-import com.reprezen.jsonoverlay.StringOverlay;
-import com.reprezen.jsonoverlay.ReferenceRegistry;
+import java.util.Map;
+
+import javax.annotation.Generated;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.reprezen.jsonoverlay.AbstractJsonOverlay;
 import com.reprezen.jsonoverlay.ChildMapOverlay;
+import com.reprezen.jsonoverlay.ChildOverlay;
+import com.reprezen.jsonoverlay.JsonOverlay;
 import com.reprezen.jsonoverlay.ObjectOverlay;
-import com.reprezen.jsonoverlay.MapOverlay;
-import java.util.stream.Collectors;
-import com.reprezen.kaizen.oasparser.model3.*;
 import com.reprezen.jsonoverlay.OverlayFactory;
 import com.reprezen.jsonoverlay.PropertiesOverlay;
-import javax.annotation.Generated;
-import com.fasterxml.jackson.core.JsonPointer;
-import com.reprezen.jsonoverlay.IJsonOverlay;
-import com.reprezen.jsonoverlay.JsonOverlay;
-import java.util.Map;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.reprezen.jsonoverlay.ChildOverlay;
+import com.reprezen.jsonoverlay.ReferenceRegistry;
+import com.reprezen.jsonoverlay.StringOverlay;
+import com.reprezen.kaizen.oasparser.model3.License;
 
 public class LicenseImpl extends PropertiesOverlay<License> implements License {
 
-    JsonNode initJson = jsonMissing();
+	JsonNode initJson = jsonMissing();
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public LicenseImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        super(json, parent, refReg);
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public LicenseImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+		super(json, parent, refReg);
+	}
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public LicenseImpl(License license, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        super(license, parent, refReg);
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public LicenseImpl(License license, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+		super(license, parent, refReg);
+	}
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<String> name;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<String> name;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<String> url;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<String> url;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildMapOverlay<Object> extensions;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildMapOverlay<Object> extensions;
 
-    // Name
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getName() {
-        return name.get();
-    }
+	// Name
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getName() {
+		return name._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getName(boolean elaborate) {
-        return name.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getName(boolean elaborate) {
+		return name._get(elaborate);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setName(String name) {
-        this.name.set(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setName(String name) {
+		this.name._set(name);
+	}
 
-    // Url
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getUrl() {
-        return url.get();
-    }
+	// Url
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getUrl() {
+		return url._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getUrl(boolean elaborate) {
-        return url.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getUrl(boolean elaborate) {
+		return url._get(elaborate);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setUrl(String url) {
-        this.url.set(url);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setUrl(String url) {
+		this.url._set(url);
+	}
 
-    // Extension
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Object> getExtensions() {
-        return extensions.get();
-    }
+	// Extension
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Object> getExtensions() {
+		return extensions._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Object> getExtensions(boolean elaborate) {
-        return extensions.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Object> getExtensions(boolean elaborate) {
+		return extensions._get(elaborate);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasExtension(String name) {
-        return extensions.containsKey(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasExtension(String name) {
+		return extensions.containsKey(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Object getExtension(String name) {
-        return extensions.get(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Object getExtension(String name) {
+		return extensions._get(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setExtensions(Map<String, Object> extensions) {
-        this.extensions.set(extensions);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setExtensions(Map<String, Object> extensions) {
+		this.extensions._set(extensions);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setExtension(String name, Object extension) {
-        extensions.set(name, extension);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setExtension(String name, Object extension) {
+		extensions._set(name, extension);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeExtension(String name) {
-        extensions.remove(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeExtension(String name) {
+		extensions._remove(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    protected void elaborateChildren() {
-        super.elaborateChildren();
-        name = createChild("name", this, StringOverlay.factory);
-        url = createChild("url", this, StringOverlay.factory);
-        extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	protected void elaborateChildren() {
+		super.elaborateChildren();
+		name = createChild("name", this, StringOverlay.factory);
+		url = createChild("url", this, StringOverlay.factory);
+		extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
+	}
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public static OverlayFactory<License> factory = new OverlayFactory<License>() {
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public static OverlayFactory<License> factory = new OverlayFactory<License>() {
 
-        @Override
-        protected Class<? extends IJsonOverlay<? super License>> getOverlayClass() {
-            return LicenseImpl.class;
-        }
+		@Override
+		protected Class<? extends AbstractJsonOverlay<? super License>> getOverlayClass() {
+			return LicenseImpl.class;
+		}
 
-        @Override
-        public JsonOverlay<License> _create(License license, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            IJsonOverlay<?> overlay;
-            overlay = new LicenseImpl(license, parent, refReg);
-            @SuppressWarnings("unchecked") JsonOverlay<License> castOverlay = (JsonOverlay<License>) overlay;
-            return castOverlay;
-        }
+		@Override
+		public JsonOverlay<License> _create(License license, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+			AbstractJsonOverlay<?> overlay;
+			overlay = new LicenseImpl(license, parent, refReg);
+			@SuppressWarnings("unchecked")
+			JsonOverlay<License> castOverlay = (JsonOverlay<License>) overlay;
+			return castOverlay;
+		}
 
-        @Override
-        public JsonOverlay<License> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            IJsonOverlay<?> overlay;
-            overlay = new LicenseImpl(json, parent, refReg);
-            @SuppressWarnings("unchecked") JsonOverlay<License> castOverlay = (JsonOverlay<License>) overlay;
-            return castOverlay;
-        }
-    };
+		@Override
+		public JsonOverlay<License> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+			AbstractJsonOverlay<?> overlay;
+			overlay = new LicenseImpl(json, parent, refReg);
+			@SuppressWarnings("unchecked")
+			JsonOverlay<License> castOverlay = (JsonOverlay<License>) overlay;
+			return castOverlay;
+		}
+	};
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private static Class<? extends License> getSubtypeOf(License license) {
-        return License.class;
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private static Class<? extends License> getSubtypeOf(License license) {
+		return License.class;
+	}
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private static Class<? extends License> getSubtypeOf(JsonNode json) {
-        return License.class;
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private static Class<? extends License> getSubtypeOf(JsonNode json) {
+		return License.class;
+	}
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/LinkImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/LinkImpl.java
@@ -1,309 +1,308 @@
 package com.reprezen.kaizen.oasparser.ovl3;
 
-import com.reprezen.jsonoverlay.StringOverlay;
-import com.reprezen.kaizen.oasparser.model3.Server;
-import com.reprezen.jsonoverlay.ReferenceRegistry;
-import com.reprezen.kaizen.oasparser.ovl3.HeaderImpl;
+import java.util.Map;
+
+import javax.annotation.Generated;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.reprezen.jsonoverlay.AbstractJsonOverlay;
 import com.reprezen.jsonoverlay.ChildMapOverlay;
-import com.reprezen.kaizen.oasparser.model3.Header;
+import com.reprezen.jsonoverlay.ChildOverlay;
+import com.reprezen.jsonoverlay.JsonOverlay;
 import com.reprezen.jsonoverlay.ObjectOverlay;
-import com.reprezen.jsonoverlay.MapOverlay;
-import java.util.stream.Collectors;
-import com.reprezen.kaizen.oasparser.model3.*;
 import com.reprezen.jsonoverlay.OverlayFactory;
 import com.reprezen.jsonoverlay.PropertiesOverlay;
-import javax.annotation.Generated;
-import com.fasterxml.jackson.core.JsonPointer;
-import com.reprezen.jsonoverlay.IJsonOverlay;
-import com.reprezen.jsonoverlay.JsonOverlay;
-import java.util.Map;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.reprezen.jsonoverlay.ChildOverlay;
-import com.reprezen.kaizen.oasparser.ovl3.ServerImpl;
+import com.reprezen.jsonoverlay.ReferenceRegistry;
+import com.reprezen.jsonoverlay.StringOverlay;
+import com.reprezen.kaizen.oasparser.model3.Header;
+import com.reprezen.kaizen.oasparser.model3.Link;
+import com.reprezen.kaizen.oasparser.model3.Server;
 
 public class LinkImpl extends PropertiesOverlay<Link> implements Link {
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public LinkImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        super(json, parent, refReg);
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public LinkImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+		super(json, parent, refReg);
+	}
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public LinkImpl(Link link, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        super(link, parent, refReg);
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public LinkImpl(Link link, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+		super(link, parent, refReg);
+	}
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<String> operationId;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<String> operationId;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<String> operationRef;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<String> operationRef;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildMapOverlay<String> parameters;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildMapOverlay<String> parameters;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildMapOverlay<Header> headers;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildMapOverlay<Header> headers;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<String> description;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<String> description;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<Server> server;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<Server> server;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildMapOverlay<Object> extensions;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildMapOverlay<Object> extensions;
 
-    // OperationId
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getOperationId() {
-        return operationId.get();
-    }
+	// OperationId
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getOperationId() {
+		return operationId._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getOperationId(boolean elaborate) {
-        return operationId.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getOperationId(boolean elaborate) {
+		return operationId._get(elaborate);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setOperationId(String operationId) {
-        this.operationId.set(operationId);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setOperationId(String operationId) {
+		this.operationId._set(operationId);
+	}
 
-    // OperationRef
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getOperationRef() {
-        return operationRef.get();
-    }
+	// OperationRef
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getOperationRef() {
+		return operationRef._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getOperationRef(boolean elaborate) {
-        return operationRef.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getOperationRef(boolean elaborate) {
+		return operationRef._get(elaborate);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setOperationRef(String operationRef) {
-        this.operationRef.set(operationRef);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setOperationRef(String operationRef) {
+		this.operationRef._set(operationRef);
+	}
 
-    // Parameter
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, String> getParameters() {
-        return parameters.get();
-    }
+	// Parameter
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, String> getParameters() {
+		return parameters._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, String> getParameters(boolean elaborate) {
-        return parameters.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, String> getParameters(boolean elaborate) {
+		return parameters._get(elaborate);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasParameter(String name) {
-        return parameters.containsKey(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasParameter(String name) {
+		return parameters.containsKey(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getParameter(String name) {
-        return parameters.get(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getParameter(String name) {
+		return parameters._get(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setParameters(Map<String, String> parameters) {
-        this.parameters.set(parameters);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setParameters(Map<String, String> parameters) {
+		this.parameters._set(parameters);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setParameter(String name, String parameter) {
-        parameters.set(name, parameter);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setParameter(String name, String parameter) {
+		parameters._set(name, parameter);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeParameter(String name) {
-        parameters.remove(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeParameter(String name) {
+		parameters._remove(name);
+	}
 
-    // Header
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Header> getHeaders() {
-        return headers.get();
-    }
+	// Header
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Header> getHeaders() {
+		return headers._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Header> getHeaders(boolean elaborate) {
-        return headers.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Header> getHeaders(boolean elaborate) {
+		return headers._get(elaborate);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasHeader(String name) {
-        return headers.containsKey(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasHeader(String name) {
+		return headers.containsKey(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Header getHeader(String name) {
-        return headers.get(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Header getHeader(String name) {
+		return headers._get(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setHeaders(Map<String, Header> headers) {
-        this.headers.set(headers);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setHeaders(Map<String, Header> headers) {
+		this.headers._set(headers);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setHeader(String name, Header header) {
-        headers.set(name, header);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setHeader(String name, Header header) {
+		headers._set(name, header);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeHeader(String name) {
-        headers.remove(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeHeader(String name) {
+		headers._remove(name);
+	}
 
-    // Description
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getDescription() {
-        return description.get();
-    }
+	// Description
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getDescription() {
+		return description._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getDescription(boolean elaborate) {
-        return description.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getDescription(boolean elaborate) {
+		return description._get(elaborate);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setDescription(String description) {
-        this.description.set(description);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setDescription(String description) {
+		this.description._set(description);
+	}
 
-    // Server
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Server getServer() {
-        return server.get();
-    }
+	// Server
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Server getServer() {
+		return server._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Server getServer(boolean elaborate) {
-        return server.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Server getServer(boolean elaborate) {
+		return server._get(elaborate);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setServer(Server server) {
-        this.server.set(server);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setServer(Server server) {
+		this.server._set(server);
+	}
 
-    // Extension
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Object> getExtensions() {
-        return extensions.get();
-    }
+	// Extension
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Object> getExtensions() {
+		return extensions._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Object> getExtensions(boolean elaborate) {
-        return extensions.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Object> getExtensions(boolean elaborate) {
+		return extensions._get(elaborate);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasExtension(String name) {
-        return extensions.containsKey(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasExtension(String name) {
+		return extensions.containsKey(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Object getExtension(String name) {
-        return extensions.get(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Object getExtension(String name) {
+		return extensions._get(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setExtensions(Map<String, Object> extensions) {
-        this.extensions.set(extensions);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setExtensions(Map<String, Object> extensions) {
+		this.extensions._set(extensions);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setExtension(String name, Object extension) {
-        extensions.set(name, extension);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setExtension(String name, Object extension) {
+		extensions._set(name, extension);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeExtension(String name) {
-        extensions.remove(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeExtension(String name) {
+		extensions._remove(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    protected void elaborateChildren() {
-        super.elaborateChildren();
-        operationId = createChild("operationId", this, StringOverlay.factory);
-        operationRef = createChild("operationRef", this, StringOverlay.factory);
-        parameters = createChildMap("parameters", this, StringOverlay.factory, null);
-        headers = createChildMap("headers", this, HeaderImpl.factory, null);
-        description = createChild("description", this, StringOverlay.factory);
-        server = createChild("server", this, ServerImpl.factory);
-        extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	protected void elaborateChildren() {
+		super.elaborateChildren();
+		operationId = createChild("operationId", this, StringOverlay.factory);
+		operationRef = createChild("operationRef", this, StringOverlay.factory);
+		parameters = createChildMap("parameters", this, StringOverlay.factory, null);
+		headers = createChildMap("headers", this, HeaderImpl.factory, null);
+		description = createChild("description", this, StringOverlay.factory);
+		server = createChild("server", this, ServerImpl.factory);
+		extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
+	}
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public static OverlayFactory<Link> factory = new OverlayFactory<Link>() {
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public static OverlayFactory<Link> factory = new OverlayFactory<Link>() {
 
-        @Override
-        protected Class<? extends IJsonOverlay<? super Link>> getOverlayClass() {
-            return LinkImpl.class;
-        }
+		@Override
+		protected Class<? extends AbstractJsonOverlay<? super Link>> getOverlayClass() {
+			return LinkImpl.class;
+		}
 
-        @Override
-        public JsonOverlay<Link> _create(Link link, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            IJsonOverlay<?> overlay;
-            overlay = new LinkImpl(link, parent, refReg);
-            @SuppressWarnings("unchecked") JsonOverlay<Link> castOverlay = (JsonOverlay<Link>) overlay;
-            return castOverlay;
-        }
+		@Override
+		public JsonOverlay<Link> _create(Link link, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+			AbstractJsonOverlay<?> overlay;
+			overlay = new LinkImpl(link, parent, refReg);
+			@SuppressWarnings("unchecked")
+			JsonOverlay<Link> castOverlay = (JsonOverlay<Link>) overlay;
+			return castOverlay;
+		}
 
-        @Override
-        public JsonOverlay<Link> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            IJsonOverlay<?> overlay;
-            overlay = new LinkImpl(json, parent, refReg);
-            @SuppressWarnings("unchecked") JsonOverlay<Link> castOverlay = (JsonOverlay<Link>) overlay;
-            return castOverlay;
-        }
-    };
+		@Override
+		public JsonOverlay<Link> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+			AbstractJsonOverlay<?> overlay;
+			overlay = new LinkImpl(json, parent, refReg);
+			@SuppressWarnings("unchecked")
+			JsonOverlay<Link> castOverlay = (JsonOverlay<Link>) overlay;
+			return castOverlay;
+		}
+	};
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private static Class<? extends Link> getSubtypeOf(Link link) {
-        return Link.class;
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private static Class<? extends Link> getSubtypeOf(Link link) {
+		return Link.class;
+	}
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private static Class<? extends Link> getSubtypeOf(JsonNode json) {
-        return Link.class;
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private static Class<? extends Link> getSubtypeOf(JsonNode json) {
+		return Link.class;
+	}
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/MediaTypeImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/MediaTypeImpl.java
@@ -1,293 +1,262 @@
 package com.reprezen.kaizen.oasparser.ovl3;
 
-import com.reprezen.kaizen.oasparser.model3.Schema;
-import com.reprezen.jsonoverlay.ReferenceRegistry;
+import java.util.Map;
+
+import javax.annotation.Generated;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.reprezen.jsonoverlay.AbstractJsonOverlay;
 import com.reprezen.jsonoverlay.ChildMapOverlay;
-import com.reprezen.kaizen.oasparser.ovl3.ExampleImpl;
-import com.reprezen.jsonoverlay.Reference;
+import com.reprezen.jsonoverlay.ChildOverlay;
+import com.reprezen.jsonoverlay.JsonOverlay;
 import com.reprezen.jsonoverlay.ObjectOverlay;
-import com.reprezen.jsonoverlay.MapOverlay;
-import java.util.stream.Collectors;
-import com.reprezen.kaizen.oasparser.model3.*;
 import com.reprezen.jsonoverlay.OverlayFactory;
 import com.reprezen.jsonoverlay.PropertiesOverlay;
-import com.reprezen.kaizen.oasparser.ovl3.EncodingPropertyImpl;
-import javax.annotation.Generated;
-import com.fasterxml.jackson.core.JsonPointer;
-import com.reprezen.kaizen.oasparser.ovl3.SchemaImpl;
-import com.reprezen.jsonoverlay.IJsonOverlay;
-import com.reprezen.kaizen.oasparser.model3.Example;
-import com.reprezen.jsonoverlay.JsonOverlay;
-import java.util.Map;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.reprezen.jsonoverlay.ChildOverlay;
+import com.reprezen.jsonoverlay.ReferenceRegistry;
 import com.reprezen.kaizen.oasparser.model3.EncodingProperty;
+import com.reprezen.kaizen.oasparser.model3.Example;
+import com.reprezen.kaizen.oasparser.model3.MediaType;
+import com.reprezen.kaizen.oasparser.model3.Schema;
 
 public class MediaTypeImpl extends PropertiesOverlay<MediaType> implements MediaType {
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public MediaTypeImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        super(json, parent, refReg);
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public MediaTypeImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+		super(json, parent, refReg);
+	}
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public MediaTypeImpl(MediaType mediaType, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        super(mediaType, parent, refReg);
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public MediaTypeImpl(MediaType mediaType, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+		super(mediaType, parent, refReg);
+	}
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<Schema> schema;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<Schema> schema;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildMapOverlay<Example> examples;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildMapOverlay<Example> examples;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<Object> example;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<Object> example;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildMapOverlay<EncodingProperty> encodingProperties;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildMapOverlay<EncodingProperty> encodingProperties;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildMapOverlay<Object> extensions;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildMapOverlay<Object> extensions;
 
-    // Schema
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Schema getSchema() {
-        return schema.get();
-    }
+	// Schema
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Schema getSchema() {
+		return schema._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Schema getSchema(boolean elaborate) {
-        return schema.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Schema getSchema(boolean elaborate) {
+		return schema._get(elaborate);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setSchema(Schema schema) {
-        this.schema.set(schema);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setSchema(Schema schema) {
+		this.schema._set(schema);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean isSchemaReference() {
-        return schema != null ? schema.isReference() : false;
-    }
+	// Example
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Example> getExamples() {
+		return examples._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Reference getSchemaReference() {
-        return schema != null ? schema.getReference() : null;
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Example> getExamples(boolean elaborate) {
+		return examples._get(elaborate);
+	}
 
-    // Example
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Example> getExamples() {
-        return examples.get();
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasExample(String name) {
+		return examples.containsKey(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Example> getExamples(boolean elaborate) {
-        return examples.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Example getExample(String name) {
+		return examples._get(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasExample(String name) {
-        return examples.containsKey(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setExamples(Map<String, Example> examples) {
+		this.examples._set(examples);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Example getExample(String name) {
-        return examples.get(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setExample(String name, Example example) {
+		examples._set(name, example);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setExamples(Map<String, Example> examples) {
-        this.examples.set(examples);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeExample(String name) {
+		examples._remove(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setExample(String name, Example example) {
-        examples.set(name, example);
-    }
+	// Example
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Object getExample() {
+		return example._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeExample(String name) {
-        examples.remove(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Object getExample(boolean elaborate) {
+		return example._get(elaborate);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean isExampleReference(String name) {
-        ChildOverlay<Example> child = examples.getChild(name);
-        return child != null ? child.isReference() : false;
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setExample(Object example) {
+		this.example._set(example);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Reference getExampleReference(String name) {
-        ChildOverlay<Example> child = examples.getChild(name);
-        return child != null ? child.getReference() : null;
-    }
+	// EncodingProperty
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, EncodingProperty> getEncodingProperties() {
+		return encodingProperties._get();
+	}
 
-    // Example
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Object getExample() {
-        return example.get();
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, EncodingProperty> getEncodingProperties(boolean elaborate) {
+		return encodingProperties._get(elaborate);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Object getExample(boolean elaborate) {
-        return example.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasEncodingProperty(String name) {
+		return encodingProperties.containsKey(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setExample(Object example) {
-        this.example.set(example);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public EncodingProperty getEncodingProperty(String name) {
+		return encodingProperties._get(name);
+	}
 
-    // EncodingProperty
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, EncodingProperty> getEncodingProperties() {
-        return encodingProperties.get();
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setEncodingProperties(Map<String, EncodingProperty> encodingProperties) {
+		this.encodingProperties._set(encodingProperties);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, EncodingProperty> getEncodingProperties(boolean elaborate) {
-        return encodingProperties.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setEncodingProperty(String name, EncodingProperty encodingProperty) {
+		encodingProperties._set(name, encodingProperty);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasEncodingProperty(String name) {
-        return encodingProperties.containsKey(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeEncodingProperty(String name) {
+		encodingProperties._remove(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public EncodingProperty getEncodingProperty(String name) {
-        return encodingProperties.get(name);
-    }
+	// Extension
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Object> getExtensions() {
+		return extensions._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setEncodingProperties(Map<String, EncodingProperty> encodingProperties) {
-        this.encodingProperties.set(encodingProperties);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Object> getExtensions(boolean elaborate) {
+		return extensions._get(elaborate);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setEncodingProperty(String name, EncodingProperty encodingProperty) {
-        encodingProperties.set(name, encodingProperty);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasExtension(String name) {
+		return extensions.containsKey(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeEncodingProperty(String name) {
-        encodingProperties.remove(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Object getExtension(String name) {
+		return extensions._get(name);
+	}
 
-    // Extension
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Object> getExtensions() {
-        return extensions.get();
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setExtensions(Map<String, Object> extensions) {
+		this.extensions._set(extensions);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Object> getExtensions(boolean elaborate) {
-        return extensions.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setExtension(String name, Object extension) {
+		extensions._set(name, extension);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasExtension(String name) {
-        return extensions.containsKey(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeExtension(String name) {
+		extensions._remove(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Object getExtension(String name) {
-        return extensions.get(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	protected void elaborateChildren() {
+		super.elaborateChildren();
+		schema = createChild("schema", this, SchemaImpl.factory);
+		examples = createChildMap("examples", this, ExampleImpl.factory, "[a-zA-Z0-9\\._-]+");
+		example = createChild("example", this, ObjectOverlay.factory);
+		encodingProperties = createChildMap("encoding", this, EncodingPropertyImpl.factory, null);
+		extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setExtensions(Map<String, Object> extensions) {
-        this.extensions.set(extensions);
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public static OverlayFactory<MediaType> factory = new OverlayFactory<MediaType>() {
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setExtension(String name, Object extension) {
-        extensions.set(name, extension);
-    }
+		@Override
+		protected Class<? extends AbstractJsonOverlay<? super MediaType>> getOverlayClass() {
+			return MediaTypeImpl.class;
+		}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeExtension(String name) {
-        extensions.remove(name);
-    }
+		@Override
+		public JsonOverlay<MediaType> _create(MediaType mediaType, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+			AbstractJsonOverlay<?> overlay;
+			overlay = new MediaTypeImpl(mediaType, parent, refReg);
+			@SuppressWarnings("unchecked")
+			JsonOverlay<MediaType> castOverlay = (JsonOverlay<MediaType>) overlay;
+			return castOverlay;
+		}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    protected void elaborateChildren() {
-        super.elaborateChildren();
-        schema = createChild("schema", this, SchemaImpl.factory);
-        refables.put("schema", schema);
-        examples = createChildMap("examples", this, ExampleImpl.factory, "[a-zA-Z0-9\\._-]+");
-        refables.put("examples", examples);
-        example = createChild("example", this, ObjectOverlay.factory);
-        encodingProperties = createChildMap("encoding", this, EncodingPropertyImpl.factory, null);
-        extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
-    }
+		@Override
+		public JsonOverlay<MediaType> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+			AbstractJsonOverlay<?> overlay;
+			overlay = new MediaTypeImpl(json, parent, refReg);
+			@SuppressWarnings("unchecked")
+			JsonOverlay<MediaType> castOverlay = (JsonOverlay<MediaType>) overlay;
+			return castOverlay;
+		}
+	};
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public static OverlayFactory<MediaType> factory = new OverlayFactory<MediaType>() {
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private static Class<? extends MediaType> getSubtypeOf(MediaType mediaType) {
+		return MediaType.class;
+	}
 
-        @Override
-        protected Class<? extends IJsonOverlay<? super MediaType>> getOverlayClass() {
-            return MediaTypeImpl.class;
-        }
-
-        @Override
-        public JsonOverlay<MediaType> _create(MediaType mediaType, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            IJsonOverlay<?> overlay;
-            overlay = new MediaTypeImpl(mediaType, parent, refReg);
-            @SuppressWarnings("unchecked") JsonOverlay<MediaType> castOverlay = (JsonOverlay<MediaType>) overlay;
-            return castOverlay;
-        }
-
-        @Override
-        public JsonOverlay<MediaType> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            IJsonOverlay<?> overlay;
-            overlay = new MediaTypeImpl(json, parent, refReg);
-            @SuppressWarnings("unchecked") JsonOverlay<MediaType> castOverlay = (JsonOverlay<MediaType>) overlay;
-            return castOverlay;
-        }
-    };
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private static Class<? extends MediaType> getSubtypeOf(MediaType mediaType) {
-        return MediaType.class;
-    }
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private static Class<? extends MediaType> getSubtypeOf(JsonNode json) {
-        return MediaType.class;
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private static Class<? extends MediaType> getSubtypeOf(JsonNode json) {
+		return MediaType.class;
+	}
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/OAuthFlowImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/OAuthFlowImpl.java
@@ -1,282 +1,283 @@
 package com.reprezen.kaizen.oasparser.ovl3;
 
-import com.reprezen.jsonoverlay.StringOverlay;
-import com.reprezen.jsonoverlay.ReferenceRegistry;
+import java.util.Map;
+
+import javax.annotation.Generated;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.reprezen.jsonoverlay.AbstractJsonOverlay;
 import com.reprezen.jsonoverlay.ChildMapOverlay;
+import com.reprezen.jsonoverlay.ChildOverlay;
+import com.reprezen.jsonoverlay.JsonOverlay;
 import com.reprezen.jsonoverlay.ObjectOverlay;
-import com.reprezen.jsonoverlay.MapOverlay;
-import java.util.stream.Collectors;
-import com.reprezen.kaizen.oasparser.model3.*;
 import com.reprezen.jsonoverlay.OverlayFactory;
 import com.reprezen.jsonoverlay.PropertiesOverlay;
-import javax.annotation.Generated;
-import com.fasterxml.jackson.core.JsonPointer;
-import com.reprezen.jsonoverlay.IJsonOverlay;
-import com.reprezen.jsonoverlay.JsonOverlay;
-import java.util.Map;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.reprezen.jsonoverlay.ChildOverlay;
+import com.reprezen.jsonoverlay.ReferenceRegistry;
+import com.reprezen.jsonoverlay.StringOverlay;
+import com.reprezen.kaizen.oasparser.model3.OAuthFlow;
 
 public class OAuthFlowImpl extends PropertiesOverlay<OAuthFlow> implements OAuthFlow {
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public OAuthFlowImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        super(json, parent, refReg);
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public OAuthFlowImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+		super(json, parent, refReg);
+	}
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public OAuthFlowImpl(OAuthFlow oAuthFlow, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        super(oAuthFlow, parent, refReg);
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public OAuthFlowImpl(OAuthFlow oAuthFlow, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+		super(oAuthFlow, parent, refReg);
+	}
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<String> authorizationUrl;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<String> authorizationUrl;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<String> tokenUrl;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<String> tokenUrl;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<String> refreshUrl;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<String> refreshUrl;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildMapOverlay<String> scopes;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildMapOverlay<String> scopes;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildMapOverlay<Object> scopesExtensions;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildMapOverlay<Object> scopesExtensions;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildMapOverlay<Object> extensions;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildMapOverlay<Object> extensions;
 
-    // AuthorizationUrl
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getAuthorizationUrl() {
-        return authorizationUrl.get();
-    }
+	// AuthorizationUrl
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getAuthorizationUrl() {
+		return authorizationUrl._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getAuthorizationUrl(boolean elaborate) {
-        return authorizationUrl.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getAuthorizationUrl(boolean elaborate) {
+		return authorizationUrl._get(elaborate);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setAuthorizationUrl(String authorizationUrl) {
-        this.authorizationUrl.set(authorizationUrl);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setAuthorizationUrl(String authorizationUrl) {
+		this.authorizationUrl._set(authorizationUrl);
+	}
 
-    // TokenUrl
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getTokenUrl() {
-        return tokenUrl.get();
-    }
+	// TokenUrl
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getTokenUrl() {
+		return tokenUrl._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getTokenUrl(boolean elaborate) {
-        return tokenUrl.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getTokenUrl(boolean elaborate) {
+		return tokenUrl._get(elaborate);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setTokenUrl(String tokenUrl) {
-        this.tokenUrl.set(tokenUrl);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setTokenUrl(String tokenUrl) {
+		this.tokenUrl._set(tokenUrl);
+	}
 
-    // RefreshUrl
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getRefreshUrl() {
-        return refreshUrl.get();
-    }
+	// RefreshUrl
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getRefreshUrl() {
+		return refreshUrl._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getRefreshUrl(boolean elaborate) {
-        return refreshUrl.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getRefreshUrl(boolean elaborate) {
+		return refreshUrl._get(elaborate);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setRefreshUrl(String refreshUrl) {
-        this.refreshUrl.set(refreshUrl);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setRefreshUrl(String refreshUrl) {
+		this.refreshUrl._set(refreshUrl);
+	}
 
-    // Scope
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, String> getScopes() {
-        return scopes.get();
-    }
+	// Scope
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, String> getScopes() {
+		return scopes._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, String> getScopes(boolean elaborate) {
-        return scopes.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, String> getScopes(boolean elaborate) {
+		return scopes._get(elaborate);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasScope(String name) {
-        return scopes.containsKey(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasScope(String name) {
+		return scopes.containsKey(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getScope(String name) {
-        return scopes.get(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getScope(String name) {
+		return scopes._get(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setScopes(Map<String, String> scopes) {
-        this.scopes.set(scopes);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setScopes(Map<String, String> scopes) {
+		this.scopes._set(scopes);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setScope(String name, String scope) {
-        scopes.set(name, scope);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setScope(String name, String scope) {
+		scopes._set(name, scope);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeScope(String name) {
-        scopes.remove(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeScope(String name) {
+		scopes._remove(name);
+	}
 
-    // ScopesExtension
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Object> getScopesExtensions() {
-        return scopesExtensions.get();
-    }
+	// ScopesExtension
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Object> getScopesExtensions() {
+		return scopesExtensions._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Object> getScopesExtensions(boolean elaborate) {
-        return scopesExtensions.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Object> getScopesExtensions(boolean elaborate) {
+		return scopesExtensions._get(elaborate);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasScopesExtension(String name) {
-        return scopesExtensions.containsKey(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasScopesExtension(String name) {
+		return scopesExtensions.containsKey(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Object getScopesExtension(String name) {
-        return scopesExtensions.get(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Object getScopesExtension(String name) {
+		return scopesExtensions._get(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setScopesExtensions(Map<String, Object> scopesExtensions) {
-        this.scopesExtensions.set(scopesExtensions);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setScopesExtensions(Map<String, Object> scopesExtensions) {
+		this.scopesExtensions._set(scopesExtensions);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setScopesExtension(String name, Object scopesExtension) {
-        scopesExtensions.set(name, scopesExtension);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setScopesExtension(String name, Object scopesExtension) {
+		scopesExtensions._set(name, scopesExtension);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeScopesExtension(String name) {
-        scopesExtensions.remove(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeScopesExtension(String name) {
+		scopesExtensions._remove(name);
+	}
 
-    // Extension
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Object> getExtensions() {
-        return extensions.get();
-    }
+	// Extension
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Object> getExtensions() {
+		return extensions._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Object> getExtensions(boolean elaborate) {
-        return extensions.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Object> getExtensions(boolean elaborate) {
+		return extensions._get(elaborate);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasExtension(String name) {
-        return extensions.containsKey(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasExtension(String name) {
+		return extensions.containsKey(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Object getExtension(String name) {
-        return extensions.get(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Object getExtension(String name) {
+		return extensions._get(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setExtensions(Map<String, Object> extensions) {
-        this.extensions.set(extensions);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setExtensions(Map<String, Object> extensions) {
+		this.extensions._set(extensions);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setExtension(String name, Object extension) {
-        extensions.set(name, extension);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setExtension(String name, Object extension) {
+		extensions._set(name, extension);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeExtension(String name) {
-        extensions.remove(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeExtension(String name) {
+		extensions._remove(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    protected void elaborateChildren() {
-        super.elaborateChildren();
-        authorizationUrl = createChild("authorizationUrl", this, StringOverlay.factory);
-        tokenUrl = createChild("tokenUrl", this, StringOverlay.factory);
-        refreshUrl = createChild("refreshUrl", this, StringOverlay.factory);
-        scopes = createChildMap("scopes", this, StringOverlay.factory, "(?!x-).*");
-        scopesExtensions = createChildMap("scopes", this, ObjectOverlay.factory, "x-.+");
-        extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	protected void elaborateChildren() {
+		super.elaborateChildren();
+		authorizationUrl = createChild("authorizationUrl", this, StringOverlay.factory);
+		tokenUrl = createChild("tokenUrl", this, StringOverlay.factory);
+		refreshUrl = createChild("refreshUrl", this, StringOverlay.factory);
+		scopes = createChildMap("scopes", this, StringOverlay.factory, "(?!x-).*");
+		scopesExtensions = createChildMap("scopes", this, ObjectOverlay.factory, "x-.+");
+		extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
+	}
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public static OverlayFactory<OAuthFlow> factory = new OverlayFactory<OAuthFlow>() {
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public static OverlayFactory<OAuthFlow> factory = new OverlayFactory<OAuthFlow>() {
 
-        @Override
-        protected Class<? extends IJsonOverlay<? super OAuthFlow>> getOverlayClass() {
-            return OAuthFlowImpl.class;
-        }
+		@Override
+		protected Class<? extends AbstractJsonOverlay<? super OAuthFlow>> getOverlayClass() {
+			return OAuthFlowImpl.class;
+		}
 
-        @Override
-        public JsonOverlay<OAuthFlow> _create(OAuthFlow oAuthFlow, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            IJsonOverlay<?> overlay;
-            overlay = new OAuthFlowImpl(oAuthFlow, parent, refReg);
-            @SuppressWarnings("unchecked") JsonOverlay<OAuthFlow> castOverlay = (JsonOverlay<OAuthFlow>) overlay;
-            return castOverlay;
-        }
+		@Override
+		public JsonOverlay<OAuthFlow> _create(OAuthFlow oAuthFlow, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+			AbstractJsonOverlay<?> overlay;
+			overlay = new OAuthFlowImpl(oAuthFlow, parent, refReg);
+			@SuppressWarnings("unchecked")
+			JsonOverlay<OAuthFlow> castOverlay = (JsonOverlay<OAuthFlow>) overlay;
+			return castOverlay;
+		}
 
-        @Override
-        public JsonOverlay<OAuthFlow> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            IJsonOverlay<?> overlay;
-            overlay = new OAuthFlowImpl(json, parent, refReg);
-            @SuppressWarnings("unchecked") JsonOverlay<OAuthFlow> castOverlay = (JsonOverlay<OAuthFlow>) overlay;
-            return castOverlay;
-        }
-    };
+		@Override
+		public JsonOverlay<OAuthFlow> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+			AbstractJsonOverlay<?> overlay;
+			overlay = new OAuthFlowImpl(json, parent, refReg);
+			@SuppressWarnings("unchecked")
+			JsonOverlay<OAuthFlow> castOverlay = (JsonOverlay<OAuthFlow>) overlay;
+			return castOverlay;
+		}
+	};
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private static Class<? extends OAuthFlow> getSubtypeOf(OAuthFlow oAuthFlow) {
-        return OAuthFlow.class;
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private static Class<? extends OAuthFlow> getSubtypeOf(OAuthFlow oAuthFlow) {
+		return OAuthFlow.class;
+	}
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private static Class<? extends OAuthFlow> getSubtypeOf(JsonNode json) {
-        return OAuthFlow.class;
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private static Class<? extends OAuthFlow> getSubtypeOf(JsonNode json) {
+		return OAuthFlow.class;
+	}
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/OpenApi3Impl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/OpenApi3Impl.java
@@ -1,1163 +1,995 @@
 package com.reprezen.kaizen.oasparser.ovl3;
 
-import com.reprezen.kaizen.oasparser.ovl3.HeaderImpl;
-import com.reprezen.kaizen.oasparser.ovl3.CallbackImpl;
-import com.google.inject.Inject;
-import com.reprezen.kaizen.oasparser.ovl3.SecuritySchemeImpl;
-import com.reprezen.kaizen.oasparser.ovl3.SecurityRequirementImpl;
-import javax.annotation.Generated;
-import com.reprezen.kaizen.oasparser.model3.Tag;
-import com.reprezen.jsonoverlay.IJsonOverlay;
-import com.reprezen.kaizen.oasparser.model3.Parameter;
-import java.util.Map;
-import com.reprezen.jsonoverlay.ListOverlay;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.reprezen.kaizen.oasparser.ovl3.ServerImpl;
-import com.reprezen.jsonoverlay.ChildListOverlay;
-import com.reprezen.kaizen.oasparser.val.ValidationResults.Severity;
 import java.util.Collection;
-import com.reprezen.kaizen.oasparser.ovl3.ResponseImpl;
-import com.reprezen.kaizen.oasparser.model3.Header;
-import java.util.stream.Collectors;
-import com.reprezen.kaizen.oasparser.model3.*;
-import com.reprezen.jsonoverlay.OverlayFactory;
-import com.reprezen.kaizen.oasparser.ovl3.ExternalDocsImpl;
-import com.reprezen.kaizen.oasparser.val3.OpenApi3Validator;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import com.reprezen.jsonoverlay.ChildOverlay;
-import com.reprezen.kaizen.oasparser.ovl3.RequestBodyImpl;
-import com.reprezen.kaizen.oasparser.model3.Schema;
-import com.reprezen.jsonoverlay.StringOverlay;
-import com.reprezen.kaizen.oasparser.model3.Server;
-import com.reprezen.jsonoverlay.ReferenceRegistry;
-import com.reprezen.kaizen.oasparser.ovl3.InfoImpl;
-import com.reprezen.jsonoverlay.Reference;
-import com.reprezen.kaizen.oasparser.ovl3.TagImpl;
-import com.reprezen.kaizen.oasparser.ovl3.ParameterImpl;
-import com.reprezen.kaizen.oasparser.ovl3.PathImpl;
-import com.reprezen.kaizen.oasparser.model3.Link;
+import java.util.Map;
+
+import javax.annotation.Generated;
+
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.reprezen.kaizen.oasparser.OpenApi;
-import com.reprezen.kaizen.oasparser.model3.Callback;
-import com.reprezen.kaizen.oasparser.val.Validator;
-import com.fasterxml.jackson.core.JsonPointer;
-import com.reprezen.kaizen.oasparser.model3.Response;
-import com.reprezen.kaizen.oasparser.ovl3.SchemaImpl;
-import com.reprezen.kaizen.oasparser.model3.RequestBody;
-import com.reprezen.kaizen.oasparser.model3.Example;
-import com.reprezen.jsonoverlay.JsonOverlay;
-import com.reprezen.kaizen.oasparser.model3.Path;
-import com.reprezen.kaizen.oasparser.model3.SecurityRequirement;
+import com.google.inject.Inject;
+import com.reprezen.jsonoverlay.AbstractJsonOverlay;
+import com.reprezen.jsonoverlay.ChildListOverlay;
 import com.reprezen.jsonoverlay.ChildMapOverlay;
-import com.reprezen.kaizen.oasparser.ovl3.ExampleImpl;
+import com.reprezen.jsonoverlay.ChildOverlay;
+import com.reprezen.jsonoverlay.JsonOverlay;
 import com.reprezen.jsonoverlay.ObjectOverlay;
-import com.reprezen.jsonoverlay.MapOverlay;
+import com.reprezen.jsonoverlay.OverlayFactory;
 import com.reprezen.jsonoverlay.PropertiesOverlay;
-import com.reprezen.kaizen.oasparser.val.ValidationResults;
-import com.reprezen.kaizen.oasparser.model3.SecurityScheme;
-import com.reprezen.kaizen.oasparser.model3.Info;
-import com.reprezen.kaizen.oasparser.ovl3.LinkImpl;
+import com.reprezen.jsonoverlay.ReferenceRegistry;
+import com.reprezen.jsonoverlay.StringOverlay;
+import com.reprezen.kaizen.oasparser.model3.Callback;
+import com.reprezen.kaizen.oasparser.model3.Example;
 import com.reprezen.kaizen.oasparser.model3.ExternalDocs;
+import com.reprezen.kaizen.oasparser.model3.Header;
+import com.reprezen.kaizen.oasparser.model3.Info;
+import com.reprezen.kaizen.oasparser.model3.Link;
+import com.reprezen.kaizen.oasparser.model3.OpenApi3;
+import com.reprezen.kaizen.oasparser.model3.Parameter;
+import com.reprezen.kaizen.oasparser.model3.Path;
+import com.reprezen.kaizen.oasparser.model3.RequestBody;
+import com.reprezen.kaizen.oasparser.model3.Response;
+import com.reprezen.kaizen.oasparser.model3.Schema;
+import com.reprezen.kaizen.oasparser.model3.SecurityRequirement;
+import com.reprezen.kaizen.oasparser.model3.SecurityScheme;
+import com.reprezen.kaizen.oasparser.model3.Server;
+import com.reprezen.kaizen.oasparser.model3.Tag;
+import com.reprezen.kaizen.oasparser.val.ValidationResults;
+import com.reprezen.kaizen.oasparser.val.ValidationResults.Severity;
+import com.reprezen.kaizen.oasparser.val.Validator;
 
 public class OpenApi3Impl extends PropertiesOverlay<OpenApi3> implements OpenApi3 {
 
-    private ValidationResults validationResults = null;
-
-    @Override
-    protected JsonNode fixJson(JsonNode json) {
-        if (json.isMissingNode()) {
-            json = jsonObject();
-        }
-        if (!json.has("paths")) {
-            ((ObjectNode) json).putObject("paths");
-        }
-        return json;
-    }
+	private ValidationResults validationResults = null;
+
+	@Override
+	protected JsonNode fixJson(JsonNode json) {
+		if (json.isMissingNode()) {
+			json = jsonObject();
+		}
+		if (!json.has("paths")) {
+			((ObjectNode) json).putObject("paths");
+		}
+		return json;
+	}
 
-    @Inject
-    private Validator<OpenApi3> validator;
-
-    @Override
-    public void validate() {
-        validationResults = validator.validate(this);
-    }
-
-    @Override
-    public boolean isValid() {
-        if (validationResults == null) {
-            validate();
-        }
-        return validationResults.getSeverity().lt(Severity.ERROR);
-    }
-
-    @Override
-    public ValidationResults getValidationResults() {
-        if (validationResults == null) {
-            validate();
-        }
-        return validationResults;
-    }
-
-    @Override
-    public Collection<ValidationResults.ValidationItem> getValidationItems() {
-        return getValidationResults().getItems();
-    }
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public OpenApi3Impl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        super(json, parent, refReg);
-    }
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public OpenApi3Impl(OpenApi3 openApi3, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        super(openApi3, parent, refReg);
-    }
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<String> openApi;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<Info> info;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildListOverlay<Server> servers;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildMapOverlay<Path> paths;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildMapOverlay<Object> pathsExtensions;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildMapOverlay<Schema> schemas;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildMapOverlay<Response> responses;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildMapOverlay<Parameter> parameters;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildMapOverlay<Example> examples;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildMapOverlay<RequestBody> requestBodies;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildMapOverlay<Header> headers;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildMapOverlay<SecurityScheme> securitySchemes;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildMapOverlay<Link> links;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildMapOverlay<Callback> callbacks;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildMapOverlay<Object> componentsExtensions;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildListOverlay<SecurityRequirement> securityRequirements;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildListOverlay<Tag> tags;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<ExternalDocs> externalDocs;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildMapOverlay<Object> extensions;
-
-    // OpenApi
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getOpenApi() {
-        return openApi.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getOpenApi(boolean elaborate) {
-        return openApi.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setOpenApi(String openApi) {
-        this.openApi.set(openApi);
-    }
-
-    // Info
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Info getInfo() {
-        return info.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Info getInfo(boolean elaborate) {
-        return info.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setInfo(Info info) {
-        this.info.set(info);
-    }
-
-    // Server
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Collection<Server> getServers() {
-        return servers.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Collection<Server> getServers(boolean elaborate) {
-        return servers.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasServers() {
-        return servers.isPresent();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Server getServer(int index) {
-        return servers.get(index);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setServers(Collection<Server> servers) {
-        this.servers.set(servers);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setServer(int index, Server server) {
-        servers.set(index, server);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void addServer(Server server) {
-        servers.add(server);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void insertServer(int index, Server server) {
-        servers.insert(index, server);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeServer(int index) {
-        servers.remove(index);
-    }
-
-    // Path
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Path> getPaths() {
-        return paths.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Path> getPaths(boolean elaborate) {
-        return paths.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasPath(String name) {
-        return paths.containsKey(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Path getPath(String name) {
-        return paths.get(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setPaths(Map<String, Path> paths) {
-        this.paths.set(paths);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setPath(String name, Path path) {
-        paths.set(name, path);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removePath(String name) {
-        paths.remove(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean isPathReference(String name) {
-        ChildOverlay<Path> child = paths.getChild(name);
-        return child != null ? child.isReference() : false;
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Reference getPathReference(String name) {
-        ChildOverlay<Path> child = paths.getChild(name);
-        return child != null ? child.getReference() : null;
-    }
-
-    // PathsExtension
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Object> getPathsExtensions() {
-        return pathsExtensions.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Object> getPathsExtensions(boolean elaborate) {
-        return pathsExtensions.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasPathsExtension(String name) {
-        return pathsExtensions.containsKey(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Object getPathsExtension(String name) {
-        return pathsExtensions.get(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setPathsExtensions(Map<String, Object> pathsExtensions) {
-        this.pathsExtensions.set(pathsExtensions);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setPathsExtension(String name, Object pathsExtension) {
-        pathsExtensions.set(name, pathsExtension);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removePathsExtension(String name) {
-        pathsExtensions.remove(name);
-    }
-
-    // Schema
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Schema> getSchemas() {
-        return schemas.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Schema> getSchemas(boolean elaborate) {
-        return schemas.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasSchema(String name) {
-        return schemas.containsKey(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Schema getSchema(String name) {
-        return schemas.get(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setSchemas(Map<String, Schema> schemas) {
-        this.schemas.set(schemas);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setSchema(String name, Schema schema) {
-        schemas.set(name, schema);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeSchema(String name) {
-        schemas.remove(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean isSchemaReference(String name) {
-        ChildOverlay<Schema> child = schemas.getChild(name);
-        return child != null ? child.isReference() : false;
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Reference getSchemaReference(String name) {
-        ChildOverlay<Schema> child = schemas.getChild(name);
-        return child != null ? child.getReference() : null;
-    }
-
-    // Response
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Response> getResponses() {
-        return responses.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Response> getResponses(boolean elaborate) {
-        return responses.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasResponse(String name) {
-        return responses.containsKey(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Response getResponse(String name) {
-        return responses.get(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setResponses(Map<String, Response> responses) {
-        this.responses.set(responses);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setResponse(String name, Response response) {
-        responses.set(name, response);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeResponse(String name) {
-        responses.remove(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean isResponseReference(String name) {
-        ChildOverlay<Response> child = responses.getChild(name);
-        return child != null ? child.isReference() : false;
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Reference getResponseReference(String name) {
-        ChildOverlay<Response> child = responses.getChild(name);
-        return child != null ? child.getReference() : null;
-    }
-
-    // Parameter
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Parameter> getParameters() {
-        return parameters.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Parameter> getParameters(boolean elaborate) {
-        return parameters.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasParameter(String name) {
-        return parameters.containsKey(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Parameter getParameter(String name) {
-        return parameters.get(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setParameters(Map<String, Parameter> parameters) {
-        this.parameters.set(parameters);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setParameter(String name, Parameter parameter) {
-        parameters.set(name, parameter);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeParameter(String name) {
-        parameters.remove(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean isParameterReference(String name) {
-        ChildOverlay<Parameter> child = parameters.getChild(name);
-        return child != null ? child.isReference() : false;
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Reference getParameterReference(String name) {
-        ChildOverlay<Parameter> child = parameters.getChild(name);
-        return child != null ? child.getReference() : null;
-    }
-
-    // Example
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Example> getExamples() {
-        return examples.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Example> getExamples(boolean elaborate) {
-        return examples.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasExample(String name) {
-        return examples.containsKey(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Example getExample(String name) {
-        return examples.get(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setExamples(Map<String, Example> examples) {
-        this.examples.set(examples);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setExample(String name, Example example) {
-        examples.set(name, example);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeExample(String name) {
-        examples.remove(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean isExampleReference(String name) {
-        ChildOverlay<Example> child = examples.getChild(name);
-        return child != null ? child.isReference() : false;
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Reference getExampleReference(String name) {
-        ChildOverlay<Example> child = examples.getChild(name);
-        return child != null ? child.getReference() : null;
-    }
-
-    // RequestBody
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, RequestBody> getRequestBodies() {
-        return requestBodies.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, RequestBody> getRequestBodies(boolean elaborate) {
-        return requestBodies.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasRequestBody(String name) {
-        return requestBodies.containsKey(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public RequestBody getRequestBody(String name) {
-        return requestBodies.get(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setRequestBodies(Map<String, RequestBody> requestBodies) {
-        this.requestBodies.set(requestBodies);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setRequestBody(String name, RequestBody requestBody) {
-        requestBodies.set(name, requestBody);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeRequestBody(String name) {
-        requestBodies.remove(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean isRequestBodyReference(String name) {
-        ChildOverlay<RequestBody> child = requestBodies.getChild(name);
-        return child != null ? child.isReference() : false;
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Reference getRequestBodyReference(String name) {
-        ChildOverlay<RequestBody> child = requestBodies.getChild(name);
-        return child != null ? child.getReference() : null;
-    }
-
-    // Header
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Header> getHeaders() {
-        return headers.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Header> getHeaders(boolean elaborate) {
-        return headers.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasHeader(String name) {
-        return headers.containsKey(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Header getHeader(String name) {
-        return headers.get(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setHeaders(Map<String, Header> headers) {
-        this.headers.set(headers);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setHeader(String name, Header header) {
-        headers.set(name, header);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeHeader(String name) {
-        headers.remove(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean isHeaderReference(String name) {
-        ChildOverlay<Header> child = headers.getChild(name);
-        return child != null ? child.isReference() : false;
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Reference getHeaderReference(String name) {
-        ChildOverlay<Header> child = headers.getChild(name);
-        return child != null ? child.getReference() : null;
-    }
-
-    // SecurityScheme
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, SecurityScheme> getSecuritySchemes() {
-        return securitySchemes.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, SecurityScheme> getSecuritySchemes(boolean elaborate) {
-        return securitySchemes.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasSecurityScheme(String name) {
-        return securitySchemes.containsKey(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public SecurityScheme getSecurityScheme(String name) {
-        return securitySchemes.get(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setSecuritySchemes(Map<String, SecurityScheme> securitySchemes) {
-        this.securitySchemes.set(securitySchemes);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setSecurityScheme(String name, SecurityScheme securityScheme) {
-        securitySchemes.set(name, securityScheme);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeSecurityScheme(String name) {
-        securitySchemes.remove(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean isSecuritySchemeReference(String name) {
-        ChildOverlay<SecurityScheme> child = securitySchemes.getChild(name);
-        return child != null ? child.isReference() : false;
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Reference getSecuritySchemeReference(String name) {
-        ChildOverlay<SecurityScheme> child = securitySchemes.getChild(name);
-        return child != null ? child.getReference() : null;
-    }
-
-    // Link
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Link> getLinks() {
-        return links.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Link> getLinks(boolean elaborate) {
-        return links.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasLink(String name) {
-        return links.containsKey(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Link getLink(String name) {
-        return links.get(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setLinks(Map<String, Link> links) {
-        this.links.set(links);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setLink(String name, Link link) {
-        links.set(name, link);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeLink(String name) {
-        links.remove(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean isLinkReference(String name) {
-        ChildOverlay<Link> child = links.getChild(name);
-        return child != null ? child.isReference() : false;
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Reference getLinkReference(String name) {
-        ChildOverlay<Link> child = links.getChild(name);
-        return child != null ? child.getReference() : null;
-    }
-
-    // Callback
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Callback> getCallbacks() {
-        return callbacks.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Callback> getCallbacks(boolean elaborate) {
-        return callbacks.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasCallback(String name) {
-        return callbacks.containsKey(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Callback getCallback(String name) {
-        return callbacks.get(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setCallbacks(Map<String, Callback> callbacks) {
-        this.callbacks.set(callbacks);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setCallback(String name, Callback callback) {
-        callbacks.set(name, callback);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeCallback(String name) {
-        callbacks.remove(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean isCallbackReference(String name) {
-        ChildOverlay<Callback> child = callbacks.getChild(name);
-        return child != null ? child.isReference() : false;
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Reference getCallbackReference(String name) {
-        ChildOverlay<Callback> child = callbacks.getChild(name);
-        return child != null ? child.getReference() : null;
-    }
-
-    // ComponentsExtension
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Object> getComponentsExtensions() {
-        return componentsExtensions.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Object> getComponentsExtensions(boolean elaborate) {
-        return componentsExtensions.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasComponentsExtension(String name) {
-        return componentsExtensions.containsKey(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Object getComponentsExtension(String name) {
-        return componentsExtensions.get(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setComponentsExtensions(Map<String, Object> componentsExtensions) {
-        this.componentsExtensions.set(componentsExtensions);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setComponentsExtension(String name, Object componentsExtension) {
-        componentsExtensions.set(name, componentsExtension);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeComponentsExtension(String name) {
-        componentsExtensions.remove(name);
-    }
-
-    // SecurityRequirement
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Collection<SecurityRequirement> getSecurityRequirements() {
-        return securityRequirements.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Collection<SecurityRequirement> getSecurityRequirements(boolean elaborate) {
-        return securityRequirements.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasSecurityRequirements() {
-        return securityRequirements.isPresent();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public SecurityRequirement getSecurityRequirement(int index) {
-        return securityRequirements.get(index);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setSecurityRequirements(Collection<SecurityRequirement> securityRequirements) {
-        this.securityRequirements.set(securityRequirements);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setSecurityRequirement(int index, SecurityRequirement securityRequirement) {
-        securityRequirements.set(index, securityRequirement);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void addSecurityRequirement(SecurityRequirement securityRequirement) {
-        securityRequirements.add(securityRequirement);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void insertSecurityRequirement(int index, SecurityRequirement securityRequirement) {
-        securityRequirements.insert(index, securityRequirement);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeSecurityRequirement(int index) {
-        securityRequirements.remove(index);
-    }
-
-    // Tag
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Collection<Tag> getTags() {
-        return tags.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Collection<Tag> getTags(boolean elaborate) {
-        return tags.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasTags() {
-        return tags.isPresent();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Tag getTag(int index) {
-        return tags.get(index);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setTags(Collection<Tag> tags) {
-        this.tags.set(tags);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setTag(int index, Tag tag) {
-        tags.set(index, tag);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void addTag(Tag tag) {
-        tags.add(tag);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void insertTag(int index, Tag tag) {
-        tags.insert(index, tag);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeTag(int index) {
-        tags.remove(index);
-    }
-
-    // ExternalDocs
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public ExternalDocs getExternalDocs() {
-        return externalDocs.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public ExternalDocs getExternalDocs(boolean elaborate) {
-        return externalDocs.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setExternalDocs(ExternalDocs externalDocs) {
-        this.externalDocs.set(externalDocs);
-    }
-
-    // Extension
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Object> getExtensions() {
-        return extensions.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Object> getExtensions(boolean elaborate) {
-        return extensions.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasExtension(String name) {
-        return extensions.containsKey(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Object getExtension(String name) {
-        return extensions.get(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setExtensions(Map<String, Object> extensions) {
-        this.extensions.set(extensions);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setExtension(String name, Object extension) {
-        extensions.set(name, extension);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeExtension(String name) {
-        extensions.remove(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    protected void elaborateChildren() {
-        super.elaborateChildren();
-        openApi = createChild("openapi", this, StringOverlay.factory);
-        info = createChild("info", this, InfoImpl.factory);
-        servers = createChildList("servers", this, ServerImpl.factory);
-        paths = createChildMap("paths", this, PathImpl.factory, "/.*");
-        refables.put("paths", paths);
-        pathsExtensions = createChildMap("paths", this, ObjectOverlay.factory, "x-.+");
-        schemas = createChildMap("components/schemas", this, SchemaImpl.factory, "[a-zA-Z0-9\\._-]+");
-        refables.put("components/schemas", schemas);
-        responses = createChildMap("components/responses", this, ResponseImpl.factory, "[a-zA-Z0-9\\._-]+");
-        refables.put("components/responses", responses);
-        parameters = createChildMap("components/parameters", this, ParameterImpl.factory, "[a-zA-Z0-9\\._-]+");
-        refables.put("components/parameters", parameters);
-        examples = createChildMap("components/examples", this, ExampleImpl.factory, "[a-zA-Z0-9\\._-]+");
-        refables.put("components/examples", examples);
-        requestBodies = createChildMap("components/requestBodies", this, RequestBodyImpl.factory, "[a-zA-Z0-9\\._-]+");
-        refables.put("components/requestBodies", requestBodies);
-        headers = createChildMap("components/headers", this, HeaderImpl.factory, "[a-zA-Z0-9\\._-]+");
-        refables.put("components/headers", headers);
-        securitySchemes = createChildMap("components/securitySchemes", this, SecuritySchemeImpl.factory, "[a-zA-Z0-9\\._-]+");
-        refables.put("components/securitySchemes", securitySchemes);
-        links = createChildMap("components/links", this, LinkImpl.factory, "[a-zA-Z0-9\\._-]+");
-        refables.put("components/links", links);
-        callbacks = createChildMap("components/callbacks", this, CallbackImpl.factory, "(?!x-)[a-zA-Z0-9\\._-]+");
-        refables.put("components/callbacks", callbacks);
-        componentsExtensions = createChildMap("components", this, ObjectOverlay.factory, "x-.+");
-        securityRequirements = createChildList("security", this, SecurityRequirementImpl.factory);
-        tags = createChildList("tags", this, TagImpl.factory);
-        externalDocs = createChild("externalDocs", this, ExternalDocsImpl.factory);
-        extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
-    }
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public static OverlayFactory<OpenApi3> factory = new OverlayFactory<OpenApi3>() {
-
-        @Override
-        protected Class<? extends IJsonOverlay<? super OpenApi3>> getOverlayClass() {
-            return OpenApi3Impl.class;
-        }
-
-        @Override
-        public JsonOverlay<OpenApi3> _create(OpenApi3 openApi3, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            IJsonOverlay<?> overlay;
-            overlay = new OpenApi3Impl(openApi3, parent, refReg);
-            @SuppressWarnings("unchecked") JsonOverlay<OpenApi3> castOverlay = (JsonOverlay<OpenApi3>) overlay;
-            return castOverlay;
-        }
-
-        @Override
-        public JsonOverlay<OpenApi3> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            IJsonOverlay<?> overlay;
-            overlay = new OpenApi3Impl(json, parent, refReg);
-            @SuppressWarnings("unchecked") JsonOverlay<OpenApi3> castOverlay = (JsonOverlay<OpenApi3>) overlay;
-            return castOverlay;
-        }
-    };
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private static Class<? extends OpenApi3> getSubtypeOf(OpenApi3 openApi3) {
-        return OpenApi3.class;
-    }
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private static Class<? extends OpenApi3> getSubtypeOf(JsonNode json) {
-        return OpenApi3.class;
-    }
+	@Inject
+	private Validator<OpenApi3> validator;
+
+	@Override
+	public void validate() {
+		validationResults = validator.validate(this);
+	}
+
+	@Override
+	public boolean isValid() {
+		if (validationResults == null) {
+			validate();
+		}
+		return validationResults.getSeverity().lt(Severity.ERROR);
+	}
+
+	@Override
+	public ValidationResults getValidationResults() {
+		if (validationResults == null) {
+			validate();
+		}
+		return validationResults;
+	}
+
+	@Override
+	public Collection<ValidationResults.ValidationItem> getValidationItems() {
+		return getValidationResults().getItems();
+	}
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public OpenApi3Impl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+		super(json, parent, refReg);
+	}
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public OpenApi3Impl(OpenApi3 openApi3, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+		super(openApi3, parent, refReg);
+	}
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<String> openApi;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<Info> info;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildListOverlay<Server> servers;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildMapOverlay<Path> paths;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildMapOverlay<Object> pathsExtensions;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildMapOverlay<Schema> schemas;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildMapOverlay<Response> responses;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildMapOverlay<Parameter> parameters;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildMapOverlay<Example> examples;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildMapOverlay<RequestBody> requestBodies;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildMapOverlay<Header> headers;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildMapOverlay<SecurityScheme> securitySchemes;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildMapOverlay<Link> links;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildMapOverlay<Callback> callbacks;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildMapOverlay<Object> componentsExtensions;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildListOverlay<SecurityRequirement> securityRequirements;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildListOverlay<Tag> tags;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<ExternalDocs> externalDocs;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildMapOverlay<Object> extensions;
+
+	// OpenApi
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getOpenApi() {
+		return openApi._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getOpenApi(boolean elaborate) {
+		return openApi._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setOpenApi(String openApi) {
+		this.openApi._set(openApi);
+	}
+
+	// Info
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Info getInfo() {
+		return info._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Info getInfo(boolean elaborate) {
+		return info._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setInfo(Info info) {
+		this.info._set(info);
+	}
+
+	// Server
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Collection<Server> getServers() {
+		return servers._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Collection<Server> getServers(boolean elaborate) {
+		return servers._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasServers() {
+		return servers._isPresent();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Server getServer(int index) {
+		return servers._get(index);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setServers(Collection<Server> servers) {
+		this.servers._set(servers);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setServer(int index, Server server) {
+		servers._set(index, server);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void addServer(Server server) {
+		servers._add(server);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void insertServer(int index, Server server) {
+		servers._insert(index, server);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeServer(int index) {
+		servers._remove(index);
+	}
+
+	// Path
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Path> getPaths() {
+		return paths._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Path> getPaths(boolean elaborate) {
+		return paths._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasPath(String name) {
+		return paths.containsKey(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Path getPath(String name) {
+		return paths._get(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setPaths(Map<String, Path> paths) {
+		this.paths._set(paths);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setPath(String name, Path path) {
+		paths._set(name, path);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removePath(String name) {
+		paths._remove(name);
+	}
+
+	// PathsExtension
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Object> getPathsExtensions() {
+		return pathsExtensions._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Object> getPathsExtensions(boolean elaborate) {
+		return pathsExtensions._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasPathsExtension(String name) {
+		return pathsExtensions.containsKey(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Object getPathsExtension(String name) {
+		return pathsExtensions._get(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setPathsExtensions(Map<String, Object> pathsExtensions) {
+		this.pathsExtensions._set(pathsExtensions);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setPathsExtension(String name, Object pathsExtension) {
+		pathsExtensions._set(name, pathsExtension);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removePathsExtension(String name) {
+		pathsExtensions._remove(name);
+	}
+
+	// Schema
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Schema> getSchemas() {
+		return schemas._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Schema> getSchemas(boolean elaborate) {
+		return schemas._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasSchema(String name) {
+		return schemas.containsKey(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Schema getSchema(String name) {
+		return schemas._get(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setSchemas(Map<String, Schema> schemas) {
+		this.schemas._set(schemas);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setSchema(String name, Schema schema) {
+		schemas._set(name, schema);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeSchema(String name) {
+		schemas._remove(name);
+	}
+
+	// Response
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Response> getResponses() {
+		return responses._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Response> getResponses(boolean elaborate) {
+		return responses._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasResponse(String name) {
+		return responses.containsKey(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Response getResponse(String name) {
+		return responses._get(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setResponses(Map<String, Response> responses) {
+		this.responses._set(responses);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setResponse(String name, Response response) {
+		responses._set(name, response);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeResponse(String name) {
+		responses._remove(name);
+	}
+
+	// Parameter
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Parameter> getParameters() {
+		return parameters._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Parameter> getParameters(boolean elaborate) {
+		return parameters._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasParameter(String name) {
+		return parameters.containsKey(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Parameter getParameter(String name) {
+		return parameters._get(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setParameters(Map<String, Parameter> parameters) {
+		this.parameters._set(parameters);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setParameter(String name, Parameter parameter) {
+		parameters._set(name, parameter);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeParameter(String name) {
+		parameters._remove(name);
+	}
+
+	// Example
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Example> getExamples() {
+		return examples._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Example> getExamples(boolean elaborate) {
+		return examples._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasExample(String name) {
+		return examples.containsKey(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Example getExample(String name) {
+		return examples._get(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setExamples(Map<String, Example> examples) {
+		this.examples._set(examples);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setExample(String name, Example example) {
+		examples._set(name, example);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeExample(String name) {
+		examples._remove(name);
+	}
+
+	// RequestBody
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, RequestBody> getRequestBodies() {
+		return requestBodies._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, RequestBody> getRequestBodies(boolean elaborate) {
+		return requestBodies._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasRequestBody(String name) {
+		return requestBodies.containsKey(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public RequestBody getRequestBody(String name) {
+		return requestBodies._get(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setRequestBodies(Map<String, RequestBody> requestBodies) {
+		this.requestBodies._set(requestBodies);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setRequestBody(String name, RequestBody requestBody) {
+		requestBodies._set(name, requestBody);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeRequestBody(String name) {
+		requestBodies._remove(name);
+	}
+
+	// Header
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Header> getHeaders() {
+		return headers._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Header> getHeaders(boolean elaborate) {
+		return headers._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasHeader(String name) {
+		return headers.containsKey(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Header getHeader(String name) {
+		return headers._get(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setHeaders(Map<String, Header> headers) {
+		this.headers._set(headers);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setHeader(String name, Header header) {
+		headers._set(name, header);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeHeader(String name) {
+		headers._remove(name);
+	}
+
+	// SecurityScheme
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, SecurityScheme> getSecuritySchemes() {
+		return securitySchemes._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, SecurityScheme> getSecuritySchemes(boolean elaborate) {
+		return securitySchemes._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasSecurityScheme(String name) {
+		return securitySchemes.containsKey(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public SecurityScheme getSecurityScheme(String name) {
+		return securitySchemes._get(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setSecuritySchemes(Map<String, SecurityScheme> securitySchemes) {
+		this.securitySchemes._set(securitySchemes);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setSecurityScheme(String name, SecurityScheme securityScheme) {
+		securitySchemes._set(name, securityScheme);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeSecurityScheme(String name) {
+		securitySchemes._remove(name);
+	}
+
+	// Link
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Link> getLinks() {
+		return links._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Link> getLinks(boolean elaborate) {
+		return links._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasLink(String name) {
+		return links.containsKey(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Link getLink(String name) {
+		return links._get(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setLinks(Map<String, Link> links) {
+		this.links._set(links);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setLink(String name, Link link) {
+		links._set(name, link);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeLink(String name) {
+		links._remove(name);
+	}
+
+	// Callback
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Callback> getCallbacks() {
+		return callbacks._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Callback> getCallbacks(boolean elaborate) {
+		return callbacks._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasCallback(String name) {
+		return callbacks.containsKey(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Callback getCallback(String name) {
+		return callbacks._get(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setCallbacks(Map<String, Callback> callbacks) {
+		this.callbacks._set(callbacks);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setCallback(String name, Callback callback) {
+		callbacks._set(name, callback);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeCallback(String name) {
+		callbacks._remove(name);
+	}
+
+	// ComponentsExtension
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Object> getComponentsExtensions() {
+		return componentsExtensions._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Object> getComponentsExtensions(boolean elaborate) {
+		return componentsExtensions._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasComponentsExtension(String name) {
+		return componentsExtensions.containsKey(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Object getComponentsExtension(String name) {
+		return componentsExtensions._get(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setComponentsExtensions(Map<String, Object> componentsExtensions) {
+		this.componentsExtensions._set(componentsExtensions);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setComponentsExtension(String name, Object componentsExtension) {
+		componentsExtensions._set(name, componentsExtension);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeComponentsExtension(String name) {
+		componentsExtensions._remove(name);
+	}
+
+	// SecurityRequirement
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Collection<SecurityRequirement> getSecurityRequirements() {
+		return securityRequirements._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Collection<SecurityRequirement> getSecurityRequirements(boolean elaborate) {
+		return securityRequirements._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasSecurityRequirements() {
+		return securityRequirements._isPresent();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public SecurityRequirement getSecurityRequirement(int index) {
+		return securityRequirements._get(index);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setSecurityRequirements(Collection<SecurityRequirement> securityRequirements) {
+		this.securityRequirements._set(securityRequirements);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setSecurityRequirement(int index, SecurityRequirement securityRequirement) {
+		securityRequirements._set(index, securityRequirement);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void addSecurityRequirement(SecurityRequirement securityRequirement) {
+		securityRequirements._add(securityRequirement);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void insertSecurityRequirement(int index, SecurityRequirement securityRequirement) {
+		securityRequirements._insert(index, securityRequirement);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeSecurityRequirement(int index) {
+		securityRequirements._remove(index);
+	}
+
+	// Tag
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Collection<Tag> getTags() {
+		return tags._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Collection<Tag> getTags(boolean elaborate) {
+		return tags._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasTags() {
+		return tags._isPresent();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Tag getTag(int index) {
+		return tags._get(index);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setTags(Collection<Tag> tags) {
+		this.tags._set(tags);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setTag(int index, Tag tag) {
+		tags._set(index, tag);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void addTag(Tag tag) {
+		tags._add(tag);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void insertTag(int index, Tag tag) {
+		tags._insert(index, tag);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeTag(int index) {
+		tags._remove(index);
+	}
+
+	// ExternalDocs
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public ExternalDocs getExternalDocs() {
+		return externalDocs._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public ExternalDocs getExternalDocs(boolean elaborate) {
+		return externalDocs._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setExternalDocs(ExternalDocs externalDocs) {
+		this.externalDocs._set(externalDocs);
+	}
+
+	// Extension
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Object> getExtensions() {
+		return extensions._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Object> getExtensions(boolean elaborate) {
+		return extensions._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasExtension(String name) {
+		return extensions.containsKey(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Object getExtension(String name) {
+		return extensions._get(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setExtensions(Map<String, Object> extensions) {
+		this.extensions._set(extensions);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setExtension(String name, Object extension) {
+		extensions._set(name, extension);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeExtension(String name) {
+		extensions._remove(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	protected void elaborateChildren() {
+		super.elaborateChildren();
+		openApi = createChild("openapi", this, StringOverlay.factory);
+		info = createChild("info", this, InfoImpl.factory);
+		servers = createChildList("servers", this, ServerImpl.factory);
+		paths = createChildMap("paths", this, PathImpl.factory, "/.*");
+		pathsExtensions = createChildMap("paths", this, ObjectOverlay.factory, "x-.+");
+		schemas = createChildMap("components/schemas", this, SchemaImpl.factory, "[a-zA-Z0-9\\._-]+");
+		responses = createChildMap("components/responses", this, ResponseImpl.factory, "[a-zA-Z0-9\\._-]+");
+		parameters = createChildMap("components/parameters", this, ParameterImpl.factory, "[a-zA-Z0-9\\._-]+");
+		examples = createChildMap("components/examples", this, ExampleImpl.factory, "[a-zA-Z0-9\\._-]+");
+		requestBodies = createChildMap("components/requestBodies", this, RequestBodyImpl.factory, "[a-zA-Z0-9\\._-]+");
+		headers = createChildMap("components/headers", this, HeaderImpl.factory, "[a-zA-Z0-9\\._-]+");
+		securitySchemes = createChildMap("components/securitySchemes", this, SecuritySchemeImpl.factory,
+				"[a-zA-Z0-9\\._-]+");
+		links = createChildMap("components/links", this, LinkImpl.factory, "[a-zA-Z0-9\\._-]+");
+		callbacks = createChildMap("components/callbacks", this, CallbackImpl.factory, "(?!x-)[a-zA-Z0-9\\._-]+");
+		componentsExtensions = createChildMap("components", this, ObjectOverlay.factory, "x-.+");
+		securityRequirements = createChildList("security", this, SecurityRequirementImpl.factory);
+		tags = createChildList("tags", this, TagImpl.factory);
+		externalDocs = createChild("externalDocs", this, ExternalDocsImpl.factory);
+		extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
+	}
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public static OverlayFactory<OpenApi3> factory = new OverlayFactory<OpenApi3>() {
+
+		@Override
+		protected Class<? extends AbstractJsonOverlay<? super OpenApi3>> getOverlayClass() {
+			return OpenApi3Impl.class;
+		}
+
+		@Override
+		public JsonOverlay<OpenApi3> _create(OpenApi3 openApi3, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+			AbstractJsonOverlay<?> overlay;
+			overlay = new OpenApi3Impl(openApi3, parent, refReg);
+			@SuppressWarnings("unchecked")
+			JsonOverlay<OpenApi3> castOverlay = (JsonOverlay<OpenApi3>) overlay;
+			return castOverlay;
+		}
+
+		@Override
+		public JsonOverlay<OpenApi3> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+			AbstractJsonOverlay<?> overlay;
+			overlay = new OpenApi3Impl(json, parent, refReg);
+			@SuppressWarnings("unchecked")
+			JsonOverlay<OpenApi3> castOverlay = (JsonOverlay<OpenApi3>) overlay;
+			return castOverlay;
+		}
+	};
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private static Class<? extends OpenApi3> getSubtypeOf(OpenApi3 openApi3) {
+		return OpenApi3.class;
+	}
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private static Class<? extends OpenApi3> getSubtypeOf(JsonNode json) {
+		return OpenApi3.class;
+	}
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/OperationImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/OperationImpl.java
@@ -1,762 +1,698 @@
 package com.reprezen.kaizen.oasparser.ovl3;
 
-import com.reprezen.jsonoverlay.StringOverlay;
-import com.reprezen.kaizen.oasparser.model3.Server;
-import com.reprezen.jsonoverlay.ReferenceRegistry;
-import com.reprezen.kaizen.oasparser.ovl3.CallbackImpl;
-import com.reprezen.jsonoverlay.Reference;
-import com.reprezen.kaizen.oasparser.ovl3.ParameterImpl;
-import com.reprezen.jsonoverlay.BooleanOverlay;
-import com.reprezen.kaizen.oasparser.ovl3.SecurityRequirementImpl;
-import com.reprezen.kaizen.oasparser.model3.Callback;
-import com.fasterxml.jackson.core.JsonPointer;
-import javax.annotation.Generated;
-import com.reprezen.kaizen.oasparser.model3.Response;
-import com.reprezen.kaizen.oasparser.model3.RequestBody;
-import com.reprezen.jsonoverlay.IJsonOverlay;
-import com.reprezen.kaizen.oasparser.model3.Parameter;
-import com.reprezen.jsonoverlay.JsonOverlay;
-import java.util.Map;
-import com.reprezen.jsonoverlay.ListOverlay;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.reprezen.kaizen.oasparser.ovl3.ServerImpl;
-import com.reprezen.jsonoverlay.ChildListOverlay;
-import com.reprezen.kaizen.oasparser.model3.SecurityRequirement;
-import com.reprezen.jsonoverlay.ChildMapOverlay;
 import java.util.Collection;
-import com.reprezen.kaizen.oasparser.ovl3.ResponseImpl;
-import com.reprezen.jsonoverlay.ObjectOverlay;
-import com.reprezen.jsonoverlay.MapOverlay;
-import java.util.stream.Collectors;
-import com.reprezen.kaizen.oasparser.model3.*;
-import com.reprezen.jsonoverlay.OverlayFactory;
-import com.reprezen.kaizen.oasparser.ovl3.ExternalDocsImpl;
-import com.reprezen.jsonoverlay.PropertiesOverlay;
+import java.util.Map;
+
+import javax.annotation.Generated;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.reprezen.jsonoverlay.AbstractJsonOverlay;
+import com.reprezen.jsonoverlay.BooleanOverlay;
+import com.reprezen.jsonoverlay.ChildListOverlay;
+import com.reprezen.jsonoverlay.ChildMapOverlay;
 import com.reprezen.jsonoverlay.ChildOverlay;
-import com.reprezen.kaizen.oasparser.ovl3.RequestBodyImpl;
+import com.reprezen.jsonoverlay.JsonOverlay;
+import com.reprezen.jsonoverlay.ObjectOverlay;
+import com.reprezen.jsonoverlay.OverlayFactory;
+import com.reprezen.jsonoverlay.PropertiesOverlay;
+import com.reprezen.jsonoverlay.ReferenceRegistry;
+import com.reprezen.jsonoverlay.StringOverlay;
+import com.reprezen.kaizen.oasparser.model3.Callback;
 import com.reprezen.kaizen.oasparser.model3.ExternalDocs;
+import com.reprezen.kaizen.oasparser.model3.Operation;
+import com.reprezen.kaizen.oasparser.model3.Parameter;
+import com.reprezen.kaizen.oasparser.model3.RequestBody;
+import com.reprezen.kaizen.oasparser.model3.Response;
+import com.reprezen.kaizen.oasparser.model3.SecurityRequirement;
+import com.reprezen.kaizen.oasparser.model3.Server;
 
 public class OperationImpl extends PropertiesOverlay<Operation> implements Operation {
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public OperationImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        super(json, parent, refReg);
-    }
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public OperationImpl(Operation operation, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        super(operation, parent, refReg);
-    }
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildListOverlay<String> tags;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<String> summary;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<String> description;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<ExternalDocs> externalDocs;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<String> operationId;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildListOverlay<Parameter> parameters;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<RequestBody> requestBody;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildMapOverlay<Response> responses;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildMapOverlay<Object> responsesExtensions;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildMapOverlay<Callback> callbacks;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildMapOverlay<Object> callbacksExtensions;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<Boolean> deprecated;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildListOverlay<SecurityRequirement> securityRequirements;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildListOverlay<Server> servers;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildMapOverlay<Object> extensions;
-
-    // Tag
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Collection<String> getTags() {
-        return tags.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Collection<String> getTags(boolean elaborate) {
-        return tags.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasTags() {
-        return tags.isPresent();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getTag(int index) {
-        return tags.get(index);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setTags(Collection<String> tags) {
-        this.tags.set(tags);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setTag(int index, String tag) {
-        tags.set(index, tag);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void addTag(String tag) {
-        tags.add(tag);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void insertTag(int index, String tag) {
-        tags.insert(index, tag);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeTag(int index) {
-        tags.remove(index);
-    }
-
-    // Summary
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getSummary() {
-        return summary.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getSummary(boolean elaborate) {
-        return summary.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setSummary(String summary) {
-        this.summary.set(summary);
-    }
-
-    // Description
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getDescription() {
-        return description.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getDescription(boolean elaborate) {
-        return description.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setDescription(String description) {
-        this.description.set(description);
-    }
-
-    // ExternalDocs
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public ExternalDocs getExternalDocs() {
-        return externalDocs.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public ExternalDocs getExternalDocs(boolean elaborate) {
-        return externalDocs.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setExternalDocs(ExternalDocs externalDocs) {
-        this.externalDocs.set(externalDocs);
-    }
-
-    // OperationId
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getOperationId() {
-        return operationId.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getOperationId(boolean elaborate) {
-        return operationId.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setOperationId(String operationId) {
-        this.operationId.set(operationId);
-    }
-
-    // Parameter
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Collection<Parameter> getParameters() {
-        return parameters.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Collection<Parameter> getParameters(boolean elaborate) {
-        return parameters.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasParameters() {
-        return parameters.isPresent();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Parameter getParameter(int index) {
-        return parameters.get(index);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setParameters(Collection<Parameter> parameters) {
-        this.parameters.set(parameters);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setParameter(int index, Parameter parameter) {
-        parameters.set(index, parameter);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void addParameter(Parameter parameter) {
-        parameters.add(parameter);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void insertParameter(int index, Parameter parameter) {
-        parameters.insert(index, parameter);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeParameter(int index) {
-        parameters.remove(index);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean isParameterReference(int index) {
-        return parameters.getChild(index).isReference();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Reference getParameterReference(int index) {
-        return parameters.getChild(index).getReference();
-    }
-
-    // RequestBody
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public RequestBody getRequestBody() {
-        return requestBody.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public RequestBody getRequestBody(boolean elaborate) {
-        return requestBody.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setRequestBody(RequestBody requestBody) {
-        this.requestBody.set(requestBody);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean isRequestBodyReference() {
-        return requestBody != null ? requestBody.isReference() : false;
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Reference getRequestBodyReference() {
-        return requestBody != null ? requestBody.getReference() : null;
-    }
-
-    // Response
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Response> getResponses() {
-        return responses.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Response> getResponses(boolean elaborate) {
-        return responses.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasResponse(String name) {
-        return responses.containsKey(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Response getResponse(String name) {
-        return responses.get(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setResponses(Map<String, Response> responses) {
-        this.responses.set(responses);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setResponse(String name, Response response) {
-        responses.set(name, response);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeResponse(String name) {
-        responses.remove(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean isResponseReference(String name) {
-        ChildOverlay<Response> child = responses.getChild(name);
-        return child != null ? child.isReference() : false;
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Reference getResponseReference(String name) {
-        ChildOverlay<Response> child = responses.getChild(name);
-        return child != null ? child.getReference() : null;
-    }
-
-    // ResponsesExtension
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Object> getResponsesExtensions() {
-        return responsesExtensions.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Object> getResponsesExtensions(boolean elaborate) {
-        return responsesExtensions.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasResponsesExtension(String name) {
-        return responsesExtensions.containsKey(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Object getResponsesExtension(String name) {
-        return responsesExtensions.get(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setResponsesExtensions(Map<String, Object> responsesExtensions) {
-        this.responsesExtensions.set(responsesExtensions);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setResponsesExtension(String name, Object responsesExtension) {
-        responsesExtensions.set(name, responsesExtension);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeResponsesExtension(String name) {
-        responsesExtensions.remove(name);
-    }
-
-    // Callback
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Callback> getCallbacks() {
-        return callbacks.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Callback> getCallbacks(boolean elaborate) {
-        return callbacks.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasCallback(String name) {
-        return callbacks.containsKey(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Callback getCallback(String name) {
-        return callbacks.get(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setCallbacks(Map<String, Callback> callbacks) {
-        this.callbacks.set(callbacks);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setCallback(String name, Callback callback) {
-        callbacks.set(name, callback);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeCallback(String name) {
-        callbacks.remove(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean isCallbackReference(String name) {
-        ChildOverlay<Callback> child = callbacks.getChild(name);
-        return child != null ? child.isReference() : false;
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Reference getCallbackReference(String name) {
-        ChildOverlay<Callback> child = callbacks.getChild(name);
-        return child != null ? child.getReference() : null;
-    }
-
-    // CallbacksExtension
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Object> getCallbacksExtensions() {
-        return callbacksExtensions.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Object> getCallbacksExtensions(boolean elaborate) {
-        return callbacksExtensions.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasCallbacksExtension(String name) {
-        return callbacksExtensions.containsKey(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Object getCallbacksExtension(String name) {
-        return callbacksExtensions.get(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setCallbacksExtensions(Map<String, Object> callbacksExtensions) {
-        this.callbacksExtensions.set(callbacksExtensions);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setCallbacksExtension(String name, Object callbacksExtension) {
-        callbacksExtensions.set(name, callbacksExtension);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeCallbacksExtension(String name) {
-        callbacksExtensions.remove(name);
-    }
-
-    // Deprecated
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Boolean getDeprecated() {
-        return deprecated.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Boolean getDeprecated(boolean elaborate) {
-        return deprecated.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean isDeprecated() {
-        return deprecated.get() != null ? deprecated.get() : false;
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setDeprecated(Boolean deprecated) {
-        this.deprecated.set(deprecated);
-    }
-
-    // SecurityRequirement
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Collection<SecurityRequirement> getSecurityRequirements() {
-        return securityRequirements.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Collection<SecurityRequirement> getSecurityRequirements(boolean elaborate) {
-        return securityRequirements.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasSecurityRequirements() {
-        return securityRequirements.isPresent();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public SecurityRequirement getSecurityRequirement(int index) {
-        return securityRequirements.get(index);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setSecurityRequirements(Collection<SecurityRequirement> securityRequirements) {
-        this.securityRequirements.set(securityRequirements);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setSecurityRequirement(int index, SecurityRequirement securityRequirement) {
-        securityRequirements.set(index, securityRequirement);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void addSecurityRequirement(SecurityRequirement securityRequirement) {
-        securityRequirements.add(securityRequirement);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void insertSecurityRequirement(int index, SecurityRequirement securityRequirement) {
-        securityRequirements.insert(index, securityRequirement);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeSecurityRequirement(int index) {
-        securityRequirements.remove(index);
-    }
-
-    // Server
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Collection<Server> getServers() {
-        return servers.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Collection<Server> getServers(boolean elaborate) {
-        return servers.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasServers() {
-        return servers.isPresent();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Server getServer(int index) {
-        return servers.get(index);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setServers(Collection<Server> servers) {
-        this.servers.set(servers);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setServer(int index, Server server) {
-        servers.set(index, server);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void addServer(Server server) {
-        servers.add(server);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void insertServer(int index, Server server) {
-        servers.insert(index, server);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeServer(int index) {
-        servers.remove(index);
-    }
-
-    // Extension
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Object> getExtensions() {
-        return extensions.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Object> getExtensions(boolean elaborate) {
-        return extensions.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasExtension(String name) {
-        return extensions.containsKey(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Object getExtension(String name) {
-        return extensions.get(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setExtensions(Map<String, Object> extensions) {
-        this.extensions.set(extensions);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setExtension(String name, Object extension) {
-        extensions.set(name, extension);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeExtension(String name) {
-        extensions.remove(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    protected void elaborateChildren() {
-        super.elaborateChildren();
-        tags = createChildList("tags", this, StringOverlay.factory);
-        summary = createChild("summary", this, StringOverlay.factory);
-        description = createChild("description", this, StringOverlay.factory);
-        externalDocs = createChild("externalDocs", this, ExternalDocsImpl.factory);
-        operationId = createChild("operationId", this, StringOverlay.factory);
-        parameters = createChildList("parameters", this, ParameterImpl.factory);
-        refables.put("parameters", parameters);
-        requestBody = createChild("requestBody", this, RequestBodyImpl.factory);
-        refables.put("requestBody", requestBody);
-        responses = createChildMap("responses", this, ResponseImpl.factory, "default|(\\d\\d\\d)");
-        refables.put("responses", responses);
-        responsesExtensions = createChildMap("responses", this, ObjectOverlay.factory, "x-.+");
-        callbacks = createChildMap("callbacks", this, CallbackImpl.factory, "(?!x-)[a-zA-Z0-9\\._-]+");
-        refables.put("callbacks", callbacks);
-        callbacksExtensions = createChildMap("callbacks", this, ObjectOverlay.factory, "x-.+");
-        deprecated = createChild("deprecated", this, BooleanOverlay.factory);
-        securityRequirements = createChildList("security", this, SecurityRequirementImpl.factory);
-        servers = createChildList("servers", this, ServerImpl.factory);
-        extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
-    }
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public static OverlayFactory<Operation> factory = new OverlayFactory<Operation>() {
-
-        @Override
-        protected Class<? extends IJsonOverlay<? super Operation>> getOverlayClass() {
-            return OperationImpl.class;
-        }
-
-        @Override
-        public JsonOverlay<Operation> _create(Operation operation, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            IJsonOverlay<?> overlay;
-            overlay = new OperationImpl(operation, parent, refReg);
-            @SuppressWarnings("unchecked") JsonOverlay<Operation> castOverlay = (JsonOverlay<Operation>) overlay;
-            return castOverlay;
-        }
-
-        @Override
-        public JsonOverlay<Operation> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            IJsonOverlay<?> overlay;
-            overlay = new OperationImpl(json, parent, refReg);
-            @SuppressWarnings("unchecked") JsonOverlay<Operation> castOverlay = (JsonOverlay<Operation>) overlay;
-            return castOverlay;
-        }
-    };
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private static Class<? extends Operation> getSubtypeOf(Operation operation) {
-        return Operation.class;
-    }
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private static Class<? extends Operation> getSubtypeOf(JsonNode json) {
-        return Operation.class;
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public OperationImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+		super(json, parent, refReg);
+	}
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public OperationImpl(Operation operation, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+		super(operation, parent, refReg);
+	}
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildListOverlay<String> tags;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<String> summary;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<String> description;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<ExternalDocs> externalDocs;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<String> operationId;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildListOverlay<Parameter> parameters;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<RequestBody> requestBody;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildMapOverlay<Response> responses;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildMapOverlay<Object> responsesExtensions;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildMapOverlay<Callback> callbacks;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildMapOverlay<Object> callbacksExtensions;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<Boolean> deprecated;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildListOverlay<SecurityRequirement> securityRequirements;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildListOverlay<Server> servers;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildMapOverlay<Object> extensions;
+
+	// Tag
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Collection<String> getTags() {
+		return tags._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Collection<String> getTags(boolean elaborate) {
+		return tags._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasTags() {
+		return tags._isPresent();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getTag(int index) {
+		return tags._get(index);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setTags(Collection<String> tags) {
+		this.tags._set(tags);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setTag(int index, String tag) {
+		tags._set(index, tag);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void addTag(String tag) {
+		tags._add(tag);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void insertTag(int index, String tag) {
+		tags._insert(index, tag);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeTag(int index) {
+		tags._remove(index);
+	}
+
+	// Summary
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getSummary() {
+		return summary._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getSummary(boolean elaborate) {
+		return summary._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setSummary(String summary) {
+		this.summary._set(summary);
+	}
+
+	// Description
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getDescription() {
+		return description._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getDescription(boolean elaborate) {
+		return description._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setDescription(String description) {
+		this.description._set(description);
+	}
+
+	// ExternalDocs
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public ExternalDocs getExternalDocs() {
+		return externalDocs._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public ExternalDocs getExternalDocs(boolean elaborate) {
+		return externalDocs._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setExternalDocs(ExternalDocs externalDocs) {
+		this.externalDocs._set(externalDocs);
+	}
+
+	// OperationId
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getOperationId() {
+		return operationId._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getOperationId(boolean elaborate) {
+		return operationId._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setOperationId(String operationId) {
+		this.operationId._set(operationId);
+	}
+
+	// Parameter
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Collection<Parameter> getParameters() {
+		return parameters._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Collection<Parameter> getParameters(boolean elaborate) {
+		return parameters._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasParameters() {
+		return parameters._isPresent();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Parameter getParameter(int index) {
+		return parameters._get(index);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setParameters(Collection<Parameter> parameters) {
+		this.parameters._set(parameters);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setParameter(int index, Parameter parameter) {
+		parameters._set(index, parameter);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void addParameter(Parameter parameter) {
+		parameters._add(parameter);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void insertParameter(int index, Parameter parameter) {
+		parameters._insert(index, parameter);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeParameter(int index) {
+		parameters._remove(index);
+	}
+
+	// RequestBody
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public RequestBody getRequestBody() {
+		return requestBody._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public RequestBody getRequestBody(boolean elaborate) {
+		return requestBody._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setRequestBody(RequestBody requestBody) {
+		this.requestBody._set(requestBody);
+	}
+
+	// Response
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Response> getResponses() {
+		return responses._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Response> getResponses(boolean elaborate) {
+		return responses._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasResponse(String name) {
+		return responses.containsKey(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Response getResponse(String name) {
+		return responses._get(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setResponses(Map<String, Response> responses) {
+		this.responses._set(responses);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setResponse(String name, Response response) {
+		responses._set(name, response);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeResponse(String name) {
+		responses._remove(name);
+	}
+
+	// ResponsesExtension
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Object> getResponsesExtensions() {
+		return responsesExtensions._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Object> getResponsesExtensions(boolean elaborate) {
+		return responsesExtensions._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasResponsesExtension(String name) {
+		return responsesExtensions.containsKey(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Object getResponsesExtension(String name) {
+		return responsesExtensions._get(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setResponsesExtensions(Map<String, Object> responsesExtensions) {
+		this.responsesExtensions._set(responsesExtensions);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setResponsesExtension(String name, Object responsesExtension) {
+		responsesExtensions._set(name, responsesExtension);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeResponsesExtension(String name) {
+		responsesExtensions._remove(name);
+	}
+
+	// Callback
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Callback> getCallbacks() {
+		return callbacks._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Callback> getCallbacks(boolean elaborate) {
+		return callbacks._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasCallback(String name) {
+		return callbacks.containsKey(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Callback getCallback(String name) {
+		return callbacks._get(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setCallbacks(Map<String, Callback> callbacks) {
+		this.callbacks._set(callbacks);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setCallback(String name, Callback callback) {
+		callbacks._set(name, callback);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeCallback(String name) {
+		callbacks._remove(name);
+	}
+
+	// CallbacksExtension
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Object> getCallbacksExtensions() {
+		return callbacksExtensions._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Object> getCallbacksExtensions(boolean elaborate) {
+		return callbacksExtensions._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasCallbacksExtension(String name) {
+		return callbacksExtensions.containsKey(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Object getCallbacksExtension(String name) {
+		return callbacksExtensions._get(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setCallbacksExtensions(Map<String, Object> callbacksExtensions) {
+		this.callbacksExtensions._set(callbacksExtensions);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setCallbacksExtension(String name, Object callbacksExtension) {
+		callbacksExtensions._set(name, callbacksExtension);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeCallbacksExtension(String name) {
+		callbacksExtensions._remove(name);
+	}
+
+	// Deprecated
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Boolean getDeprecated() {
+		return deprecated._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Boolean getDeprecated(boolean elaborate) {
+		return deprecated._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean isDeprecated() {
+		return deprecated._get() != null ? deprecated._get() : false;
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setDeprecated(Boolean deprecated) {
+		this.deprecated._set(deprecated);
+	}
+
+	// SecurityRequirement
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Collection<SecurityRequirement> getSecurityRequirements() {
+		return securityRequirements._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Collection<SecurityRequirement> getSecurityRequirements(boolean elaborate) {
+		return securityRequirements._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasSecurityRequirements() {
+		return securityRequirements._isPresent();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public SecurityRequirement getSecurityRequirement(int index) {
+		return securityRequirements._get(index);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setSecurityRequirements(Collection<SecurityRequirement> securityRequirements) {
+		this.securityRequirements._set(securityRequirements);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setSecurityRequirement(int index, SecurityRequirement securityRequirement) {
+		securityRequirements._set(index, securityRequirement);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void addSecurityRequirement(SecurityRequirement securityRequirement) {
+		securityRequirements._add(securityRequirement);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void insertSecurityRequirement(int index, SecurityRequirement securityRequirement) {
+		securityRequirements._insert(index, securityRequirement);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeSecurityRequirement(int index) {
+		securityRequirements._remove(index);
+	}
+
+	// Server
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Collection<Server> getServers() {
+		return servers._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Collection<Server> getServers(boolean elaborate) {
+		return servers._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasServers() {
+		return servers._isPresent();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Server getServer(int index) {
+		return servers._get(index);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setServers(Collection<Server> servers) {
+		this.servers._set(servers);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setServer(int index, Server server) {
+		servers._set(index, server);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void addServer(Server server) {
+		servers._add(server);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void insertServer(int index, Server server) {
+		servers._insert(index, server);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeServer(int index) {
+		servers._remove(index);
+	}
+
+	// Extension
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Object> getExtensions() {
+		return extensions._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Object> getExtensions(boolean elaborate) {
+		return extensions._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasExtension(String name) {
+		return extensions.containsKey(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Object getExtension(String name) {
+		return extensions._get(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setExtensions(Map<String, Object> extensions) {
+		this.extensions._set(extensions);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setExtension(String name, Object extension) {
+		extensions._set(name, extension);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeExtension(String name) {
+		extensions._remove(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	protected void elaborateChildren() {
+		super.elaborateChildren();
+		tags = createChildList("tags", this, StringOverlay.factory);
+		summary = createChild("summary", this, StringOverlay.factory);
+		description = createChild("description", this, StringOverlay.factory);
+		externalDocs = createChild("externalDocs", this, ExternalDocsImpl.factory);
+		operationId = createChild("operationId", this, StringOverlay.factory);
+		parameters = createChildList("parameters", this, ParameterImpl.factory);
+		requestBody = createChild("requestBody", this, RequestBodyImpl.factory);
+		responses = createChildMap("responses", this, ResponseImpl.factory, "default|(\\d\\d\\d)");
+		responsesExtensions = createChildMap("responses", this, ObjectOverlay.factory, "x-.+");
+		callbacks = createChildMap("callbacks", this, CallbackImpl.factory, "(?!x-)[a-zA-Z0-9\\._-]+");
+		callbacksExtensions = createChildMap("callbacks", this, ObjectOverlay.factory, "x-.+");
+		deprecated = createChild("deprecated", this, BooleanOverlay.factory);
+		securityRequirements = createChildList("security", this, SecurityRequirementImpl.factory);
+		servers = createChildList("servers", this, ServerImpl.factory);
+		extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
+	}
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public static OverlayFactory<Operation> factory = new OverlayFactory<Operation>() {
+
+		@Override
+		protected Class<? extends AbstractJsonOverlay<? super Operation>> getOverlayClass() {
+			return OperationImpl.class;
+		}
+
+		@Override
+		public JsonOverlay<Operation> _create(Operation operation, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+			AbstractJsonOverlay<?> overlay;
+			overlay = new OperationImpl(operation, parent, refReg);
+			@SuppressWarnings("unchecked")
+			JsonOverlay<Operation> castOverlay = (JsonOverlay<Operation>) overlay;
+			return castOverlay;
+		}
+
+		@Override
+		public JsonOverlay<Operation> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+			AbstractJsonOverlay<?> overlay;
+			overlay = new OperationImpl(json, parent, refReg);
+			@SuppressWarnings("unchecked")
+			JsonOverlay<Operation> castOverlay = (JsonOverlay<Operation>) overlay;
+			return castOverlay;
+		}
+	};
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private static Class<? extends Operation> getSubtypeOf(Operation operation) {
+		return Operation.class;
+	}
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private static Class<? extends Operation> getSubtypeOf(JsonNode json) {
+		return Operation.class;
+	}
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ParameterImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ParameterImpl.java
@@ -1,532 +1,501 @@
 package com.reprezen.kaizen.oasparser.ovl3;
 
-import com.reprezen.jsonoverlay.StringOverlay;
-import com.reprezen.kaizen.oasparser.model3.Schema;
-import com.reprezen.jsonoverlay.ReferenceRegistry;
-import com.reprezen.jsonoverlay.ChildMapOverlay;
-import com.reprezen.kaizen.oasparser.ovl3.MediaTypeImpl;
-import com.reprezen.kaizen.oasparser.ovl3.ExampleImpl;
-import com.reprezen.jsonoverlay.Reference;
-import com.reprezen.jsonoverlay.ObjectOverlay;
+import java.util.Map;
+
+import javax.annotation.Generated;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.reprezen.jsonoverlay.AbstractJsonOverlay;
 import com.reprezen.jsonoverlay.BooleanOverlay;
-import com.reprezen.jsonoverlay.MapOverlay;
-import java.util.stream.Collectors;
-import com.reprezen.kaizen.oasparser.model3.*;
+import com.reprezen.jsonoverlay.ChildMapOverlay;
+import com.reprezen.jsonoverlay.ChildOverlay;
+import com.reprezen.jsonoverlay.JsonOverlay;
+import com.reprezen.jsonoverlay.ObjectOverlay;
 import com.reprezen.jsonoverlay.OverlayFactory;
 import com.reprezen.jsonoverlay.PropertiesOverlay;
-import com.fasterxml.jackson.core.JsonPointer;
-import javax.annotation.Generated;
-import com.reprezen.kaizen.oasparser.ovl3.SchemaImpl;
-import com.reprezen.kaizen.oasparser.model3.MediaType;
-import com.reprezen.jsonoverlay.IJsonOverlay;
+import com.reprezen.jsonoverlay.ReferenceRegistry;
+import com.reprezen.jsonoverlay.StringOverlay;
 import com.reprezen.kaizen.oasparser.model3.Example;
-import com.reprezen.jsonoverlay.JsonOverlay;
-import java.util.Map;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.reprezen.jsonoverlay.ChildOverlay;
+import com.reprezen.kaizen.oasparser.model3.MediaType;
+import com.reprezen.kaizen.oasparser.model3.Parameter;
+import com.reprezen.kaizen.oasparser.model3.Schema;
 
 public class ParameterImpl extends PropertiesOverlay<Parameter> implements Parameter {
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public ParameterImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        super(json, parent, refReg);
-    }
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public ParameterImpl(Parameter parameter, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        super(parameter, parent, refReg);
-    }
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<String> name;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<String> in;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<String> description;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<Boolean> required;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<Boolean> deprecated;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<Boolean> allowEmptyValue;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<String> style;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<Boolean> explode;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<Boolean> allowReserved;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<Schema> schema;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<Object> example;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildMapOverlay<Example> examples;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildMapOverlay<MediaType> contentMediaTypes;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildMapOverlay<Object> extensions;
-
-    // Name
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getName() {
-        return name.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getName(boolean elaborate) {
-        return name.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setName(String name) {
-        this.name.set(name);
-    }
-
-    // In
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getIn() {
-        return in.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getIn(boolean elaborate) {
-        return in.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setIn(String in) {
-        this.in.set(in);
-    }
-
-    // Description
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getDescription() {
-        return description.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getDescription(boolean elaborate) {
-        return description.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setDescription(String description) {
-        this.description.set(description);
-    }
-
-    // Required
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Boolean getRequired() {
-        return required.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Boolean getRequired(boolean elaborate) {
-        return required.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean isRequired() {
-        return required.get() != null ? required.get() : false;
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setRequired(Boolean required) {
-        this.required.set(required);
-    }
-
-    // Deprecated
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Boolean getDeprecated() {
-        return deprecated.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Boolean getDeprecated(boolean elaborate) {
-        return deprecated.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean isDeprecated() {
-        return deprecated.get() != null ? deprecated.get() : false;
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setDeprecated(Boolean deprecated) {
-        this.deprecated.set(deprecated);
-    }
-
-    // AllowEmptyValue
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Boolean getAllowEmptyValue() {
-        return allowEmptyValue.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Boolean getAllowEmptyValue(boolean elaborate) {
-        return allowEmptyValue.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean isAllowEmptyValue() {
-        return allowEmptyValue.get() != null ? allowEmptyValue.get() : false;
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setAllowEmptyValue(Boolean allowEmptyValue) {
-        this.allowEmptyValue.set(allowEmptyValue);
-    }
-
-    // Style
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getStyle() {
-        return style.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getStyle(boolean elaborate) {
-        return style.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setStyle(String style) {
-        this.style.set(style);
-    }
-
-    // Explode
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Boolean getExplode() {
-        return explode.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Boolean getExplode(boolean elaborate) {
-        return explode.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean isExplode() {
-        return explode.get() != null ? explode.get() : false;
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setExplode(Boolean explode) {
-        this.explode.set(explode);
-    }
-
-    // AllowReserved
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Boolean getAllowReserved() {
-        return allowReserved.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Boolean getAllowReserved(boolean elaborate) {
-        return allowReserved.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean isAllowReserved() {
-        return allowReserved.get() != null ? allowReserved.get() : false;
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setAllowReserved(Boolean allowReserved) {
-        this.allowReserved.set(allowReserved);
-    }
-
-    // Schema
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Schema getSchema() {
-        return schema.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Schema getSchema(boolean elaborate) {
-        return schema.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setSchema(Schema schema) {
-        this.schema.set(schema);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean isSchemaReference() {
-        return schema != null ? schema.isReference() : false;
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Reference getSchemaReference() {
-        return schema != null ? schema.getReference() : null;
-    }
-
-    // Example
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Object getExample() {
-        return example.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Object getExample(boolean elaborate) {
-        return example.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setExample(Object example) {
-        this.example.set(example);
-    }
-
-    // Example
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Example> getExamples() {
-        return examples.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Example> getExamples(boolean elaborate) {
-        return examples.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasExample(String name) {
-        return examples.containsKey(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Example getExample(String name) {
-        return examples.get(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setExamples(Map<String, Example> examples) {
-        this.examples.set(examples);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setExample(String name, Example example) {
-        examples.set(name, example);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeExample(String name) {
-        examples.remove(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean isExampleReference(String name) {
-        ChildOverlay<Example> child = examples.getChild(name);
-        return child != null ? child.isReference() : false;
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Reference getExampleReference(String name) {
-        ChildOverlay<Example> child = examples.getChild(name);
-        return child != null ? child.getReference() : null;
-    }
-
-    // ContentMediaType
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, MediaType> getContentMediaTypes() {
-        return contentMediaTypes.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, MediaType> getContentMediaTypes(boolean elaborate) {
-        return contentMediaTypes.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasContentMediaType(String name) {
-        return contentMediaTypes.containsKey(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public MediaType getContentMediaType(String name) {
-        return contentMediaTypes.get(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setContentMediaTypes(Map<String, MediaType> contentMediaTypes) {
-        this.contentMediaTypes.set(contentMediaTypes);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setContentMediaType(String name, MediaType contentMediaType) {
-        contentMediaTypes.set(name, contentMediaType);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeContentMediaType(String name) {
-        contentMediaTypes.remove(name);
-    }
-
-    // Extension
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Object> getExtensions() {
-        return extensions.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Object> getExtensions(boolean elaborate) {
-        return extensions.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasExtension(String name) {
-        return extensions.containsKey(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Object getExtension(String name) {
-        return extensions.get(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setExtensions(Map<String, Object> extensions) {
-        this.extensions.set(extensions);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setExtension(String name, Object extension) {
-        extensions.set(name, extension);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeExtension(String name) {
-        extensions.remove(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    protected void elaborateChildren() {
-        super.elaborateChildren();
-        name = createChild("name", this, StringOverlay.factory);
-        in = createChild("in", this, StringOverlay.factory);
-        description = createChild("description", this, StringOverlay.factory);
-        required = createChild("required", this, BooleanOverlay.factory);
-        deprecated = createChild("deprecated", this, BooleanOverlay.factory);
-        allowEmptyValue = createChild("allowEmptyValue", this, BooleanOverlay.factory);
-        style = createChild("style", this, StringOverlay.factory);
-        explode = createChild("explode", this, BooleanOverlay.factory);
-        allowReserved = createChild("allowReserved", this, BooleanOverlay.factory);
-        schema = createChild("schema", this, SchemaImpl.factory);
-        refables.put("schema", schema);
-        example = createChild("example", this, ObjectOverlay.factory);
-        examples = createChildMap("examples", this, ExampleImpl.factory, "[a-zA-Z0-9\\._-]+");
-        refables.put("examples", examples);
-        contentMediaTypes = createChildMap("content", this, MediaTypeImpl.factory, null);
-        extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
-    }
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public static OverlayFactory<Parameter> factory = new OverlayFactory<Parameter>() {
-
-        @Override
-        protected Class<? extends IJsonOverlay<? super Parameter>> getOverlayClass() {
-            return ParameterImpl.class;
-        }
-
-        @Override
-        public JsonOverlay<Parameter> _create(Parameter parameter, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            IJsonOverlay<?> overlay;
-            overlay = new ParameterImpl(parameter, parent, refReg);
-            @SuppressWarnings("unchecked") JsonOverlay<Parameter> castOverlay = (JsonOverlay<Parameter>) overlay;
-            return castOverlay;
-        }
-
-        @Override
-        public JsonOverlay<Parameter> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            IJsonOverlay<?> overlay;
-            overlay = new ParameterImpl(json, parent, refReg);
-            @SuppressWarnings("unchecked") JsonOverlay<Parameter> castOverlay = (JsonOverlay<Parameter>) overlay;
-            return castOverlay;
-        }
-    };
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private static Class<? extends Parameter> getSubtypeOf(Parameter parameter) {
-        return Parameter.class;
-    }
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private static Class<? extends Parameter> getSubtypeOf(JsonNode json) {
-        return Parameter.class;
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public ParameterImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+		super(json, parent, refReg);
+	}
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public ParameterImpl(Parameter parameter, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+		super(parameter, parent, refReg);
+	}
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<String> name;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<String> in;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<String> description;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<Boolean> required;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<Boolean> deprecated;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<Boolean> allowEmptyValue;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<String> style;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<Boolean> explode;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<Boolean> allowReserved;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<Schema> schema;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<Object> example;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildMapOverlay<Example> examples;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildMapOverlay<MediaType> contentMediaTypes;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildMapOverlay<Object> extensions;
+
+	// Name
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getName() {
+		return name._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getName(boolean elaborate) {
+		return name._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setName(String name) {
+		this.name._set(name);
+	}
+
+	// In
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getIn() {
+		return in._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getIn(boolean elaborate) {
+		return in._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setIn(String in) {
+		this.in._set(in);
+	}
+
+	// Description
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getDescription() {
+		return description._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getDescription(boolean elaborate) {
+		return description._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setDescription(String description) {
+		this.description._set(description);
+	}
+
+	// Required
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Boolean getRequired() {
+		return required._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Boolean getRequired(boolean elaborate) {
+		return required._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean isRequired() {
+		return required._get() != null ? required._get() : false;
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setRequired(Boolean required) {
+		this.required._set(required);
+	}
+
+	// Deprecated
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Boolean getDeprecated() {
+		return deprecated._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Boolean getDeprecated(boolean elaborate) {
+		return deprecated._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean isDeprecated() {
+		return deprecated._get() != null ? deprecated._get() : false;
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setDeprecated(Boolean deprecated) {
+		this.deprecated._set(deprecated);
+	}
+
+	// AllowEmptyValue
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Boolean getAllowEmptyValue() {
+		return allowEmptyValue._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Boolean getAllowEmptyValue(boolean elaborate) {
+		return allowEmptyValue._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean isAllowEmptyValue() {
+		return allowEmptyValue._get() != null ? allowEmptyValue._get() : false;
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setAllowEmptyValue(Boolean allowEmptyValue) {
+		this.allowEmptyValue._set(allowEmptyValue);
+	}
+
+	// Style
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getStyle() {
+		return style._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getStyle(boolean elaborate) {
+		return style._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setStyle(String style) {
+		this.style._set(style);
+	}
+
+	// Explode
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Boolean getExplode() {
+		return explode._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Boolean getExplode(boolean elaborate) {
+		return explode._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean isExplode() {
+		return explode._get() != null ? explode._get() : false;
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setExplode(Boolean explode) {
+		this.explode._set(explode);
+	}
+
+	// AllowReserved
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Boolean getAllowReserved() {
+		return allowReserved._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Boolean getAllowReserved(boolean elaborate) {
+		return allowReserved._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean isAllowReserved() {
+		return allowReserved._get() != null ? allowReserved._get() : false;
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setAllowReserved(Boolean allowReserved) {
+		this.allowReserved._set(allowReserved);
+	}
+
+	// Schema
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Schema getSchema() {
+		return schema._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Schema getSchema(boolean elaborate) {
+		return schema._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setSchema(Schema schema) {
+		this.schema._set(schema);
+	}
+
+	// Example
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Object getExample() {
+		return example._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Object getExample(boolean elaborate) {
+		return example._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setExample(Object example) {
+		this.example._set(example);
+	}
+
+	// Example
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Example> getExamples() {
+		return examples._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Example> getExamples(boolean elaborate) {
+		return examples._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasExample(String name) {
+		return examples.containsKey(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Example getExample(String name) {
+		return examples._get(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setExamples(Map<String, Example> examples) {
+		this.examples._set(examples);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setExample(String name, Example example) {
+		examples._set(name, example);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeExample(String name) {
+		examples._remove(name);
+	}
+
+	// ContentMediaType
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, MediaType> getContentMediaTypes() {
+		return contentMediaTypes._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, MediaType> getContentMediaTypes(boolean elaborate) {
+		return contentMediaTypes._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasContentMediaType(String name) {
+		return contentMediaTypes.containsKey(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public MediaType getContentMediaType(String name) {
+		return contentMediaTypes._get(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setContentMediaTypes(Map<String, MediaType> contentMediaTypes) {
+		this.contentMediaTypes._set(contentMediaTypes);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setContentMediaType(String name, MediaType contentMediaType) {
+		contentMediaTypes._set(name, contentMediaType);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeContentMediaType(String name) {
+		contentMediaTypes._remove(name);
+	}
+
+	// Extension
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Object> getExtensions() {
+		return extensions._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Object> getExtensions(boolean elaborate) {
+		return extensions._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasExtension(String name) {
+		return extensions.containsKey(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Object getExtension(String name) {
+		return extensions._get(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setExtensions(Map<String, Object> extensions) {
+		this.extensions._set(extensions);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setExtension(String name, Object extension) {
+		extensions._set(name, extension);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeExtension(String name) {
+		extensions._remove(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	protected void elaborateChildren() {
+		super.elaborateChildren();
+		name = createChild("name", this, StringOverlay.factory);
+		in = createChild("in", this, StringOverlay.factory);
+		description = createChild("description", this, StringOverlay.factory);
+		required = createChild("required", this, BooleanOverlay.factory);
+		deprecated = createChild("deprecated", this, BooleanOverlay.factory);
+		allowEmptyValue = createChild("allowEmptyValue", this, BooleanOverlay.factory);
+		style = createChild("style", this, StringOverlay.factory);
+		explode = createChild("explode", this, BooleanOverlay.factory);
+		allowReserved = createChild("allowReserved", this, BooleanOverlay.factory);
+		schema = createChild("schema", this, SchemaImpl.factory);
+		example = createChild("example", this, ObjectOverlay.factory);
+		examples = createChildMap("examples", this, ExampleImpl.factory, "[a-zA-Z0-9\\._-]+");
+		contentMediaTypes = createChildMap("content", this, MediaTypeImpl.factory, null);
+		extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
+	}
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public static OverlayFactory<Parameter> factory = new OverlayFactory<Parameter>() {
+
+		@Override
+		protected Class<? extends AbstractJsonOverlay<? super Parameter>> getOverlayClass() {
+			return ParameterImpl.class;
+		}
+
+		@Override
+		public JsonOverlay<Parameter> _create(Parameter parameter, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+			AbstractJsonOverlay<?> overlay;
+			overlay = new ParameterImpl(parameter, parent, refReg);
+			@SuppressWarnings("unchecked")
+			JsonOverlay<Parameter> castOverlay = (JsonOverlay<Parameter>) overlay;
+			return castOverlay;
+		}
+
+		@Override
+		public JsonOverlay<Parameter> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+			AbstractJsonOverlay<?> overlay;
+			overlay = new ParameterImpl(json, parent, refReg);
+			@SuppressWarnings("unchecked")
+			JsonOverlay<Parameter> castOverlay = (JsonOverlay<Parameter>) overlay;
+			return castOverlay;
+		}
+	};
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private static Class<? extends Parameter> getSubtypeOf(Parameter parameter) {
+		return Parameter.class;
+	}
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private static Class<? extends Parameter> getSubtypeOf(JsonNode json) {
+		return Parameter.class;
+	}
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/PathImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/PathImpl.java
@@ -1,473 +1,456 @@
 package com.reprezen.kaizen.oasparser.ovl3;
 
-import com.reprezen.jsonoverlay.StringOverlay;
-import com.reprezen.kaizen.oasparser.model3.Server;
-import com.reprezen.jsonoverlay.ReferenceRegistry;
-import com.reprezen.jsonoverlay.Reference;
-import com.reprezen.kaizen.oasparser.ovl3.ParameterImpl;
-import com.fasterxml.jackson.core.JsonPointer;
-import javax.annotation.Generated;
-import com.reprezen.jsonoverlay.IJsonOverlay;
-import com.reprezen.kaizen.oasparser.model3.Parameter;
-import com.reprezen.jsonoverlay.JsonOverlay;
-import java.util.Map;
-import com.reprezen.jsonoverlay.ListOverlay;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.reprezen.kaizen.oasparser.ovl3.ServerImpl;
-import com.reprezen.jsonoverlay.ChildListOverlay;
-import com.reprezen.kaizen.oasparser.ovl3.OperationImpl;
-import com.reprezen.jsonoverlay.ChildMapOverlay;
 import java.util.Collection;
+import java.util.Map;
+
+import javax.annotation.Generated;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.reprezen.jsonoverlay.AbstractJsonOverlay;
+import com.reprezen.jsonoverlay.ChildListOverlay;
+import com.reprezen.jsonoverlay.ChildMapOverlay;
+import com.reprezen.jsonoverlay.ChildOverlay;
+import com.reprezen.jsonoverlay.JsonOverlay;
 import com.reprezen.jsonoverlay.ObjectOverlay;
-import com.reprezen.jsonoverlay.MapOverlay;
-import java.util.stream.Collectors;
-import com.reprezen.kaizen.oasparser.model3.*;
 import com.reprezen.jsonoverlay.OverlayFactory;
 import com.reprezen.jsonoverlay.PropertiesOverlay;
+import com.reprezen.jsonoverlay.ReferenceRegistry;
+import com.reprezen.jsonoverlay.StringOverlay;
 import com.reprezen.kaizen.oasparser.model3.Operation;
-import com.reprezen.jsonoverlay.ChildOverlay;
+import com.reprezen.kaizen.oasparser.model3.Parameter;
+import com.reprezen.kaizen.oasparser.model3.Path;
+import com.reprezen.kaizen.oasparser.model3.Server;
 
 public class PathImpl extends PropertiesOverlay<Path> implements Path {
 
-    @Override
-    public Operation getGet() {
-        return operations.get("get");
-    }
-
-    @Override
-    public Operation getGet(boolean elaborate) {
-        return operations.get("get").get(elaborate);
-    }
-
-    @Override
-    public void setGet(Operation get) {
-        operations.set("get", (OperationImpl) get);
-    }
-
-    @Override
-    public Operation getPut() {
-        return operations.get("put");
-    }
-
-    @Override
-    public Operation getPut(boolean elaborate) {
-        return operations.get("put").get(elaborate);
-    }
-
-    @Override
-    public void setPut(Operation put) {
-        operations.set("put", (OperationImpl) put);
-    }
-
-    @Override
-    public Operation getPost() {
-        return operations.get("post");
-    }
-
-    @Override
-    public Operation getPost(boolean elaborate) {
-        return operations.get("post").get(elaborate);
-    }
-
-    @Override
-    public void setPost(Operation post) {
-        operations.set("post", (OperationImpl) post);
-    }
-
-    @Override
-    public Operation getDelete() {
-        return operations.get("delete");
-    }
-
-    @Override
-    public Operation getDelete(boolean elaborate) {
-        return operations.get("delete").get(elaborate);
-    }
-
-    @Override
-    public void setDelete(Operation delete) {
-        operations.set("delete", (OperationImpl) delete);
-    }
-
-    @Override
-    public Operation getOptions() {
-        return operations.get("options");
-    }
-
-    @Override
-    public Operation getOptions(boolean elaborate) {
-        return operations.get("options").get(elaborate);
-    }
-
-    @Override
-    public void setOptions(Operation options) {
-        operations.set("options", (OperationImpl) options);
-    }
-
-    @Override
-    public Operation getHead() {
-        return operations.get("head");
-    }
-
-    @Override
-    public Operation getHead(boolean elaborate) {
-        return operations.get("head").get(elaborate);
-    }
-
-    @Override
-    public void setHead(Operation head) {
-        operations.set("head", (OperationImpl) head);
-    }
-
-    @Override
-    public Operation getPatch() {
-        return operations.get("patch");
-    }
-
-    @Override
-    public Operation getPatch(boolean elaborate) {
-        return operations.get("patch").get(elaborate);
-    }
-
-    @Override
-    public void setPatch(Operation patch) {
-        operations.set("patch", (OperationImpl) patch);
-    }
-
-    @Override
-    public Operation getTrace() {
-        return operations.get("trace");
-    }
-
-    @Override
-    public Operation getTrace(boolean elaborate) {
-        return operations.get("trace").get(elaborate);
-    }
-
-    @Override
-    public void setTrace(Operation trace) {
-        operations.set("trace", (OperationImpl) trace);
-    }
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public PathImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        super(json, parent, refReg);
-    }
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public PathImpl(Path path, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        super(path, parent, refReg);
-    }
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<String> summary;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<String> description;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildMapOverlay<Operation> operations;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildListOverlay<Server> servers;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildListOverlay<Parameter> parameters;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildMapOverlay<Object> extensions;
-
-    // Summary
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getSummary() {
-        return summary.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getSummary(boolean elaborate) {
-        return summary.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setSummary(String summary) {
-        this.summary.set(summary);
-    }
-
-    // Description
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getDescription() {
-        return description.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getDescription(boolean elaborate) {
-        return description.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setDescription(String description) {
-        this.description.set(description);
-    }
-
-    // Operation
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Operation> getOperations() {
-        return operations.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Operation> getOperations(boolean elaborate) {
-        return operations.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasOperation(String name) {
-        return operations.containsKey(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Operation getOperation(String name) {
-        return operations.get(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setOperations(Map<String, Operation> operations) {
-        this.operations.set(operations);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setOperation(String name, Operation operation) {
-        operations.set(name, operation);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeOperation(String name) {
-        operations.remove(name);
-    }
-
-    // Server
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Collection<Server> getServers() {
-        return servers.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Collection<Server> getServers(boolean elaborate) {
-        return servers.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasServers() {
-        return servers.isPresent();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Server getServer(int index) {
-        return servers.get(index);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setServers(Collection<Server> servers) {
-        this.servers.set(servers);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setServer(int index, Server server) {
-        servers.set(index, server);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void addServer(Server server) {
-        servers.add(server);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void insertServer(int index, Server server) {
-        servers.insert(index, server);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeServer(int index) {
-        servers.remove(index);
-    }
-
-    // Parameter
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Collection<Parameter> getParameters() {
-        return parameters.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Collection<Parameter> getParameters(boolean elaborate) {
-        return parameters.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasParameters() {
-        return parameters.isPresent();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Parameter getParameter(int index) {
-        return parameters.get(index);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setParameters(Collection<Parameter> parameters) {
-        this.parameters.set(parameters);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setParameter(int index, Parameter parameter) {
-        parameters.set(index, parameter);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void addParameter(Parameter parameter) {
-        parameters.add(parameter);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void insertParameter(int index, Parameter parameter) {
-        parameters.insert(index, parameter);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeParameter(int index) {
-        parameters.remove(index);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean isParameterReference(int index) {
-        return parameters.getChild(index).isReference();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Reference getParameterReference(int index) {
-        return parameters.getChild(index).getReference();
-    }
-
-    // Extension
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Object> getExtensions() {
-        return extensions.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Object> getExtensions(boolean elaborate) {
-        return extensions.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasExtension(String name) {
-        return extensions.containsKey(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Object getExtension(String name) {
-        return extensions.get(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setExtensions(Map<String, Object> extensions) {
-        this.extensions.set(extensions);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setExtension(String name, Object extension) {
-        extensions.set(name, extension);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeExtension(String name) {
-        extensions.remove(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    protected void elaborateChildren() {
-        super.elaborateChildren();
-        summary = createChild("summary", this, StringOverlay.factory);
-        description = createChild("description", this, StringOverlay.factory);
-        operations = createChildMap("", this, OperationImpl.factory, "get|put|post|delete|options|head|patch|trace");
-        servers = createChildList("servers", this, ServerImpl.factory);
-        parameters = createChildList("parameters", this, ParameterImpl.factory);
-        refables.put("parameters", parameters);
-        extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
-    }
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public static OverlayFactory<Path> factory = new OverlayFactory<Path>() {
-
-        @Override
-        protected Class<? extends IJsonOverlay<? super Path>> getOverlayClass() {
-            return PathImpl.class;
-        }
-
-        @Override
-        public JsonOverlay<Path> _create(Path path, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            IJsonOverlay<?> overlay;
-            overlay = new PathImpl(path, parent, refReg);
-            @SuppressWarnings("unchecked") JsonOverlay<Path> castOverlay = (JsonOverlay<Path>) overlay;
-            return castOverlay;
-        }
-
-        @Override
-        public JsonOverlay<Path> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            IJsonOverlay<?> overlay;
-            overlay = new PathImpl(json, parent, refReg);
-            @SuppressWarnings("unchecked") JsonOverlay<Path> castOverlay = (JsonOverlay<Path>) overlay;
-            return castOverlay;
-        }
-    };
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private static Class<? extends Path> getSubtypeOf(Path path) {
-        return Path.class;
-    }
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private static Class<? extends Path> getSubtypeOf(JsonNode json) {
-        return Path.class;
-    }
+	@Override
+	public Operation getGet() {
+		return operations._get("get");
+	}
+
+	@Override
+	public Operation getGet(boolean elaborate) {
+		return ((OperationImpl) operations._get("get"))._get(elaborate);
+	}
+
+	@Override
+	public void setGet(Operation get) {
+		operations._set("get", (OperationImpl) get);
+	}
+
+	@Override
+	public Operation getPut() {
+		return operations._get("put");
+	}
+
+	@Override
+	public Operation getPut(boolean elaborate) {
+		return ((OperationImpl) operations._get("put"))._get(elaborate);
+	}
+
+	@Override
+	public void setPut(Operation put) {
+		operations._set("put", (OperationImpl) put);
+	}
+
+	@Override
+	public Operation getPost() {
+		return operations._get("post");
+	}
+
+	@Override
+	public Operation getPost(boolean elaborate) {
+		return ((OperationImpl) operations._get("post"))._get(elaborate);
+	}
+
+	@Override
+	public void setPost(Operation post) {
+		operations._set("post", (OperationImpl) post);
+	}
+
+	@Override
+	public Operation getDelete() {
+		return operations._get("delete");
+	}
+
+	@Override
+	public Operation getDelete(boolean elaborate) {
+		return ((OperationImpl) operations._get("delete"))._get(elaborate);
+	}
+
+	@Override
+	public void setDelete(Operation delete) {
+		operations._set("delete", (OperationImpl) delete);
+	}
+
+	@Override
+	public Operation getOptions() {
+		return operations._get("options");
+	}
+
+	@Override
+	public Operation getOptions(boolean elaborate) {
+		return ((OperationImpl) operations._get("options"))._get(elaborate);
+	}
+
+	@Override
+	public void setOptions(Operation options) {
+		operations._set("options", (OperationImpl) options);
+	}
+
+	@Override
+	public Operation getHead() {
+		return operations._get("head");
+	}
+
+	@Override
+	public Operation getHead(boolean elaborate) {
+		return ((OperationImpl) operations._get("head"))._get(elaborate);
+	}
+
+	@Override
+	public void setHead(Operation head) {
+		operations._set("head", (OperationImpl) head);
+	}
+
+	@Override
+	public Operation getPatch() {
+		return operations._get("patch");
+	}
+
+	@Override
+	public Operation getPatch(boolean elaborate) {
+		return ((OperationImpl) operations._get("patch"))._get(elaborate);
+	}
+
+	@Override
+	public void setPatch(Operation patch) {
+		operations._set("patch", (OperationImpl) patch);
+	}
+
+	@Override
+	public Operation getTrace() {
+		return operations._get("trace");
+	}
+
+	@Override
+	public Operation getTrace(boolean elaborate) {
+		return ((OperationImpl) operations._get("trace"))._get(elaborate);
+	}
+
+	@Override
+	public void setTrace(Operation trace) {
+		operations._set("trace", (OperationImpl) trace);
+	}
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public PathImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+		super(json, parent, refReg);
+	}
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public PathImpl(Path path, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+		super(path, parent, refReg);
+	}
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<String> summary;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<String> description;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildMapOverlay<Operation> operations;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildListOverlay<Server> servers;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildListOverlay<Parameter> parameters;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildMapOverlay<Object> extensions;
+
+	// Summary
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getSummary() {
+		return summary._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getSummary(boolean elaborate) {
+		return summary._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setSummary(String summary) {
+		this.summary._set(summary);
+	}
+
+	// Description
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getDescription() {
+		return description._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getDescription(boolean elaborate) {
+		return description._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setDescription(String description) {
+		this.description._set(description);
+	}
+
+	// Operation
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Operation> getOperations() {
+		return operations._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Operation> getOperations(boolean elaborate) {
+		return operations._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasOperation(String name) {
+		return operations.containsKey(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Operation getOperation(String name) {
+		return operations._get(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setOperations(Map<String, Operation> operations) {
+		this.operations._set(operations);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setOperation(String name, Operation operation) {
+		operations._set(name, operation);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeOperation(String name) {
+		operations._remove(name);
+	}
+
+	// Server
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Collection<Server> getServers() {
+		return servers._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Collection<Server> getServers(boolean elaborate) {
+		return servers._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasServers() {
+		return servers._isPresent();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Server getServer(int index) {
+		return servers._get(index);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setServers(Collection<Server> servers) {
+		this.servers._set(servers);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setServer(int index, Server server) {
+		servers._set(index, server);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void addServer(Server server) {
+		servers._add(server);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void insertServer(int index, Server server) {
+		servers._insert(index, server);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeServer(int index) {
+		servers._remove(index);
+	}
+
+	// Parameter
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Collection<Parameter> getParameters() {
+		return parameters._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Collection<Parameter> getParameters(boolean elaborate) {
+		return parameters._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasParameters() {
+		return parameters._isPresent();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Parameter getParameter(int index) {
+		return parameters._get(index);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setParameters(Collection<Parameter> parameters) {
+		this.parameters._set(parameters);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setParameter(int index, Parameter parameter) {
+		parameters._set(index, parameter);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void addParameter(Parameter parameter) {
+		parameters._add(parameter);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void insertParameter(int index, Parameter parameter) {
+		parameters._insert(index, parameter);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeParameter(int index) {
+		parameters._remove(index);
+	}
+
+	// Extension
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Object> getExtensions() {
+		return extensions._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Object> getExtensions(boolean elaborate) {
+		return extensions._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasExtension(String name) {
+		return extensions.containsKey(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Object getExtension(String name) {
+		return extensions._get(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setExtensions(Map<String, Object> extensions) {
+		this.extensions._set(extensions);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setExtension(String name, Object extension) {
+		extensions._set(name, extension);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeExtension(String name) {
+		extensions._remove(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	protected void elaborateChildren() {
+		super.elaborateChildren();
+		summary = createChild("summary", this, StringOverlay.factory);
+		description = createChild("description", this, StringOverlay.factory);
+		operations = createChildMap("", this, OperationImpl.factory, "get|put|post|delete|options|head|patch|trace");
+		servers = createChildList("servers", this, ServerImpl.factory);
+		parameters = createChildList("parameters", this, ParameterImpl.factory);
+		extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
+	}
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public static OverlayFactory<Path> factory = new OverlayFactory<Path>() {
+
+		@Override
+		protected Class<? extends AbstractJsonOverlay<? super Path>> getOverlayClass() {
+			return PathImpl.class;
+		}
+
+		@Override
+		public JsonOverlay<Path> _create(Path path, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+			AbstractJsonOverlay<?> overlay;
+			overlay = new PathImpl(path, parent, refReg);
+			@SuppressWarnings("unchecked")
+			JsonOverlay<Path> castOverlay = (JsonOverlay<Path>) overlay;
+			return castOverlay;
+		}
+
+		@Override
+		public JsonOverlay<Path> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+			AbstractJsonOverlay<?> overlay;
+			overlay = new PathImpl(json, parent, refReg);
+			@SuppressWarnings("unchecked")
+			JsonOverlay<Path> castOverlay = (JsonOverlay<Path>) overlay;
+			return castOverlay;
+		}
+	};
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private static Class<? extends Path> getSubtypeOf(Path path) {
+		return Path.class;
+	}
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private static Class<? extends Path> getSubtypeOf(JsonNode json) {
+		return Path.class;
+	}
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/RequestBodyImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/RequestBodyImpl.java
@@ -1,221 +1,222 @@
 package com.reprezen.kaizen.oasparser.ovl3;
 
-import com.reprezen.jsonoverlay.StringOverlay;
-import com.reprezen.jsonoverlay.ReferenceRegistry;
-import com.reprezen.jsonoverlay.ChildMapOverlay;
-import com.reprezen.kaizen.oasparser.ovl3.MediaTypeImpl;
-import com.reprezen.jsonoverlay.ObjectOverlay;
+import java.util.Map;
+
+import javax.annotation.Generated;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.reprezen.jsonoverlay.AbstractJsonOverlay;
 import com.reprezen.jsonoverlay.BooleanOverlay;
-import com.reprezen.jsonoverlay.MapOverlay;
-import java.util.stream.Collectors;
-import com.reprezen.kaizen.oasparser.model3.*;
+import com.reprezen.jsonoverlay.ChildMapOverlay;
+import com.reprezen.jsonoverlay.ChildOverlay;
+import com.reprezen.jsonoverlay.JsonOverlay;
+import com.reprezen.jsonoverlay.ObjectOverlay;
 import com.reprezen.jsonoverlay.OverlayFactory;
 import com.reprezen.jsonoverlay.PropertiesOverlay;
-import javax.annotation.Generated;
-import com.fasterxml.jackson.core.JsonPointer;
+import com.reprezen.jsonoverlay.ReferenceRegistry;
+import com.reprezen.jsonoverlay.StringOverlay;
 import com.reprezen.kaizen.oasparser.model3.MediaType;
-import com.reprezen.jsonoverlay.IJsonOverlay;
-import com.reprezen.jsonoverlay.JsonOverlay;
-import java.util.Map;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.reprezen.jsonoverlay.ChildOverlay;
+import com.reprezen.kaizen.oasparser.model3.RequestBody;
 
 public class RequestBodyImpl extends PropertiesOverlay<RequestBody> implements RequestBody {
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public RequestBodyImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        super(json, parent, refReg);
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public RequestBodyImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+		super(json, parent, refReg);
+	}
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public RequestBodyImpl(RequestBody requestBody, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        super(requestBody, parent, refReg);
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public RequestBodyImpl(RequestBody requestBody, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+		super(requestBody, parent, refReg);
+	}
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<String> description;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<String> description;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildMapOverlay<MediaType> contentMediaTypes;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildMapOverlay<MediaType> contentMediaTypes;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<Boolean> required;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<Boolean> required;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildMapOverlay<Object> extensions;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildMapOverlay<Object> extensions;
 
-    // Description
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getDescription() {
-        return description.get();
-    }
+	// Description
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getDescription() {
+		return description._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getDescription(boolean elaborate) {
-        return description.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getDescription(boolean elaborate) {
+		return description._get(elaborate);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setDescription(String description) {
-        this.description.set(description);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setDescription(String description) {
+		this.description._set(description);
+	}
 
-    // ContentMediaType
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, MediaType> getContentMediaTypes() {
-        return contentMediaTypes.get();
-    }
+	// ContentMediaType
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, MediaType> getContentMediaTypes() {
+		return contentMediaTypes._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, MediaType> getContentMediaTypes(boolean elaborate) {
-        return contentMediaTypes.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, MediaType> getContentMediaTypes(boolean elaborate) {
+		return contentMediaTypes._get(elaborate);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasContentMediaType(String name) {
-        return contentMediaTypes.containsKey(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasContentMediaType(String name) {
+		return contentMediaTypes.containsKey(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public MediaType getContentMediaType(String name) {
-        return contentMediaTypes.get(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public MediaType getContentMediaType(String name) {
+		return contentMediaTypes._get(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setContentMediaTypes(Map<String, MediaType> contentMediaTypes) {
-        this.contentMediaTypes.set(contentMediaTypes);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setContentMediaTypes(Map<String, MediaType> contentMediaTypes) {
+		this.contentMediaTypes._set(contentMediaTypes);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setContentMediaType(String name, MediaType contentMediaType) {
-        contentMediaTypes.set(name, contentMediaType);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setContentMediaType(String name, MediaType contentMediaType) {
+		contentMediaTypes._set(name, contentMediaType);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeContentMediaType(String name) {
-        contentMediaTypes.remove(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeContentMediaType(String name) {
+		contentMediaTypes._remove(name);
+	}
 
-    // Required
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Boolean getRequired() {
-        return required.get();
-    }
+	// Required
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Boolean getRequired() {
+		return required._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Boolean getRequired(boolean elaborate) {
-        return required.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Boolean getRequired(boolean elaborate) {
+		return required._get(elaborate);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean isRequired() {
-        return required.get() != null ? required.get() : false;
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean isRequired() {
+		return required._get() != null ? required._get() : false;
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setRequired(Boolean required) {
-        this.required.set(required);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setRequired(Boolean required) {
+		this.required._set(required);
+	}
 
-    // Extension
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Object> getExtensions() {
-        return extensions.get();
-    }
+	// Extension
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Object> getExtensions() {
+		return extensions._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Object> getExtensions(boolean elaborate) {
-        return extensions.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Object> getExtensions(boolean elaborate) {
+		return extensions._get(elaborate);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasExtension(String name) {
-        return extensions.containsKey(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasExtension(String name) {
+		return extensions.containsKey(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Object getExtension(String name) {
-        return extensions.get(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Object getExtension(String name) {
+		return extensions._get(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setExtensions(Map<String, Object> extensions) {
-        this.extensions.set(extensions);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setExtensions(Map<String, Object> extensions) {
+		this.extensions._set(extensions);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setExtension(String name, Object extension) {
-        extensions.set(name, extension);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setExtension(String name, Object extension) {
+		extensions._set(name, extension);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeExtension(String name) {
-        extensions.remove(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeExtension(String name) {
+		extensions._remove(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    protected void elaborateChildren() {
-        super.elaborateChildren();
-        description = createChild("description", this, StringOverlay.factory);
-        contentMediaTypes = createChildMap("content", this, MediaTypeImpl.factory, null);
-        required = createChild("required", this, BooleanOverlay.factory);
-        extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	protected void elaborateChildren() {
+		super.elaborateChildren();
+		description = createChild("description", this, StringOverlay.factory);
+		contentMediaTypes = createChildMap("content", this, MediaTypeImpl.factory, null);
+		required = createChild("required", this, BooleanOverlay.factory);
+		extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
+	}
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public static OverlayFactory<RequestBody> factory = new OverlayFactory<RequestBody>() {
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public static OverlayFactory<RequestBody> factory = new OverlayFactory<RequestBody>() {
 
-        @Override
-        protected Class<? extends IJsonOverlay<? super RequestBody>> getOverlayClass() {
-            return RequestBodyImpl.class;
-        }
+		@Override
+		protected Class<? extends AbstractJsonOverlay<? super RequestBody>> getOverlayClass() {
+			return RequestBodyImpl.class;
+		}
 
-        @Override
-        public JsonOverlay<RequestBody> _create(RequestBody requestBody, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            IJsonOverlay<?> overlay;
-            overlay = new RequestBodyImpl(requestBody, parent, refReg);
-            @SuppressWarnings("unchecked") JsonOverlay<RequestBody> castOverlay = (JsonOverlay<RequestBody>) overlay;
-            return castOverlay;
-        }
+		@Override
+		public JsonOverlay<RequestBody> _create(RequestBody requestBody, JsonOverlay<?> parent,
+				ReferenceRegistry refReg) {
+			AbstractJsonOverlay<?> overlay;
+			overlay = new RequestBodyImpl(requestBody, parent, refReg);
+			@SuppressWarnings("unchecked")
+			JsonOverlay<RequestBody> castOverlay = (JsonOverlay<RequestBody>) overlay;
+			return castOverlay;
+		}
 
-        @Override
-        public JsonOverlay<RequestBody> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            IJsonOverlay<?> overlay;
-            overlay = new RequestBodyImpl(json, parent, refReg);
-            @SuppressWarnings("unchecked") JsonOverlay<RequestBody> castOverlay = (JsonOverlay<RequestBody>) overlay;
-            return castOverlay;
-        }
-    };
+		@Override
+		public JsonOverlay<RequestBody> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+			AbstractJsonOverlay<?> overlay;
+			overlay = new RequestBodyImpl(json, parent, refReg);
+			@SuppressWarnings("unchecked")
+			JsonOverlay<RequestBody> castOverlay = (JsonOverlay<RequestBody>) overlay;
+			return castOverlay;
+		}
+	};
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private static Class<? extends RequestBody> getSubtypeOf(RequestBody requestBody) {
-        return RequestBody.class;
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private static Class<? extends RequestBody> getSubtypeOf(RequestBody requestBody) {
+		return RequestBody.class;
+	}
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private static Class<? extends RequestBody> getSubtypeOf(JsonNode json) {
-        return RequestBody.class;
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private static Class<? extends RequestBody> getSubtypeOf(JsonNode json) {
+		return RequestBody.class;
+	}
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ResponseImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ResponseImpl.java
@@ -1,320 +1,287 @@
 package com.reprezen.kaizen.oasparser.ovl3;
 
-import com.reprezen.jsonoverlay.StringOverlay;
-import com.reprezen.jsonoverlay.ReferenceRegistry;
-import com.reprezen.kaizen.oasparser.ovl3.HeaderImpl;
+import java.util.Map;
+
+import javax.annotation.Generated;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.reprezen.jsonoverlay.AbstractJsonOverlay;
 import com.reprezen.jsonoverlay.ChildMapOverlay;
-import com.reprezen.kaizen.oasparser.ovl3.MediaTypeImpl;
-import com.reprezen.jsonoverlay.Reference;
-import com.reprezen.kaizen.oasparser.model3.Header;
+import com.reprezen.jsonoverlay.ChildOverlay;
+import com.reprezen.jsonoverlay.JsonOverlay;
 import com.reprezen.jsonoverlay.ObjectOverlay;
-import com.reprezen.jsonoverlay.MapOverlay;
-import java.util.stream.Collectors;
-import com.reprezen.kaizen.oasparser.model3.Link;
-import com.reprezen.kaizen.oasparser.model3.*;
 import com.reprezen.jsonoverlay.OverlayFactory;
 import com.reprezen.jsonoverlay.PropertiesOverlay;
-import javax.annotation.Generated;
-import com.fasterxml.jackson.core.JsonPointer;
+import com.reprezen.jsonoverlay.ReferenceRegistry;
+import com.reprezen.jsonoverlay.StringOverlay;
+import com.reprezen.kaizen.oasparser.model3.Header;
+import com.reprezen.kaizen.oasparser.model3.Link;
 import com.reprezen.kaizen.oasparser.model3.MediaType;
-import com.reprezen.jsonoverlay.IJsonOverlay;
-import com.reprezen.jsonoverlay.JsonOverlay;
-import java.util.Map;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.reprezen.jsonoverlay.ChildOverlay;
-import com.reprezen.kaizen.oasparser.ovl3.LinkImpl;
+import com.reprezen.kaizen.oasparser.model3.Response;
 
 public class ResponseImpl extends PropertiesOverlay<Response> implements Response {
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public ResponseImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        super(json, parent, refReg);
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public ResponseImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+		super(json, parent, refReg);
+	}
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public ResponseImpl(Response response, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        super(response, parent, refReg);
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public ResponseImpl(Response response, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+		super(response, parent, refReg);
+	}
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<String> description;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<String> description;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildMapOverlay<Header> headers;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildMapOverlay<Header> headers;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildMapOverlay<MediaType> contentMediaTypes;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildMapOverlay<MediaType> contentMediaTypes;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildMapOverlay<Link> links;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildMapOverlay<Link> links;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildMapOverlay<Object> extensions;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildMapOverlay<Object> extensions;
 
-    // Description
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getDescription() {
-        return description.get();
-    }
+	// Description
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getDescription() {
+		return description._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getDescription(boolean elaborate) {
-        return description.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getDescription(boolean elaborate) {
+		return description._get(elaborate);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setDescription(String description) {
-        this.description.set(description);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setDescription(String description) {
+		this.description._set(description);
+	}
 
-    // Header
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Header> getHeaders() {
-        return headers.get();
-    }
+	// Header
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Header> getHeaders() {
+		return headers._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Header> getHeaders(boolean elaborate) {
-        return headers.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Header> getHeaders(boolean elaborate) {
+		return headers._get(elaborate);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasHeader(String name) {
-        return headers.containsKey(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasHeader(String name) {
+		return headers.containsKey(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Header getHeader(String name) {
-        return headers.get(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Header getHeader(String name) {
+		return headers._get(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setHeaders(Map<String, Header> headers) {
-        this.headers.set(headers);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setHeaders(Map<String, Header> headers) {
+		this.headers._set(headers);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setHeader(String name, Header header) {
-        headers.set(name, header);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setHeader(String name, Header header) {
+		headers._set(name, header);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeHeader(String name) {
-        headers.remove(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeHeader(String name) {
+		headers._remove(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean isHeaderReference(String name) {
-        ChildOverlay<Header> child = headers.getChild(name);
-        return child != null ? child.isReference() : false;
-    }
+	// ContentMediaType
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, MediaType> getContentMediaTypes() {
+		return contentMediaTypes._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Reference getHeaderReference(String name) {
-        ChildOverlay<Header> child = headers.getChild(name);
-        return child != null ? child.getReference() : null;
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, MediaType> getContentMediaTypes(boolean elaborate) {
+		return contentMediaTypes._get(elaborate);
+	}
 
-    // ContentMediaType
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, MediaType> getContentMediaTypes() {
-        return contentMediaTypes.get();
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasContentMediaType(String name) {
+		return contentMediaTypes.containsKey(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, MediaType> getContentMediaTypes(boolean elaborate) {
-        return contentMediaTypes.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public MediaType getContentMediaType(String name) {
+		return contentMediaTypes._get(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasContentMediaType(String name) {
-        return contentMediaTypes.containsKey(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setContentMediaTypes(Map<String, MediaType> contentMediaTypes) {
+		this.contentMediaTypes._set(contentMediaTypes);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public MediaType getContentMediaType(String name) {
-        return contentMediaTypes.get(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setContentMediaType(String name, MediaType contentMediaType) {
+		contentMediaTypes._set(name, contentMediaType);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setContentMediaTypes(Map<String, MediaType> contentMediaTypes) {
-        this.contentMediaTypes.set(contentMediaTypes);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeContentMediaType(String name) {
+		contentMediaTypes._remove(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setContentMediaType(String name, MediaType contentMediaType) {
-        contentMediaTypes.set(name, contentMediaType);
-    }
+	// Link
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Link> getLinks() {
+		return links._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeContentMediaType(String name) {
-        contentMediaTypes.remove(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Link> getLinks(boolean elaborate) {
+		return links._get(elaborate);
+	}
 
-    // Link
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Link> getLinks() {
-        return links.get();
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasLink(String name) {
+		return links.containsKey(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Link> getLinks(boolean elaborate) {
-        return links.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Link getLink(String name) {
+		return links._get(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasLink(String name) {
-        return links.containsKey(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setLinks(Map<String, Link> links) {
+		this.links._set(links);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Link getLink(String name) {
-        return links.get(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setLink(String name, Link link) {
+		links._set(name, link);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setLinks(Map<String, Link> links) {
-        this.links.set(links);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeLink(String name) {
+		links._remove(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setLink(String name, Link link) {
-        links.set(name, link);
-    }
+	// Extension
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Object> getExtensions() {
+		return extensions._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeLink(String name) {
-        links.remove(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Object> getExtensions(boolean elaborate) {
+		return extensions._get(elaborate);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean isLinkReference(String name) {
-        ChildOverlay<Link> child = links.getChild(name);
-        return child != null ? child.isReference() : false;
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasExtension(String name) {
+		return extensions.containsKey(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Reference getLinkReference(String name) {
-        ChildOverlay<Link> child = links.getChild(name);
-        return child != null ? child.getReference() : null;
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Object getExtension(String name) {
+		return extensions._get(name);
+	}
 
-    // Extension
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Object> getExtensions() {
-        return extensions.get();
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setExtensions(Map<String, Object> extensions) {
+		this.extensions._set(extensions);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Object> getExtensions(boolean elaborate) {
-        return extensions.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setExtension(String name, Object extension) {
+		extensions._set(name, extension);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasExtension(String name) {
-        return extensions.containsKey(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeExtension(String name) {
+		extensions._remove(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Object getExtension(String name) {
-        return extensions.get(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	protected void elaborateChildren() {
+		super.elaborateChildren();
+		description = createChild("description", this, StringOverlay.factory);
+		headers = createChildMap("headers", this, HeaderImpl.factory, null);
+		contentMediaTypes = createChildMap("content", this, MediaTypeImpl.factory, null);
+		links = createChildMap("links", this, LinkImpl.factory, null);
+		extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setExtensions(Map<String, Object> extensions) {
-        this.extensions.set(extensions);
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public static OverlayFactory<Response> factory = new OverlayFactory<Response>() {
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setExtension(String name, Object extension) {
-        extensions.set(name, extension);
-    }
+		@Override
+		protected Class<? extends AbstractJsonOverlay<? super Response>> getOverlayClass() {
+			return ResponseImpl.class;
+		}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeExtension(String name) {
-        extensions.remove(name);
-    }
+		@Override
+		public JsonOverlay<Response> _create(Response response, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+			AbstractJsonOverlay<?> overlay;
+			overlay = new ResponseImpl(response, parent, refReg);
+			@SuppressWarnings("unchecked")
+			JsonOverlay<Response> castOverlay = (JsonOverlay<Response>) overlay;
+			return castOverlay;
+		}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    protected void elaborateChildren() {
-        super.elaborateChildren();
-        description = createChild("description", this, StringOverlay.factory);
-        headers = createChildMap("headers", this, HeaderImpl.factory, null);
-        refables.put("headers", headers);
-        contentMediaTypes = createChildMap("content", this, MediaTypeImpl.factory, null);
-        links = createChildMap("links", this, LinkImpl.factory, null);
-        refables.put("links", links);
-        extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
-    }
+		@Override
+		public JsonOverlay<Response> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+			AbstractJsonOverlay<?> overlay;
+			overlay = new ResponseImpl(json, parent, refReg);
+			@SuppressWarnings("unchecked")
+			JsonOverlay<Response> castOverlay = (JsonOverlay<Response>) overlay;
+			return castOverlay;
+		}
+	};
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public static OverlayFactory<Response> factory = new OverlayFactory<Response>() {
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private static Class<? extends Response> getSubtypeOf(Response response) {
+		return Response.class;
+	}
 
-        @Override
-        protected Class<? extends IJsonOverlay<? super Response>> getOverlayClass() {
-            return ResponseImpl.class;
-        }
-
-        @Override
-        public JsonOverlay<Response> _create(Response response, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            IJsonOverlay<?> overlay;
-            overlay = new ResponseImpl(response, parent, refReg);
-            @SuppressWarnings("unchecked") JsonOverlay<Response> castOverlay = (JsonOverlay<Response>) overlay;
-            return castOverlay;
-        }
-
-        @Override
-        public JsonOverlay<Response> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            IJsonOverlay<?> overlay;
-            overlay = new ResponseImpl(json, parent, refReg);
-            @SuppressWarnings("unchecked") JsonOverlay<Response> castOverlay = (JsonOverlay<Response>) overlay;
-            return castOverlay;
-        }
-    };
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private static Class<? extends Response> getSubtypeOf(Response response) {
-        return Response.class;
-    }
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private static Class<? extends Response> getSubtypeOf(JsonNode json) {
-        return Response.class;
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private static Class<? extends Response> getSubtypeOf(JsonNode json) {
+		return Response.class;
+	}
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/SchemaImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/SchemaImpl.java
@@ -1,1364 +1,1267 @@
 package com.reprezen.kaizen.oasparser.ovl3;
 
-import com.reprezen.jsonoverlay.StringOverlay;
-import com.reprezen.kaizen.oasparser.model3.Schema;
-import com.reprezen.jsonoverlay.ReferenceRegistry;
-import com.reprezen.jsonoverlay.IntegerOverlay;
-import com.reprezen.jsonoverlay.Reference;
-import com.reprezen.jsonoverlay.BooleanOverlay;
-import com.reprezen.kaizen.oasparser.model3.Xml;
-import com.fasterxml.jackson.core.JsonPointer;
-import javax.annotation.Generated;
-import com.reprezen.kaizen.oasparser.ovl3.SchemaImpl;
-import com.reprezen.jsonoverlay.IJsonOverlay;
-import com.reprezen.kaizen.oasparser.model3.Example;
-import com.reprezen.jsonoverlay.JsonOverlay;
+import java.util.Collection;
 import java.util.Map;
-import com.reprezen.jsonoverlay.ListOverlay;
+
+import javax.annotation.Generated;
+
+import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.reprezen.jsonoverlay.AbstractJsonOverlay;
+import com.reprezen.jsonoverlay.BooleanOverlay;
 import com.reprezen.jsonoverlay.ChildListOverlay;
 import com.reprezen.jsonoverlay.ChildMapOverlay;
-import com.reprezen.kaizen.oasparser.ovl3.ExampleImpl;
-import java.util.Collection;
-import com.reprezen.jsonoverlay.ObjectOverlay;
-import com.reprezen.jsonoverlay.NumberOverlay;
-import com.reprezen.jsonoverlay.MapOverlay;
-import java.util.stream.Collectors;
-import com.reprezen.kaizen.oasparser.model3.*;
-import com.reprezen.jsonoverlay.OverlayFactory;
-import com.reprezen.kaizen.oasparser.ovl3.ExternalDocsImpl;
-import com.reprezen.jsonoverlay.PropertiesOverlay;
-import java.util.Optional;
 import com.reprezen.jsonoverlay.ChildOverlay;
+import com.reprezen.jsonoverlay.IntegerOverlay;
+import com.reprezen.jsonoverlay.JsonOverlay;
+import com.reprezen.jsonoverlay.NumberOverlay;
+import com.reprezen.jsonoverlay.ObjectOverlay;
+import com.reprezen.jsonoverlay.OverlayFactory;
+import com.reprezen.jsonoverlay.PropertiesOverlay;
+import com.reprezen.jsonoverlay.ReferenceRegistry;
+import com.reprezen.jsonoverlay.StringOverlay;
+import com.reprezen.kaizen.oasparser.model3.Example;
 import com.reprezen.kaizen.oasparser.model3.ExternalDocs;
-import com.reprezen.kaizen.oasparser.ovl3.XmlImpl;
+import com.reprezen.kaizen.oasparser.model3.Schema;
+import com.reprezen.kaizen.oasparser.model3.Xml;
 
 public class SchemaImpl extends PropertiesOverlay<Schema> implements Schema {
 
-    @Override
-    public IJsonOverlay<?> find(JsonPointer path) {
-        if (path.matchesProperty("additionalProperties")) {
-            return path.tail().matches() ? additionalProperties : additionalPropertiesSchema.find(path.tail());
-        } else {
-            return super.find(path);
-        }
-    }
+	@Override
+	public AbstractJsonOverlay<?> _findInternal(JsonPointer path) {
+		if (path.matchesProperty("additionalProperties")) {
+			return path.tail().matches() ? additionalProperties : additionalPropertiesSchema._find(path.tail());
+		} else {
+			return super._findInternal(path);
+		}
+	}
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public SchemaImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        super(json, parent, refReg);
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public SchemaImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+		super(json, parent, refReg);
+	}
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public SchemaImpl(Schema schema, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        super(schema, parent, refReg);
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public SchemaImpl(Schema schema, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+		super(schema, parent, refReg);
+	}
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<String> title;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<String> title;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<Number> multipleOf;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<Number> multipleOf;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<Number> maximum;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<Number> maximum;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<Boolean> exclusiveMaximum;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<Boolean> exclusiveMaximum;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<Number> minimum;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<Number> minimum;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<Boolean> exclusiveMinimum;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<Boolean> exclusiveMinimum;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<Integer> maxLength;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<Integer> maxLength;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<Integer> minLength;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<Integer> minLength;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<String> pattern;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<String> pattern;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<Integer> maxItems;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<Integer> maxItems;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<Integer> minItems;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<Integer> minItems;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<Boolean> uniqueItems;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<Boolean> uniqueItems;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<Integer> maxProperties;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<Integer> maxProperties;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<Integer> minProperties;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<Integer> minProperties;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildListOverlay<String> requiredFields;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildListOverlay<String> requiredFields;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildListOverlay<Object> enums;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildListOverlay<Object> enums;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<String> type;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<String> type;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildListOverlay<Schema> allOfSchemas;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildListOverlay<Schema> allOfSchemas;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildListOverlay<Schema> oneOfSchemas;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildListOverlay<Schema> oneOfSchemas;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildListOverlay<Schema> anyOfSchemas;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildListOverlay<Schema> anyOfSchemas;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<Schema> notSchema;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<Schema> notSchema;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<Schema> itemsSchema;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<Schema> itemsSchema;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildMapOverlay<Schema> properties;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildMapOverlay<Schema> properties;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<Schema> additionalPropertiesSchema;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<Schema> additionalPropertiesSchema;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<Boolean> additionalProperties;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<Boolean> additionalProperties;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<String> description;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<String> description;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<String> format;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<String> format;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<Object> defaultValue;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<Boolean> nullable;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<String> discriminator;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<Boolean> readOnly;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<Boolean> writeOnly;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<Xml> xml;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<ExternalDocs> externalDocs;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildMapOverlay<Example> examples;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<Object> example;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<Boolean> deprecated;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildMapOverlay<Object> extensions;
-
-    // Title
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getTitle() {
-        return title.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getTitle(boolean elaborate) {
-        return title.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setTitle(String title) {
-        this.title.set(title);
-    }
-
-    // MultipleOf
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Number getMultipleOf() {
-        return multipleOf.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Number getMultipleOf(boolean elaborate) {
-        return multipleOf.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setMultipleOf(Number multipleOf) {
-        this.multipleOf.set(multipleOf);
-    }
-
-    // Maximum
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Number getMaximum() {
-        return maximum.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Number getMaximum(boolean elaborate) {
-        return maximum.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setMaximum(Number maximum) {
-        this.maximum.set(maximum);
-    }
-
-    // ExclusiveMaximum
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Boolean getExclusiveMaximum() {
-        return exclusiveMaximum.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Boolean getExclusiveMaximum(boolean elaborate) {
-        return exclusiveMaximum.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean isExclusiveMaximum() {
-        return exclusiveMaximum.get() != null ? exclusiveMaximum.get() : false;
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setExclusiveMaximum(Boolean exclusiveMaximum) {
-        this.exclusiveMaximum.set(exclusiveMaximum);
-    }
-
-    // Minimum
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Number getMinimum() {
-        return minimum.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Number getMinimum(boolean elaborate) {
-        return minimum.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setMinimum(Number minimum) {
-        this.minimum.set(minimum);
-    }
-
-    // ExclusiveMinimum
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Boolean getExclusiveMinimum() {
-        return exclusiveMinimum.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Boolean getExclusiveMinimum(boolean elaborate) {
-        return exclusiveMinimum.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean isExclusiveMinimum() {
-        return exclusiveMinimum.get() != null ? exclusiveMinimum.get() : false;
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setExclusiveMinimum(Boolean exclusiveMinimum) {
-        this.exclusiveMinimum.set(exclusiveMinimum);
-    }
-
-    // MaxLength
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Integer getMaxLength() {
-        return maxLength.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Integer getMaxLength(boolean elaborate) {
-        return maxLength.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setMaxLength(Integer maxLength) {
-        this.maxLength.set(maxLength);
-    }
-
-    // MinLength
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Integer getMinLength() {
-        return minLength.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Integer getMinLength(boolean elaborate) {
-        return minLength.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setMinLength(Integer minLength) {
-        this.minLength.set(minLength);
-    }
-
-    // Pattern
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getPattern() {
-        return pattern.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getPattern(boolean elaborate) {
-        return pattern.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setPattern(String pattern) {
-        this.pattern.set(pattern);
-    }
-
-    // MaxItems
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Integer getMaxItems() {
-        return maxItems.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Integer getMaxItems(boolean elaborate) {
-        return maxItems.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setMaxItems(Integer maxItems) {
-        this.maxItems.set(maxItems);
-    }
-
-    // MinItems
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Integer getMinItems() {
-        return minItems.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Integer getMinItems(boolean elaborate) {
-        return minItems.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setMinItems(Integer minItems) {
-        this.minItems.set(minItems);
-    }
-
-    // UniqueItems
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Boolean getUniqueItems() {
-        return uniqueItems.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Boolean getUniqueItems(boolean elaborate) {
-        return uniqueItems.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean isUniqueItems() {
-        return uniqueItems.get() != null ? uniqueItems.get() : false;
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setUniqueItems(Boolean uniqueItems) {
-        this.uniqueItems.set(uniqueItems);
-    }
-
-    // MaxProperties
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Integer getMaxProperties() {
-        return maxProperties.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Integer getMaxProperties(boolean elaborate) {
-        return maxProperties.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setMaxProperties(Integer maxProperties) {
-        this.maxProperties.set(maxProperties);
-    }
-
-    // MinProperties
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Integer getMinProperties() {
-        return minProperties.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Integer getMinProperties(boolean elaborate) {
-        return minProperties.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setMinProperties(Integer minProperties) {
-        this.minProperties.set(minProperties);
-    }
-
-    // RequiredField
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Collection<String> getRequiredFields() {
-        return requiredFields.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Collection<String> getRequiredFields(boolean elaborate) {
-        return requiredFields.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasRequiredFields() {
-        return requiredFields.isPresent();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getRequiredField(int index) {
-        return requiredFields.get(index);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setRequiredFields(Collection<String> requiredFields) {
-        this.requiredFields.set(requiredFields);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setRequiredField(int index, String requiredField) {
-        requiredFields.set(index, requiredField);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void addRequiredField(String requiredField) {
-        requiredFields.add(requiredField);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void insertRequiredField(int index, String requiredField) {
-        requiredFields.insert(index, requiredField);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeRequiredField(int index) {
-        requiredFields.remove(index);
-    }
-
-    // Enum
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Collection<Object> getEnums() {
-        return enums.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Collection<Object> getEnums(boolean elaborate) {
-        return enums.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasEnums() {
-        return enums.isPresent();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Object getEnum(int index) {
-        return enums.get(index);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setEnums(Collection<Object> enums) {
-        this.enums.set(enums);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setEnum(int index, Object enumValue) {
-        enums.set(index, enumValue);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void addEnum(Object enumValue) {
-        enums.add(enumValue);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void insertEnum(int index, Object enumValue) {
-        enums.insert(index, enumValue);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeEnum(int index) {
-        enums.remove(index);
-    }
-
-    // Type
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getType() {
-        return type.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getType(boolean elaborate) {
-        return type.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setType(String type) {
-        this.type.set(type);
-    }
-
-    // AllOfSchema
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Collection<Schema> getAllOfSchemas() {
-        return allOfSchemas.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Collection<Schema> getAllOfSchemas(boolean elaborate) {
-        return allOfSchemas.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasAllOfSchemas() {
-        return allOfSchemas.isPresent();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Schema getAllOfSchema(int index) {
-        return allOfSchemas.get(index);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setAllOfSchemas(Collection<Schema> allOfSchemas) {
-        this.allOfSchemas.set(allOfSchemas);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setAllOfSchema(int index, Schema allOfSchema) {
-        allOfSchemas.set(index, allOfSchema);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void addAllOfSchema(Schema allOfSchema) {
-        allOfSchemas.add(allOfSchema);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void insertAllOfSchema(int index, Schema allOfSchema) {
-        allOfSchemas.insert(index, allOfSchema);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeAllOfSchema(int index) {
-        allOfSchemas.remove(index);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean isAllOfSchemaReference(int index) {
-        return allOfSchemas.getChild(index).isReference();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Reference getAllOfSchemaReference(int index) {
-        return allOfSchemas.getChild(index).getReference();
-    }
-
-    // OneOfSchema
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Collection<Schema> getOneOfSchemas() {
-        return oneOfSchemas.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Collection<Schema> getOneOfSchemas(boolean elaborate) {
-        return oneOfSchemas.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasOneOfSchemas() {
-        return oneOfSchemas.isPresent();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Schema getOneOfSchema(int index) {
-        return oneOfSchemas.get(index);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setOneOfSchemas(Collection<Schema> oneOfSchemas) {
-        this.oneOfSchemas.set(oneOfSchemas);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setOneOfSchema(int index, Schema oneOfSchema) {
-        oneOfSchemas.set(index, oneOfSchema);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void addOneOfSchema(Schema oneOfSchema) {
-        oneOfSchemas.add(oneOfSchema);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void insertOneOfSchema(int index, Schema oneOfSchema) {
-        oneOfSchemas.insert(index, oneOfSchema);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeOneOfSchema(int index) {
-        oneOfSchemas.remove(index);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean isOneOfSchemaReference(int index) {
-        return oneOfSchemas.getChild(index).isReference();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Reference getOneOfSchemaReference(int index) {
-        return oneOfSchemas.getChild(index).getReference();
-    }
-
-    // AnyOfSchema
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Collection<Schema> getAnyOfSchemas() {
-        return anyOfSchemas.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Collection<Schema> getAnyOfSchemas(boolean elaborate) {
-        return anyOfSchemas.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasAnyOfSchemas() {
-        return anyOfSchemas.isPresent();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Schema getAnyOfSchema(int index) {
-        return anyOfSchemas.get(index);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setAnyOfSchemas(Collection<Schema> anyOfSchemas) {
-        this.anyOfSchemas.set(anyOfSchemas);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setAnyOfSchema(int index, Schema anyOfSchema) {
-        anyOfSchemas.set(index, anyOfSchema);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void addAnyOfSchema(Schema anyOfSchema) {
-        anyOfSchemas.add(anyOfSchema);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void insertAnyOfSchema(int index, Schema anyOfSchema) {
-        anyOfSchemas.insert(index, anyOfSchema);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeAnyOfSchema(int index) {
-        anyOfSchemas.remove(index);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean isAnyOfSchemaReference(int index) {
-        return anyOfSchemas.getChild(index).isReference();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Reference getAnyOfSchemaReference(int index) {
-        return anyOfSchemas.getChild(index).getReference();
-    }
-
-    // NotSchema
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Schema getNotSchema() {
-        return notSchema.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Schema getNotSchema(boolean elaborate) {
-        return notSchema.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setNotSchema(Schema notSchema) {
-        this.notSchema.set(notSchema);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean isNotSchemaReference() {
-        return notSchema != null ? notSchema.isReference() : false;
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Reference getNotSchemaReference() {
-        return notSchema != null ? notSchema.getReference() : null;
-    }
-
-    // ItemsSchema
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Schema getItemsSchema() {
-        return itemsSchema.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Schema getItemsSchema(boolean elaborate) {
-        return itemsSchema.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setItemsSchema(Schema itemsSchema) {
-        this.itemsSchema.set(itemsSchema);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean isItemsSchemaReference() {
-        return itemsSchema != null ? itemsSchema.isReference() : false;
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Reference getItemsSchemaReference() {
-        return itemsSchema != null ? itemsSchema.getReference() : null;
-    }
-
-    // Property
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Schema> getProperties() {
-        return properties.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Schema> getProperties(boolean elaborate) {
-        return properties.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasProperty(String name) {
-        return properties.containsKey(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Schema getProperty(String name) {
-        return properties.get(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setProperties(Map<String, Schema> properties) {
-        this.properties.set(properties);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setProperty(String name, Schema property) {
-        properties.set(name, property);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeProperty(String name) {
-        properties.remove(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean isPropertyReference(String name) {
-        ChildOverlay<Schema> child = properties.getChild(name);
-        return child != null ? child.isReference() : false;
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Reference getPropertyReference(String name) {
-        ChildOverlay<Schema> child = properties.getChild(name);
-        return child != null ? child.getReference() : null;
-    }
-
-    // AdditionalPropertiesSchema
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Schema getAdditionalPropertiesSchema() {
-        return additionalPropertiesSchema.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Schema getAdditionalPropertiesSchema(boolean elaborate) {
-        return additionalPropertiesSchema.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setAdditionalPropertiesSchema(Schema additionalPropertiesSchema) {
-        this.additionalPropertiesSchema.set(additionalPropertiesSchema);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean isAdditionalPropertiesSchemaReference() {
-        return additionalPropertiesSchema != null ? additionalPropertiesSchema.isReference() : false;
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Reference getAdditionalPropertiesSchemaReference() {
-        return additionalPropertiesSchema != null ? additionalPropertiesSchema.getReference() : null;
-    }
-
-    // AdditionalProperties
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Boolean getAdditionalProperties() {
-        return additionalProperties.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Boolean getAdditionalProperties(boolean elaborate) {
-        return additionalProperties.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean isAdditionalProperties() {
-        return additionalProperties.get() != null ? additionalProperties.get() : false;
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setAdditionalProperties(Boolean additionalProperties) {
-        this.additionalProperties.set(additionalProperties);
-    }
-
-    // Description
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getDescription() {
-        return description.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getDescription(boolean elaborate) {
-        return description.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setDescription(String description) {
-        this.description.set(description);
-    }
-
-    // Format
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getFormat() {
-        return format.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getFormat(boolean elaborate) {
-        return format.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setFormat(String format) {
-        this.format.set(format);
-    }
-
-    // Default
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Object getDefault() {
-        return defaultValue.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Object getDefault(boolean elaborate) {
-        return defaultValue.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setDefault(Object defaultValue) {
-        this.defaultValue.set(defaultValue);
-    }
-
-    // Nullable
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Boolean getNullable() {
-        return nullable.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Boolean getNullable(boolean elaborate) {
-        return nullable.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean isNullable() {
-        return nullable.get() != null ? nullable.get() : false;
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setNullable(Boolean nullable) {
-        this.nullable.set(nullable);
-    }
-
-    // Discriminator
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getDiscriminator() {
-        return discriminator.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getDiscriminator(boolean elaborate) {
-        return discriminator.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setDiscriminator(String discriminator) {
-        this.discriminator.set(discriminator);
-    }
-
-    // ReadOnly
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Boolean getReadOnly() {
-        return readOnly.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Boolean getReadOnly(boolean elaborate) {
-        return readOnly.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean isReadOnly() {
-        return readOnly.get() != null ? readOnly.get() : false;
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setReadOnly(Boolean readOnly) {
-        this.readOnly.set(readOnly);
-    }
-
-    // WriteOnly
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Boolean getWriteOnly() {
-        return writeOnly.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Boolean getWriteOnly(boolean elaborate) {
-        return writeOnly.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean isWriteOnly() {
-        return writeOnly.get() != null ? writeOnly.get() : false;
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setWriteOnly(Boolean writeOnly) {
-        this.writeOnly.set(writeOnly);
-    }
-
-    // Xml
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Xml getXml() {
-        return xml.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Xml getXml(boolean elaborate) {
-        return xml.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setXml(Xml xml) {
-        this.xml.set(xml);
-    }
-
-    // ExternalDocs
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public ExternalDocs getExternalDocs() {
-        return externalDocs.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public ExternalDocs getExternalDocs(boolean elaborate) {
-        return externalDocs.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setExternalDocs(ExternalDocs externalDocs) {
-        this.externalDocs.set(externalDocs);
-    }
-
-    // Example
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Example> getExamples() {
-        return examples.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Example> getExamples(boolean elaborate) {
-        return examples.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasExample(String name) {
-        return examples.containsKey(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Example getExample(String name) {
-        return examples.get(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setExamples(Map<String, Example> examples) {
-        this.examples.set(examples);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setExample(String name, Example example) {
-        examples.set(name, example);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeExample(String name) {
-        examples.remove(name);
-    }
-
-    // Example
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Object getExample() {
-        return example.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Object getExample(boolean elaborate) {
-        return example.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setExample(Object example) {
-        this.example.set(example);
-    }
-
-    // Deprecated
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Boolean getDeprecated() {
-        return deprecated.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Boolean getDeprecated(boolean elaborate) {
-        return deprecated.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean isDeprecated() {
-        return deprecated.get() != null ? deprecated.get() : false;
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setDeprecated(Boolean deprecated) {
-        this.deprecated.set(deprecated);
-    }
-
-    // Extension
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Object> getExtensions() {
-        return extensions.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Object> getExtensions(boolean elaborate) {
-        return extensions.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasExtension(String name) {
-        return extensions.containsKey(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Object getExtension(String name) {
-        return extensions.get(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setExtensions(Map<String, Object> extensions) {
-        this.extensions.set(extensions);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setExtension(String name, Object extension) {
-        extensions.set(name, extension);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeExtension(String name) {
-        extensions.remove(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    protected void elaborateChildren() {
-        super.elaborateChildren();
-        title = createChild("title", this, StringOverlay.factory);
-        multipleOf = createChild("multipleOf", this, NumberOverlay.factory);
-        maximum = createChild("maximum", this, NumberOverlay.factory);
-        exclusiveMaximum = createChild("exclusiveMaximum", this, BooleanOverlay.factory);
-        minimum = createChild("minimum", this, NumberOverlay.factory);
-        exclusiveMinimum = createChild("exclusiveMinimum", this, BooleanOverlay.factory);
-        maxLength = createChild("maxLength", this, IntegerOverlay.factory);
-        minLength = createChild("minLength", this, IntegerOverlay.factory);
-        pattern = createChild("pattern", this, StringOverlay.factory);
-        maxItems = createChild("maxItems", this, IntegerOverlay.factory);
-        minItems = createChild("minItems", this, IntegerOverlay.factory);
-        uniqueItems = createChild("uniqueItems", this, BooleanOverlay.factory);
-        maxProperties = createChild("maxProperties", this, IntegerOverlay.factory);
-        minProperties = createChild("minProperties", this, IntegerOverlay.factory);
-        requiredFields = createChildList("required", this, StringOverlay.factory);
-        enums = createChildList("enum", this, ObjectOverlay.factory);
-        type = createChild("type", this, StringOverlay.factory);
-        allOfSchemas = createChildList("allOf", this, SchemaImpl.factory);
-        refables.put("allOf", allOfSchemas);
-        oneOfSchemas = createChildList("oneOf", this, SchemaImpl.factory);
-        refables.put("oneOf", oneOfSchemas);
-        anyOfSchemas = createChildList("anyOf", this, SchemaImpl.factory);
-        refables.put("anyOf", anyOfSchemas);
-        notSchema = createChild("not", this, SchemaImpl.factory);
-        refables.put("not", notSchema);
-        itemsSchema = createChild("items", this, SchemaImpl.factory);
-        refables.put("items", itemsSchema);
-        properties = createChildMap("properties", this, SchemaImpl.factory, null);
-        refables.put("properties", properties);
-        additionalPropertiesSchema = createChild(json.at("/additionalProperties").isObject(), "additionalProperties", this, SchemaImpl.factory);
-        refables.put("additionalProperties", additionalPropertiesSchema);
-        additionalProperties = createChild(json.at("/additionalProperties").isBoolean(), "additionalProperties", this, BooleanOverlay.factory);
-        description = createChild("description", this, StringOverlay.factory);
-        format = createChild("format", this, StringOverlay.factory);
-        defaultValue = createChild("default", this, ObjectOverlay.factory);
-        nullable = createChild("nullable", this, BooleanOverlay.factory);
-        discriminator = createChild("discriminator", this, StringOverlay.factory);
-        readOnly = createChild("readOnly", this, BooleanOverlay.factory);
-        writeOnly = createChild("writeOnly", this, BooleanOverlay.factory);
-        xml = createChild("xml", this, XmlImpl.factory);
-        externalDocs = createChild("externalDocs", this, ExternalDocsImpl.factory);
-        examples = createChildMap("examples", this, ExampleImpl.factory, "[a-zA-Z0-9\\._-]+");
-        example = createChild("example", this, ObjectOverlay.factory);
-        deprecated = createChild("deprecated", this, BooleanOverlay.factory);
-        extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
-    }
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public static OverlayFactory<Schema> factory = new OverlayFactory<Schema>() {
-
-        @Override
-        protected Class<? extends IJsonOverlay<? super Schema>> getOverlayClass() {
-            return SchemaImpl.class;
-        }
-
-        @Override
-        public JsonOverlay<Schema> _create(Schema schema, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            IJsonOverlay<?> overlay;
-            overlay = new SchemaImpl(schema, parent, refReg);
-            @SuppressWarnings("unchecked") JsonOverlay<Schema> castOverlay = (JsonOverlay<Schema>) overlay;
-            return castOverlay;
-        }
-
-        @Override
-        public JsonOverlay<Schema> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            IJsonOverlay<?> overlay;
-            overlay = new SchemaImpl(json, parent, refReg);
-            @SuppressWarnings("unchecked") JsonOverlay<Schema> castOverlay = (JsonOverlay<Schema>) overlay;
-            return castOverlay;
-        }
-    };
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private static Class<? extends Schema> getSubtypeOf(Schema schema) {
-        return Schema.class;
-    }
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private static Class<? extends Schema> getSubtypeOf(JsonNode json) {
-        return Schema.class;
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<Object> defaultValue;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<Boolean> nullable;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<String> discriminator;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<Boolean> readOnly;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<Boolean> writeOnly;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<Xml> xml;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<ExternalDocs> externalDocs;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildMapOverlay<Example> examples;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<Object> example;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<Boolean> deprecated;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildMapOverlay<Object> extensions;
+
+	// Title
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getTitle() {
+		return title._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getTitle(boolean elaborate) {
+		return title._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setTitle(String title) {
+		this.title._set(title);
+	}
+
+	// MultipleOf
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Number getMultipleOf() {
+		return multipleOf._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Number getMultipleOf(boolean elaborate) {
+		return multipleOf._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setMultipleOf(Number multipleOf) {
+		this.multipleOf._set(multipleOf);
+	}
+
+	// Maximum
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Number getMaximum() {
+		return maximum._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Number getMaximum(boolean elaborate) {
+		return maximum._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setMaximum(Number maximum) {
+		this.maximum._set(maximum);
+	}
+
+	// ExclusiveMaximum
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Boolean getExclusiveMaximum() {
+		return exclusiveMaximum._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Boolean getExclusiveMaximum(boolean elaborate) {
+		return exclusiveMaximum._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean isExclusiveMaximum() {
+		return exclusiveMaximum._get() != null ? exclusiveMaximum._get() : false;
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setExclusiveMaximum(Boolean exclusiveMaximum) {
+		this.exclusiveMaximum._set(exclusiveMaximum);
+	}
+
+	// Minimum
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Number getMinimum() {
+		return minimum._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Number getMinimum(boolean elaborate) {
+		return minimum._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setMinimum(Number minimum) {
+		this.minimum._set(minimum);
+	}
+
+	// ExclusiveMinimum
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Boolean getExclusiveMinimum() {
+		return exclusiveMinimum._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Boolean getExclusiveMinimum(boolean elaborate) {
+		return exclusiveMinimum._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean isExclusiveMinimum() {
+		return exclusiveMinimum._get() != null ? exclusiveMinimum._get() : false;
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setExclusiveMinimum(Boolean exclusiveMinimum) {
+		this.exclusiveMinimum._set(exclusiveMinimum);
+	}
+
+	// MaxLength
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Integer getMaxLength() {
+		return maxLength._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Integer getMaxLength(boolean elaborate) {
+		return maxLength._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setMaxLength(Integer maxLength) {
+		this.maxLength._set(maxLength);
+	}
+
+	// MinLength
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Integer getMinLength() {
+		return minLength._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Integer getMinLength(boolean elaborate) {
+		return minLength._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setMinLength(Integer minLength) {
+		this.minLength._set(minLength);
+	}
+
+	// Pattern
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getPattern() {
+		return pattern._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getPattern(boolean elaborate) {
+		return pattern._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setPattern(String pattern) {
+		this.pattern._set(pattern);
+	}
+
+	// MaxItems
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Integer getMaxItems() {
+		return maxItems._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Integer getMaxItems(boolean elaborate) {
+		return maxItems._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setMaxItems(Integer maxItems) {
+		this.maxItems._set(maxItems);
+	}
+
+	// MinItems
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Integer getMinItems() {
+		return minItems._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Integer getMinItems(boolean elaborate) {
+		return minItems._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setMinItems(Integer minItems) {
+		this.minItems._set(minItems);
+	}
+
+	// UniqueItems
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Boolean getUniqueItems() {
+		return uniqueItems._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Boolean getUniqueItems(boolean elaborate) {
+		return uniqueItems._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean isUniqueItems() {
+		return uniqueItems._get() != null ? uniqueItems._get() : false;
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setUniqueItems(Boolean uniqueItems) {
+		this.uniqueItems._set(uniqueItems);
+	}
+
+	// MaxProperties
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Integer getMaxProperties() {
+		return maxProperties._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Integer getMaxProperties(boolean elaborate) {
+		return maxProperties._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setMaxProperties(Integer maxProperties) {
+		this.maxProperties._set(maxProperties);
+	}
+
+	// MinProperties
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Integer getMinProperties() {
+		return minProperties._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Integer getMinProperties(boolean elaborate) {
+		return minProperties._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setMinProperties(Integer minProperties) {
+		this.minProperties._set(minProperties);
+	}
+
+	// RequiredField
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Collection<String> getRequiredFields() {
+		return requiredFields._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Collection<String> getRequiredFields(boolean elaborate) {
+		return requiredFields._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasRequiredFields() {
+		return requiredFields._isPresent();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getRequiredField(int index) {
+		return requiredFields._get(index);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setRequiredFields(Collection<String> requiredFields) {
+		this.requiredFields._set(requiredFields);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setRequiredField(int index, String requiredField) {
+		requiredFields._set(index, requiredField);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void addRequiredField(String requiredField) {
+		requiredFields._add(requiredField);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void insertRequiredField(int index, String requiredField) {
+		requiredFields._insert(index, requiredField);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeRequiredField(int index) {
+		requiredFields._remove(index);
+	}
+
+	// Enum
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Collection<Object> getEnums() {
+		return enums._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Collection<Object> getEnums(boolean elaborate) {
+		return enums._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasEnums() {
+		return enums._isPresent();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Object getEnum(int index) {
+		return enums._get(index);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setEnums(Collection<Object> enums) {
+		this.enums._set(enums);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setEnum(int index, Object enumValue) {
+		enums._set(index, enumValue);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void addEnum(Object enumValue) {
+		enums._add(enumValue);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void insertEnum(int index, Object enumValue) {
+		enums._insert(index, enumValue);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeEnum(int index) {
+		enums._remove(index);
+	}
+
+	// Type
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getType() {
+		return type._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getType(boolean elaborate) {
+		return type._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setType(String type) {
+		this.type._set(type);
+	}
+
+	// AllOfSchema
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Collection<Schema> getAllOfSchemas() {
+		return allOfSchemas._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Collection<Schema> getAllOfSchemas(boolean elaborate) {
+		return allOfSchemas._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasAllOfSchemas() {
+		return allOfSchemas._isPresent();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Schema getAllOfSchema(int index) {
+		return allOfSchemas._get(index);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setAllOfSchemas(Collection<Schema> allOfSchemas) {
+		this.allOfSchemas._set(allOfSchemas);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setAllOfSchema(int index, Schema allOfSchema) {
+		allOfSchemas._set(index, allOfSchema);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void addAllOfSchema(Schema allOfSchema) {
+		allOfSchemas._add(allOfSchema);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void insertAllOfSchema(int index, Schema allOfSchema) {
+		allOfSchemas._insert(index, allOfSchema);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeAllOfSchema(int index) {
+		allOfSchemas._remove(index);
+	}
+
+	// OneOfSchema
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Collection<Schema> getOneOfSchemas() {
+		return oneOfSchemas._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Collection<Schema> getOneOfSchemas(boolean elaborate) {
+		return oneOfSchemas._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasOneOfSchemas() {
+		return oneOfSchemas._isPresent();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Schema getOneOfSchema(int index) {
+		return oneOfSchemas._get(index);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setOneOfSchemas(Collection<Schema> oneOfSchemas) {
+		this.oneOfSchemas._set(oneOfSchemas);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setOneOfSchema(int index, Schema oneOfSchema) {
+		oneOfSchemas._set(index, oneOfSchema);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void addOneOfSchema(Schema oneOfSchema) {
+		oneOfSchemas._add(oneOfSchema);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void insertOneOfSchema(int index, Schema oneOfSchema) {
+		oneOfSchemas._insert(index, oneOfSchema);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeOneOfSchema(int index) {
+		oneOfSchemas._remove(index);
+	}
+
+	// AnyOfSchema
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Collection<Schema> getAnyOfSchemas() {
+		return anyOfSchemas._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Collection<Schema> getAnyOfSchemas(boolean elaborate) {
+		return anyOfSchemas._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasAnyOfSchemas() {
+		return anyOfSchemas._isPresent();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Schema getAnyOfSchema(int index) {
+		return anyOfSchemas._get(index);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setAnyOfSchemas(Collection<Schema> anyOfSchemas) {
+		this.anyOfSchemas._set(anyOfSchemas);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setAnyOfSchema(int index, Schema anyOfSchema) {
+		anyOfSchemas._set(index, anyOfSchema);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void addAnyOfSchema(Schema anyOfSchema) {
+		anyOfSchemas._add(anyOfSchema);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void insertAnyOfSchema(int index, Schema anyOfSchema) {
+		anyOfSchemas._insert(index, anyOfSchema);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeAnyOfSchema(int index) {
+		anyOfSchemas._remove(index);
+	}
+
+	// NotSchema
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Schema getNotSchema() {
+		return notSchema._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Schema getNotSchema(boolean elaborate) {
+		return notSchema._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setNotSchema(Schema notSchema) {
+		this.notSchema._set(notSchema);
+	}
+
+	// ItemsSchema
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Schema getItemsSchema() {
+		return itemsSchema._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Schema getItemsSchema(boolean elaborate) {
+		return itemsSchema._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setItemsSchema(Schema itemsSchema) {
+		this.itemsSchema._set(itemsSchema);
+	}
+
+	// Property
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Schema> getProperties() {
+		return properties._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Schema> getProperties(boolean elaborate) {
+		return properties._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasProperty(String name) {
+		return properties.containsKey(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Schema getProperty(String name) {
+		return properties._get(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setProperties(Map<String, Schema> properties) {
+		this.properties._set(properties);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setProperty(String name, Schema property) {
+		properties._set(name, property);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeProperty(String name) {
+		properties._remove(name);
+	}
+
+	// AdditionalPropertiesSchema
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Schema getAdditionalPropertiesSchema() {
+		return additionalPropertiesSchema._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Schema getAdditionalPropertiesSchema(boolean elaborate) {
+		return additionalPropertiesSchema._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setAdditionalPropertiesSchema(Schema additionalPropertiesSchema) {
+		this.additionalPropertiesSchema._set(additionalPropertiesSchema);
+	}
+
+	// AdditionalProperties
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Boolean getAdditionalProperties() {
+		return additionalProperties._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Boolean getAdditionalProperties(boolean elaborate) {
+		return additionalProperties._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean isAdditionalProperties() {
+		return additionalProperties._get() != null ? additionalProperties._get() : false;
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setAdditionalProperties(Boolean additionalProperties) {
+		this.additionalProperties._set(additionalProperties);
+	}
+
+	// Description
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getDescription() {
+		return description._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getDescription(boolean elaborate) {
+		return description._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setDescription(String description) {
+		this.description._set(description);
+	}
+
+	// Format
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getFormat() {
+		return format._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getFormat(boolean elaborate) {
+		return format._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setFormat(String format) {
+		this.format._set(format);
+	}
+
+	// Default
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Object getDefault() {
+		return defaultValue._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Object getDefault(boolean elaborate) {
+		return defaultValue._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setDefault(Object defaultValue) {
+		this.defaultValue._set(defaultValue);
+	}
+
+	// Nullable
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Boolean getNullable() {
+		return nullable._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Boolean getNullable(boolean elaborate) {
+		return nullable._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean isNullable() {
+		return nullable._get() != null ? nullable._get() : false;
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setNullable(Boolean nullable) {
+		this.nullable._set(nullable);
+	}
+
+	// Discriminator
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getDiscriminator() {
+		return discriminator._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getDiscriminator(boolean elaborate) {
+		return discriminator._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setDiscriminator(String discriminator) {
+		this.discriminator._set(discriminator);
+	}
+
+	// ReadOnly
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Boolean getReadOnly() {
+		return readOnly._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Boolean getReadOnly(boolean elaborate) {
+		return readOnly._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean isReadOnly() {
+		return readOnly._get() != null ? readOnly._get() : false;
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setReadOnly(Boolean readOnly) {
+		this.readOnly._set(readOnly);
+	}
+
+	// WriteOnly
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Boolean getWriteOnly() {
+		return writeOnly._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Boolean getWriteOnly(boolean elaborate) {
+		return writeOnly._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean isWriteOnly() {
+		return writeOnly._get() != null ? writeOnly._get() : false;
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setWriteOnly(Boolean writeOnly) {
+		this.writeOnly._set(writeOnly);
+	}
+
+	// Xml
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Xml getXml() {
+		return xml._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Xml getXml(boolean elaborate) {
+		return xml._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setXml(Xml xml) {
+		this.xml._set(xml);
+	}
+
+	// ExternalDocs
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public ExternalDocs getExternalDocs() {
+		return externalDocs._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public ExternalDocs getExternalDocs(boolean elaborate) {
+		return externalDocs._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setExternalDocs(ExternalDocs externalDocs) {
+		this.externalDocs._set(externalDocs);
+	}
+
+	// Example
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Example> getExamples() {
+		return examples._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Example> getExamples(boolean elaborate) {
+		return examples._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasExample(String name) {
+		return examples.containsKey(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Example getExample(String name) {
+		return examples._get(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setExamples(Map<String, Example> examples) {
+		this.examples._set(examples);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setExample(String name, Example example) {
+		examples._set(name, example);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeExample(String name) {
+		examples._remove(name);
+	}
+
+	// Example
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Object getExample() {
+		return example._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Object getExample(boolean elaborate) {
+		return example._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setExample(Object example) {
+		this.example._set(example);
+	}
+
+	// Deprecated
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Boolean getDeprecated() {
+		return deprecated._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Boolean getDeprecated(boolean elaborate) {
+		return deprecated._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean isDeprecated() {
+		return deprecated._get() != null ? deprecated._get() : false;
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setDeprecated(Boolean deprecated) {
+		this.deprecated._set(deprecated);
+	}
+
+	// Extension
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Object> getExtensions() {
+		return extensions._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Object> getExtensions(boolean elaborate) {
+		return extensions._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasExtension(String name) {
+		return extensions.containsKey(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Object getExtension(String name) {
+		return extensions._get(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setExtensions(Map<String, Object> extensions) {
+		this.extensions._set(extensions);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setExtension(String name, Object extension) {
+		extensions._set(name, extension);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeExtension(String name) {
+		extensions._remove(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	protected void elaborateChildren() {
+		super.elaborateChildren();
+		title = createChild("title", this, StringOverlay.factory);
+		multipleOf = createChild("multipleOf", this, NumberOverlay.factory);
+		maximum = createChild("maximum", this, NumberOverlay.factory);
+		exclusiveMaximum = createChild("exclusiveMaximum", this, BooleanOverlay.factory);
+		minimum = createChild("minimum", this, NumberOverlay.factory);
+		exclusiveMinimum = createChild("exclusiveMinimum", this, BooleanOverlay.factory);
+		maxLength = createChild("maxLength", this, IntegerOverlay.factory);
+		minLength = createChild("minLength", this, IntegerOverlay.factory);
+		pattern = createChild("pattern", this, StringOverlay.factory);
+		maxItems = createChild("maxItems", this, IntegerOverlay.factory);
+		minItems = createChild("minItems", this, IntegerOverlay.factory);
+		uniqueItems = createChild("uniqueItems", this, BooleanOverlay.factory);
+		maxProperties = createChild("maxProperties", this, IntegerOverlay.factory);
+		minProperties = createChild("minProperties", this, IntegerOverlay.factory);
+		requiredFields = createChildList("required", this, StringOverlay.factory);
+		enums = createChildList("enum", this, ObjectOverlay.factory);
+		type = createChild("type", this, StringOverlay.factory);
+		allOfSchemas = createChildList("allOf", this, SchemaImpl.factory);
+		oneOfSchemas = createChildList("oneOf", this, SchemaImpl.factory);
+		anyOfSchemas = createChildList("anyOf", this, SchemaImpl.factory);
+		notSchema = createChild("not", this, SchemaImpl.factory);
+		itemsSchema = createChild("items", this, SchemaImpl.factory);
+		properties = createChildMap("properties", this, SchemaImpl.factory, null);
+		additionalPropertiesSchema = createChild(json.at("/additionalProperties").isObject(), "additionalProperties",
+				this, SchemaImpl.factory);
+		additionalProperties = createChild(json.at("/additionalProperties").isBoolean(), "additionalProperties", this,
+				BooleanOverlay.factory);
+		description = createChild("description", this, StringOverlay.factory);
+		format = createChild("format", this, StringOverlay.factory);
+		defaultValue = createChild("default", this, ObjectOverlay.factory);
+		nullable = createChild("nullable", this, BooleanOverlay.factory);
+		discriminator = createChild("discriminator", this, StringOverlay.factory);
+		readOnly = createChild("readOnly", this, BooleanOverlay.factory);
+		writeOnly = createChild("writeOnly", this, BooleanOverlay.factory);
+		xml = createChild("xml", this, XmlImpl.factory);
+		externalDocs = createChild("externalDocs", this, ExternalDocsImpl.factory);
+		examples = createChildMap("examples", this, ExampleImpl.factory, "[a-zA-Z0-9\\._-]+");
+		example = createChild("example", this, ObjectOverlay.factory);
+		deprecated = createChild("deprecated", this, BooleanOverlay.factory);
+		extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
+	}
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public static OverlayFactory<Schema> factory = new OverlayFactory<Schema>() {
+
+		@Override
+		protected Class<? extends AbstractJsonOverlay<? super Schema>> getOverlayClass() {
+			return SchemaImpl.class;
+		}
+
+		@Override
+		public JsonOverlay<Schema> _create(Schema schema, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+			AbstractJsonOverlay<?> overlay;
+			overlay = new SchemaImpl(schema, parent, refReg);
+			@SuppressWarnings("unchecked")
+			JsonOverlay<Schema> castOverlay = (JsonOverlay<Schema>) overlay;
+			return castOverlay;
+		}
+
+		@Override
+		public JsonOverlay<Schema> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+			AbstractJsonOverlay<?> overlay;
+			overlay = new SchemaImpl(json, parent, refReg);
+			@SuppressWarnings("unchecked")
+			JsonOverlay<Schema> castOverlay = (JsonOverlay<Schema>) overlay;
+			return castOverlay;
+		}
+	};
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private static Class<? extends Schema> getSubtypeOf(Schema schema) {
+		return Schema.class;
+	}
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private static Class<? extends Schema> getSubtypeOf(JsonNode json) {
+		return Schema.class;
+	}
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/SecurityParameterImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/SecurityParameterImpl.java
@@ -1,135 +1,136 @@
 package com.reprezen.kaizen.oasparser.ovl3;
 
-import com.reprezen.jsonoverlay.StringOverlay;
-import com.reprezen.jsonoverlay.ChildListOverlay;
-import com.reprezen.jsonoverlay.ReferenceRegistry;
 import java.util.Collection;
-import java.util.stream.Collectors;
-import com.reprezen.kaizen.oasparser.model3.*;
+
+import javax.annotation.Generated;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.reprezen.jsonoverlay.AbstractJsonOverlay;
+import com.reprezen.jsonoverlay.ChildListOverlay;
+import com.reprezen.jsonoverlay.JsonOverlay;
 import com.reprezen.jsonoverlay.OverlayFactory;
 import com.reprezen.jsonoverlay.PropertiesOverlay;
-import javax.annotation.Generated;
-import com.fasterxml.jackson.core.JsonPointer;
-import com.reprezen.jsonoverlay.IJsonOverlay;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
-import com.reprezen.jsonoverlay.JsonOverlay;
-import com.reprezen.jsonoverlay.ListOverlay;
-import com.fasterxml.jackson.databind.JsonNode;
+import com.reprezen.jsonoverlay.ReferenceRegistry;
+import com.reprezen.jsonoverlay.StringOverlay;
+import com.reprezen.kaizen.oasparser.model3.SecurityParameter;
 
 public class SecurityParameterImpl extends PropertiesOverlay<SecurityParameter> implements SecurityParameter {
 
-    @Override
-    protected JsonNode fixJson(JsonNode json) {
-        return json.isMissingNode() ? jsonArray() : json;
-    }
+	@Override
+	protected JsonNode fixJson(JsonNode json) {
+		return json.isMissingNode() ? jsonArray() : json;
+	}
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public SecurityParameterImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        super(json, parent, refReg);
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public SecurityParameterImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+		super(json, parent, refReg);
+	}
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public SecurityParameterImpl(SecurityParameter securityParameter, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        super(securityParameter, parent, refReg);
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public SecurityParameterImpl(SecurityParameter securityParameter, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+		super(securityParameter, parent, refReg);
+	}
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildListOverlay<String> parameters;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildListOverlay<String> parameters;
 
-    // Parameter
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Collection<String> getParameters() {
-        return parameters.get();
-    }
+	// Parameter
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Collection<String> getParameters() {
+		return parameters._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Collection<String> getParameters(boolean elaborate) {
-        return parameters.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Collection<String> getParameters(boolean elaborate) {
+		return parameters._get(elaborate);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasParameters() {
-        return parameters.isPresent();
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasParameters() {
+		return parameters._isPresent();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getParameter(int index) {
-        return parameters.get(index);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getParameter(int index) {
+		return parameters._get(index);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setParameters(Collection<String> parameters) {
-        this.parameters.set(parameters);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setParameters(Collection<String> parameters) {
+		this.parameters._set(parameters);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setParameter(int index, String parameter) {
-        parameters.set(index, parameter);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setParameter(int index, String parameter) {
+		parameters._set(index, parameter);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void addParameter(String parameter) {
-        parameters.add(parameter);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void addParameter(String parameter) {
+		parameters._add(parameter);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void insertParameter(int index, String parameter) {
-        parameters.insert(index, parameter);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void insertParameter(int index, String parameter) {
+		parameters._insert(index, parameter);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeParameter(int index) {
-        parameters.remove(index);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeParameter(int index) {
+		parameters._remove(index);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    protected void elaborateChildren() {
-        super.elaborateChildren();
-        parameters = createChildList("", this, StringOverlay.factory);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	protected void elaborateChildren() {
+		super.elaborateChildren();
+		parameters = createChildList("", this, StringOverlay.factory);
+	}
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public static OverlayFactory<SecurityParameter> factory = new OverlayFactory<SecurityParameter>() {
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public static OverlayFactory<SecurityParameter> factory = new OverlayFactory<SecurityParameter>() {
 
-        @Override
-        protected Class<? extends IJsonOverlay<? super SecurityParameter>> getOverlayClass() {
-            return SecurityParameterImpl.class;
-        }
+		@Override
+		protected Class<? extends AbstractJsonOverlay<? super SecurityParameter>> getOverlayClass() {
+			return SecurityParameterImpl.class;
+		}
 
-        @Override
-        public JsonOverlay<SecurityParameter> _create(SecurityParameter securityParameter, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            IJsonOverlay<?> overlay;
-            overlay = new SecurityParameterImpl(securityParameter, parent, refReg);
-            @SuppressWarnings("unchecked") JsonOverlay<SecurityParameter> castOverlay = (JsonOverlay<SecurityParameter>) overlay;
-            return castOverlay;
-        }
+		@Override
+		public JsonOverlay<SecurityParameter> _create(SecurityParameter securityParameter, JsonOverlay<?> parent,
+				ReferenceRegistry refReg) {
+			AbstractJsonOverlay<?> overlay;
+			overlay = new SecurityParameterImpl(securityParameter, parent, refReg);
+			@SuppressWarnings("unchecked")
+			JsonOverlay<SecurityParameter> castOverlay = (JsonOverlay<SecurityParameter>) overlay;
+			return castOverlay;
+		}
 
-        @Override
-        public JsonOverlay<SecurityParameter> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            IJsonOverlay<?> overlay;
-            overlay = new SecurityParameterImpl(json, parent, refReg);
-            @SuppressWarnings("unchecked") JsonOverlay<SecurityParameter> castOverlay = (JsonOverlay<SecurityParameter>) overlay;
-            return castOverlay;
-        }
-    };
+		@Override
+		public JsonOverlay<SecurityParameter> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+			AbstractJsonOverlay<?> overlay;
+			overlay = new SecurityParameterImpl(json, parent, refReg);
+			@SuppressWarnings("unchecked")
+			JsonOverlay<SecurityParameter> castOverlay = (JsonOverlay<SecurityParameter>) overlay;
+			return castOverlay;
+		}
+	};
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private static Class<? extends SecurityParameter> getSubtypeOf(SecurityParameter securityParameter) {
-        return SecurityParameter.class;
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private static Class<? extends SecurityParameter> getSubtypeOf(SecurityParameter securityParameter) {
+		return SecurityParameter.class;
+	}
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private static Class<? extends SecurityParameter> getSubtypeOf(JsonNode json) {
-        return SecurityParameter.class;
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private static Class<? extends SecurityParameter> getSubtypeOf(JsonNode json) {
+		return SecurityParameter.class;
+	}
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/SecurityRequirementImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/SecurityRequirementImpl.java
@@ -1,118 +1,121 @@
 package com.reprezen.kaizen.oasparser.ovl3;
 
-import com.reprezen.jsonoverlay.ReferenceRegistry;
-import com.reprezen.kaizen.oasparser.ovl3.SecurityParameterImpl;
+import java.util.Map;
+
+import javax.annotation.Generated;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.reprezen.jsonoverlay.AbstractJsonOverlay;
 import com.reprezen.jsonoverlay.ChildMapOverlay;
-import com.reprezen.jsonoverlay.MapOverlay;
-import com.reprezen.kaizen.oasparser.model3.SecurityParameter;
-import java.util.stream.Collectors;
-import com.reprezen.kaizen.oasparser.model3.*;
+import com.reprezen.jsonoverlay.JsonOverlay;
 import com.reprezen.jsonoverlay.OverlayFactory;
 import com.reprezen.jsonoverlay.PropertiesOverlay;
-import javax.annotation.Generated;
-import com.fasterxml.jackson.core.JsonPointer;
-import com.reprezen.jsonoverlay.IJsonOverlay;
-import com.reprezen.jsonoverlay.JsonOverlay;
-import java.util.Map;
-import com.fasterxml.jackson.databind.JsonNode;
+import com.reprezen.jsonoverlay.ReferenceRegistry;
+import com.reprezen.kaizen.oasparser.model3.SecurityParameter;
+import com.reprezen.kaizen.oasparser.model3.SecurityRequirement;
 
 public class SecurityRequirementImpl extends PropertiesOverlay<SecurityRequirement> implements SecurityRequirement {
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public SecurityRequirementImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        super(json, parent, refReg);
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public SecurityRequirementImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+		super(json, parent, refReg);
+	}
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public SecurityRequirementImpl(SecurityRequirement securityRequirement, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        super(securityRequirement, parent, refReg);
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public SecurityRequirementImpl(SecurityRequirement securityRequirement, JsonOverlay<?> parent,
+			ReferenceRegistry refReg) {
+		super(securityRequirement, parent, refReg);
+	}
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildMapOverlay<SecurityParameter> requirements;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildMapOverlay<SecurityParameter> requirements;
 
-    // Requirement
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, SecurityParameter> getRequirements() {
-        return requirements.get();
-    }
+	// Requirement
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, SecurityParameter> getRequirements() {
+		return requirements._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, SecurityParameter> getRequirements(boolean elaborate) {
-        return requirements.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, SecurityParameter> getRequirements(boolean elaborate) {
+		return requirements._get(elaborate);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasRequirement(String name) {
-        return requirements.containsKey(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasRequirement(String name) {
+		return requirements.containsKey(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public SecurityParameter getRequirement(String name) {
-        return requirements.get(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public SecurityParameter getRequirement(String name) {
+		return requirements._get(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setRequirements(Map<String, SecurityParameter> requirements) {
-        this.requirements.set(requirements);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setRequirements(Map<String, SecurityParameter> requirements) {
+		this.requirements._set(requirements);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setRequirement(String name, SecurityParameter requirement) {
-        requirements.set(name, requirement);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setRequirement(String name, SecurityParameter requirement) {
+		requirements._set(name, requirement);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeRequirement(String name) {
-        requirements.remove(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeRequirement(String name) {
+		requirements._remove(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    protected void elaborateChildren() {
-        super.elaborateChildren();
-        requirements = createChildMap("", this, SecurityParameterImpl.factory, "[a-zA-Z0-9\\._-]+");
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	protected void elaborateChildren() {
+		super.elaborateChildren();
+		requirements = createChildMap("", this, SecurityParameterImpl.factory, "[a-zA-Z0-9\\._-]+");
+	}
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public static OverlayFactory<SecurityRequirement> factory = new OverlayFactory<SecurityRequirement>() {
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public static OverlayFactory<SecurityRequirement> factory = new OverlayFactory<SecurityRequirement>() {
 
-        @Override
-        protected Class<? extends IJsonOverlay<? super SecurityRequirement>> getOverlayClass() {
-            return SecurityRequirementImpl.class;
-        }
+		@Override
+		protected Class<? extends AbstractJsonOverlay<? super SecurityRequirement>> getOverlayClass() {
+			return SecurityRequirementImpl.class;
+		}
 
-        @Override
-        public JsonOverlay<SecurityRequirement> _create(SecurityRequirement securityRequirement, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            IJsonOverlay<?> overlay;
-            overlay = new SecurityRequirementImpl(securityRequirement, parent, refReg);
-            @SuppressWarnings("unchecked") JsonOverlay<SecurityRequirement> castOverlay = (JsonOverlay<SecurityRequirement>) overlay;
-            return castOverlay;
-        }
+		@Override
+		public JsonOverlay<SecurityRequirement> _create(SecurityRequirement securityRequirement, JsonOverlay<?> parent,
+				ReferenceRegistry refReg) {
+			AbstractJsonOverlay<?> overlay;
+			overlay = new SecurityRequirementImpl(securityRequirement, parent, refReg);
+			@SuppressWarnings("unchecked")
+			JsonOverlay<SecurityRequirement> castOverlay = (JsonOverlay<SecurityRequirement>) overlay;
+			return castOverlay;
+		}
 
-        @Override
-        public JsonOverlay<SecurityRequirement> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            IJsonOverlay<?> overlay;
-            overlay = new SecurityRequirementImpl(json, parent, refReg);
-            @SuppressWarnings("unchecked") JsonOverlay<SecurityRequirement> castOverlay = (JsonOverlay<SecurityRequirement>) overlay;
-            return castOverlay;
-        }
-    };
+		@Override
+		public JsonOverlay<SecurityRequirement> _create(JsonNode json, JsonOverlay<?> parent,
+				ReferenceRegistry refReg) {
+			AbstractJsonOverlay<?> overlay;
+			overlay = new SecurityRequirementImpl(json, parent, refReg);
+			@SuppressWarnings("unchecked")
+			JsonOverlay<SecurityRequirement> castOverlay = (JsonOverlay<SecurityRequirement>) overlay;
+			return castOverlay;
+		}
+	};
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private static Class<? extends SecurityRequirement> getSubtypeOf(SecurityRequirement securityRequirement) {
-        return SecurityRequirement.class;
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private static Class<? extends SecurityRequirement> getSubtypeOf(SecurityRequirement securityRequirement) {
+		return SecurityRequirement.class;
+	}
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private static Class<? extends SecurityRequirement> getSubtypeOf(JsonNode json) {
-        return SecurityRequirement.class;
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private static Class<? extends SecurityRequirement> getSubtypeOf(JsonNode json) {
+		return SecurityRequirement.class;
+	}
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/SecuritySchemeImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/SecuritySchemeImpl.java
@@ -1,421 +1,422 @@
 package com.reprezen.kaizen.oasparser.ovl3;
 
-import com.reprezen.jsonoverlay.StringOverlay;
-import com.reprezen.jsonoverlay.ReferenceRegistry;
-import com.reprezen.kaizen.oasparser.ovl3.OAuthFlowImpl;
+import java.util.Map;
+
+import javax.annotation.Generated;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.reprezen.jsonoverlay.AbstractJsonOverlay;
 import com.reprezen.jsonoverlay.ChildMapOverlay;
-import com.reprezen.kaizen.oasparser.model3.OAuthFlow;
+import com.reprezen.jsonoverlay.ChildOverlay;
+import com.reprezen.jsonoverlay.JsonOverlay;
 import com.reprezen.jsonoverlay.ObjectOverlay;
-import com.reprezen.jsonoverlay.MapOverlay;
-import java.util.stream.Collectors;
-import com.reprezen.kaizen.oasparser.model3.*;
 import com.reprezen.jsonoverlay.OverlayFactory;
 import com.reprezen.jsonoverlay.PropertiesOverlay;
-import javax.annotation.Generated;
-import com.fasterxml.jackson.core.JsonPointer;
-import com.reprezen.jsonoverlay.IJsonOverlay;
-import com.reprezen.jsonoverlay.JsonOverlay;
-import java.util.Map;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.reprezen.jsonoverlay.ChildOverlay;
+import com.reprezen.jsonoverlay.ReferenceRegistry;
+import com.reprezen.jsonoverlay.StringOverlay;
+import com.reprezen.kaizen.oasparser.model3.OAuthFlow;
+import com.reprezen.kaizen.oasparser.model3.SecurityScheme;
 
 public class SecuritySchemeImpl extends PropertiesOverlay<SecurityScheme> implements SecurityScheme {
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public SecuritySchemeImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        super(json, parent, refReg);
-    }
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public SecuritySchemeImpl(SecurityScheme securityScheme, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        super(securityScheme, parent, refReg);
-    }
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<String> type;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<String> description;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<String> name;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<String> in;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<String> scheme;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<String> bearerFormat;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<OAuthFlow> implicitOAuthFlow;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<OAuthFlow> passwordOAuthFlow;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<OAuthFlow> clientCredentialsOAuthFlow;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<OAuthFlow> authorizationCodeOAuthFlow;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildMapOverlay<Object> oAuthFlowsExtensions;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<String> openIdConnectUrl;
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildMapOverlay<Object> extensions;
-
-    // Type
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getType() {
-        return type.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getType(boolean elaborate) {
-        return type.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setType(String type) {
-        this.type.set(type);
-    }
-
-    // Description
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getDescription() {
-        return description.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getDescription(boolean elaborate) {
-        return description.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setDescription(String description) {
-        this.description.set(description);
-    }
-
-    // Name
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getName() {
-        return name.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getName(boolean elaborate) {
-        return name.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setName(String name) {
-        this.name.set(name);
-    }
-
-    // In
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getIn() {
-        return in.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getIn(boolean elaborate) {
-        return in.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setIn(String in) {
-        this.in.set(in);
-    }
-
-    // Scheme
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getScheme() {
-        return scheme.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getScheme(boolean elaborate) {
-        return scheme.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setScheme(String scheme) {
-        this.scheme.set(scheme);
-    }
-
-    // BearerFormat
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getBearerFormat() {
-        return bearerFormat.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getBearerFormat(boolean elaborate) {
-        return bearerFormat.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setBearerFormat(String bearerFormat) {
-        this.bearerFormat.set(bearerFormat);
-    }
-
-    // ImplicitOAuthFlow
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public OAuthFlow getImplicitOAuthFlow() {
-        return implicitOAuthFlow.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public OAuthFlow getImplicitOAuthFlow(boolean elaborate) {
-        return implicitOAuthFlow.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setImplicitOAuthFlow(OAuthFlow implicitOAuthFlow) {
-        this.implicitOAuthFlow.set(implicitOAuthFlow);
-    }
-
-    // PasswordOAuthFlow
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public OAuthFlow getPasswordOAuthFlow() {
-        return passwordOAuthFlow.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public OAuthFlow getPasswordOAuthFlow(boolean elaborate) {
-        return passwordOAuthFlow.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setPasswordOAuthFlow(OAuthFlow passwordOAuthFlow) {
-        this.passwordOAuthFlow.set(passwordOAuthFlow);
-    }
-
-    // ClientCredentialsOAuthFlow
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public OAuthFlow getClientCredentialsOAuthFlow() {
-        return clientCredentialsOAuthFlow.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public OAuthFlow getClientCredentialsOAuthFlow(boolean elaborate) {
-        return clientCredentialsOAuthFlow.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setClientCredentialsOAuthFlow(OAuthFlow clientCredentialsOAuthFlow) {
-        this.clientCredentialsOAuthFlow.set(clientCredentialsOAuthFlow);
-    }
-
-    // AuthorizationCodeOAuthFlow
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public OAuthFlow getAuthorizationCodeOAuthFlow() {
-        return authorizationCodeOAuthFlow.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public OAuthFlow getAuthorizationCodeOAuthFlow(boolean elaborate) {
-        return authorizationCodeOAuthFlow.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setAuthorizationCodeOAuthFlow(OAuthFlow authorizationCodeOAuthFlow) {
-        this.authorizationCodeOAuthFlow.set(authorizationCodeOAuthFlow);
-    }
-
-    // OAuthFlowsExtension
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Object> getOAuthFlowsExtensions() {
-        return oAuthFlowsExtensions.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Object> getOAuthFlowsExtensions(boolean elaborate) {
-        return oAuthFlowsExtensions.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasOAuthFlowsExtension(String name) {
-        return oAuthFlowsExtensions.containsKey(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Object getOAuthFlowsExtension(String name) {
-        return oAuthFlowsExtensions.get(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setOAuthFlowsExtensions(Map<String, Object> oAuthFlowsExtensions) {
-        this.oAuthFlowsExtensions.set(oAuthFlowsExtensions);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setOAuthFlowsExtension(String name, Object oAuthFlowsExtension) {
-        oAuthFlowsExtensions.set(name, oAuthFlowsExtension);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeOAuthFlowsExtension(String name) {
-        oAuthFlowsExtensions.remove(name);
-    }
-
-    // OpenIdConnectUrl
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getOpenIdConnectUrl() {
-        return openIdConnectUrl.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getOpenIdConnectUrl(boolean elaborate) {
-        return openIdConnectUrl.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setOpenIdConnectUrl(String openIdConnectUrl) {
-        this.openIdConnectUrl.set(openIdConnectUrl);
-    }
-
-    // Extension
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Object> getExtensions() {
-        return extensions.get();
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Object> getExtensions(boolean elaborate) {
-        return extensions.get(elaborate);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasExtension(String name) {
-        return extensions.containsKey(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Object getExtension(String name) {
-        return extensions.get(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setExtensions(Map<String, Object> extensions) {
-        this.extensions.set(extensions);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setExtension(String name, Object extension) {
-        extensions.set(name, extension);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeExtension(String name) {
-        extensions.remove(name);
-    }
-
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    protected void elaborateChildren() {
-        super.elaborateChildren();
-        type = createChild("type", this, StringOverlay.factory);
-        description = createChild("description", this, StringOverlay.factory);
-        name = createChild("name", this, StringOverlay.factory);
-        in = createChild("in", this, StringOverlay.factory);
-        scheme = createChild("scheme", this, StringOverlay.factory);
-        bearerFormat = createChild("bearerFormat", this, StringOverlay.factory);
-        implicitOAuthFlow = createChild("flow/implicit", this, OAuthFlowImpl.factory);
-        passwordOAuthFlow = createChild("flow/password", this, OAuthFlowImpl.factory);
-        clientCredentialsOAuthFlow = createChild("flow/clientCredentials", this, OAuthFlowImpl.factory);
-        authorizationCodeOAuthFlow = createChild("flow/authorizationCode", this, OAuthFlowImpl.factory);
-        oAuthFlowsExtensions = createChildMap("flow", this, ObjectOverlay.factory, "x-.+");
-        openIdConnectUrl = createChild("openIdConnectUrl", this, StringOverlay.factory);
-        extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
-    }
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public static OverlayFactory<SecurityScheme> factory = new OverlayFactory<SecurityScheme>() {
-
-        @Override
-        protected Class<? extends IJsonOverlay<? super SecurityScheme>> getOverlayClass() {
-            return SecuritySchemeImpl.class;
-        }
-
-        @Override
-        public JsonOverlay<SecurityScheme> _create(SecurityScheme securityScheme, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            IJsonOverlay<?> overlay;
-            overlay = new SecuritySchemeImpl(securityScheme, parent, refReg);
-            @SuppressWarnings("unchecked") JsonOverlay<SecurityScheme> castOverlay = (JsonOverlay<SecurityScheme>) overlay;
-            return castOverlay;
-        }
-
-        @Override
-        public JsonOverlay<SecurityScheme> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            IJsonOverlay<?> overlay;
-            overlay = new SecuritySchemeImpl(json, parent, refReg);
-            @SuppressWarnings("unchecked") JsonOverlay<SecurityScheme> castOverlay = (JsonOverlay<SecurityScheme>) overlay;
-            return castOverlay;
-        }
-    };
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private static Class<? extends SecurityScheme> getSubtypeOf(SecurityScheme securityScheme) {
-        return SecurityScheme.class;
-    }
-
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private static Class<? extends SecurityScheme> getSubtypeOf(JsonNode json) {
-        return SecurityScheme.class;
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public SecuritySchemeImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+		super(json, parent, refReg);
+	}
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public SecuritySchemeImpl(SecurityScheme securityScheme, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+		super(securityScheme, parent, refReg);
+	}
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<String> type;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<String> description;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<String> name;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<String> in;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<String> scheme;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<String> bearerFormat;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<OAuthFlow> implicitOAuthFlow;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<OAuthFlow> passwordOAuthFlow;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<OAuthFlow> clientCredentialsOAuthFlow;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<OAuthFlow> authorizationCodeOAuthFlow;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildMapOverlay<Object> oAuthFlowsExtensions;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<String> openIdConnectUrl;
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildMapOverlay<Object> extensions;
+
+	// Type
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getType() {
+		return type._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getType(boolean elaborate) {
+		return type._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setType(String type) {
+		this.type._set(type);
+	}
+
+	// Description
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getDescription() {
+		return description._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getDescription(boolean elaborate) {
+		return description._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setDescription(String description) {
+		this.description._set(description);
+	}
+
+	// Name
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getName() {
+		return name._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getName(boolean elaborate) {
+		return name._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setName(String name) {
+		this.name._set(name);
+	}
+
+	// In
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getIn() {
+		return in._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getIn(boolean elaborate) {
+		return in._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setIn(String in) {
+		this.in._set(in);
+	}
+
+	// Scheme
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getScheme() {
+		return scheme._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getScheme(boolean elaborate) {
+		return scheme._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setScheme(String scheme) {
+		this.scheme._set(scheme);
+	}
+
+	// BearerFormat
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getBearerFormat() {
+		return bearerFormat._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getBearerFormat(boolean elaborate) {
+		return bearerFormat._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setBearerFormat(String bearerFormat) {
+		this.bearerFormat._set(bearerFormat);
+	}
+
+	// ImplicitOAuthFlow
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public OAuthFlow getImplicitOAuthFlow() {
+		return implicitOAuthFlow._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public OAuthFlow getImplicitOAuthFlow(boolean elaborate) {
+		return implicitOAuthFlow._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setImplicitOAuthFlow(OAuthFlow implicitOAuthFlow) {
+		this.implicitOAuthFlow._set(implicitOAuthFlow);
+	}
+
+	// PasswordOAuthFlow
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public OAuthFlow getPasswordOAuthFlow() {
+		return passwordOAuthFlow._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public OAuthFlow getPasswordOAuthFlow(boolean elaborate) {
+		return passwordOAuthFlow._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setPasswordOAuthFlow(OAuthFlow passwordOAuthFlow) {
+		this.passwordOAuthFlow._set(passwordOAuthFlow);
+	}
+
+	// ClientCredentialsOAuthFlow
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public OAuthFlow getClientCredentialsOAuthFlow() {
+		return clientCredentialsOAuthFlow._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public OAuthFlow getClientCredentialsOAuthFlow(boolean elaborate) {
+		return clientCredentialsOAuthFlow._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setClientCredentialsOAuthFlow(OAuthFlow clientCredentialsOAuthFlow) {
+		this.clientCredentialsOAuthFlow._set(clientCredentialsOAuthFlow);
+	}
+
+	// AuthorizationCodeOAuthFlow
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public OAuthFlow getAuthorizationCodeOAuthFlow() {
+		return authorizationCodeOAuthFlow._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public OAuthFlow getAuthorizationCodeOAuthFlow(boolean elaborate) {
+		return authorizationCodeOAuthFlow._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setAuthorizationCodeOAuthFlow(OAuthFlow authorizationCodeOAuthFlow) {
+		this.authorizationCodeOAuthFlow._set(authorizationCodeOAuthFlow);
+	}
+
+	// OAuthFlowsExtension
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Object> getOAuthFlowsExtensions() {
+		return oAuthFlowsExtensions._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Object> getOAuthFlowsExtensions(boolean elaborate) {
+		return oAuthFlowsExtensions._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasOAuthFlowsExtension(String name) {
+		return oAuthFlowsExtensions.containsKey(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Object getOAuthFlowsExtension(String name) {
+		return oAuthFlowsExtensions._get(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setOAuthFlowsExtensions(Map<String, Object> oAuthFlowsExtensions) {
+		this.oAuthFlowsExtensions._set(oAuthFlowsExtensions);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setOAuthFlowsExtension(String name, Object oAuthFlowsExtension) {
+		oAuthFlowsExtensions._set(name, oAuthFlowsExtension);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeOAuthFlowsExtension(String name) {
+		oAuthFlowsExtensions._remove(name);
+	}
+
+	// OpenIdConnectUrl
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getOpenIdConnectUrl() {
+		return openIdConnectUrl._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getOpenIdConnectUrl(boolean elaborate) {
+		return openIdConnectUrl._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setOpenIdConnectUrl(String openIdConnectUrl) {
+		this.openIdConnectUrl._set(openIdConnectUrl);
+	}
+
+	// Extension
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Object> getExtensions() {
+		return extensions._get();
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Object> getExtensions(boolean elaborate) {
+		return extensions._get(elaborate);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasExtension(String name) {
+		return extensions.containsKey(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Object getExtension(String name) {
+		return extensions._get(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setExtensions(Map<String, Object> extensions) {
+		this.extensions._set(extensions);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setExtension(String name, Object extension) {
+		extensions._set(name, extension);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeExtension(String name) {
+		extensions._remove(name);
+	}
+
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	protected void elaborateChildren() {
+		super.elaborateChildren();
+		type = createChild("type", this, StringOverlay.factory);
+		description = createChild("description", this, StringOverlay.factory);
+		name = createChild("name", this, StringOverlay.factory);
+		in = createChild("in", this, StringOverlay.factory);
+		scheme = createChild("scheme", this, StringOverlay.factory);
+		bearerFormat = createChild("bearerFormat", this, StringOverlay.factory);
+		implicitOAuthFlow = createChild("flow/implicit", this, OAuthFlowImpl.factory);
+		passwordOAuthFlow = createChild("flow/password", this, OAuthFlowImpl.factory);
+		clientCredentialsOAuthFlow = createChild("flow/clientCredentials", this, OAuthFlowImpl.factory);
+		authorizationCodeOAuthFlow = createChild("flow/authorizationCode", this, OAuthFlowImpl.factory);
+		oAuthFlowsExtensions = createChildMap("flow", this, ObjectOverlay.factory, "x-.+");
+		openIdConnectUrl = createChild("openIdConnectUrl", this, StringOverlay.factory);
+		extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
+	}
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public static OverlayFactory<SecurityScheme> factory = new OverlayFactory<SecurityScheme>() {
+
+		@Override
+		protected Class<? extends AbstractJsonOverlay<? super SecurityScheme>> getOverlayClass() {
+			return SecuritySchemeImpl.class;
+		}
+
+		@Override
+		public JsonOverlay<SecurityScheme> _create(SecurityScheme securityScheme, JsonOverlay<?> parent,
+				ReferenceRegistry refReg) {
+			AbstractJsonOverlay<?> overlay;
+			overlay = new SecuritySchemeImpl(securityScheme, parent, refReg);
+			@SuppressWarnings("unchecked")
+			JsonOverlay<SecurityScheme> castOverlay = (JsonOverlay<SecurityScheme>) overlay;
+			return castOverlay;
+		}
+
+		@Override
+		public JsonOverlay<SecurityScheme> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+			AbstractJsonOverlay<?> overlay;
+			overlay = new SecuritySchemeImpl(json, parent, refReg);
+			@SuppressWarnings("unchecked")
+			JsonOverlay<SecurityScheme> castOverlay = (JsonOverlay<SecurityScheme>) overlay;
+			return castOverlay;
+		}
+	};
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private static Class<? extends SecurityScheme> getSubtypeOf(SecurityScheme securityScheme) {
+		return SecurityScheme.class;
+	}
+
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private static Class<? extends SecurityScheme> getSubtypeOf(JsonNode json) {
+		return SecurityScheme.class;
+	}
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ServerImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ServerImpl.java
@@ -1,261 +1,261 @@
 package com.reprezen.kaizen.oasparser.ovl3;
 
-import com.reprezen.jsonoverlay.StringOverlay;
-import com.reprezen.jsonoverlay.ReferenceRegistry;
-import com.reprezen.kaizen.oasparser.ovl3.ServerVariableImpl;
+import java.util.Map;
+
+import javax.annotation.Generated;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.reprezen.jsonoverlay.AbstractJsonOverlay;
 import com.reprezen.jsonoverlay.ChildMapOverlay;
-import com.reprezen.kaizen.oasparser.model3.ServerVariable;
+import com.reprezen.jsonoverlay.ChildOverlay;
+import com.reprezen.jsonoverlay.JsonOverlay;
 import com.reprezen.jsonoverlay.ObjectOverlay;
-import com.reprezen.jsonoverlay.MapOverlay;
-import java.util.stream.Collectors;
-import com.reprezen.kaizen.oasparser.model3.*;
 import com.reprezen.jsonoverlay.OverlayFactory;
 import com.reprezen.jsonoverlay.PropertiesOverlay;
-import javax.annotation.Generated;
-import com.fasterxml.jackson.core.JsonPointer;
-import com.reprezen.jsonoverlay.IJsonOverlay;
-import com.reprezen.jsonoverlay.JsonOverlay;
-import java.util.Map;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.reprezen.jsonoverlay.ChildOverlay;
+import com.reprezen.jsonoverlay.ReferenceRegistry;
+import com.reprezen.jsonoverlay.StringOverlay;
+import com.reprezen.kaizen.oasparser.model3.Server;
+import com.reprezen.kaizen.oasparser.model3.ServerVariable;
 
 public class ServerImpl extends PropertiesOverlay<Server> implements Server {
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public ServerImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        super(json, parent, refReg);
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public ServerImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+		super(json, parent, refReg);
+	}
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public ServerImpl(Server server, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        super(server, parent, refReg);
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public ServerImpl(Server server, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+		super(server, parent, refReg);
+	}
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<String> url;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<String> url;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<String> description;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<String> description;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildMapOverlay<ServerVariable> serverVariables;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildMapOverlay<ServerVariable> serverVariables;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildMapOverlay<Object> variablesExtensions;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildMapOverlay<Object> variablesExtensions;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildMapOverlay<Object> extensions;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildMapOverlay<Object> extensions;
 
-    // Url
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getUrl() {
-        return url.get();
-    }
+	// Url
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getUrl() {
+		return url._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getUrl(boolean elaborate) {
-        return url.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getUrl(boolean elaborate) {
+		return url._get(elaborate);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setUrl(String url) {
-        this.url.set(url);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setUrl(String url) {
+		this.url._set(url);
+	}
 
-    // Description
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getDescription() {
-        return description.get();
-    }
+	// Description
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getDescription() {
+		return description._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getDescription(boolean elaborate) {
-        return description.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getDescription(boolean elaborate) {
+		return description._get(elaborate);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setDescription(String description) {
-        this.description.set(description);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setDescription(String description) {
+		this.description._set(description);
+	}
 
-    // ServerVariable
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, ServerVariable> getServerVariables() {
-        return serverVariables.get();
-    }
+	// ServerVariable
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, ServerVariable> getServerVariables() {
+		return serverVariables._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, ServerVariable> getServerVariables(boolean elaborate) {
-        return serverVariables.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, ServerVariable> getServerVariables(boolean elaborate) {
+		return serverVariables._get(elaborate);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasServerVariable(String name) {
-        return serverVariables.containsKey(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasServerVariable(String name) {
+		return serverVariables.containsKey(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public ServerVariable getServerVariable(String name) {
-        return serverVariables.get(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public ServerVariable getServerVariable(String name) {
+		return serverVariables._get(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setServerVariables(Map<String, ServerVariable> serverVariables) {
-        this.serverVariables.set(serverVariables);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setServerVariables(Map<String, ServerVariable> serverVariables) {
+		this.serverVariables._set(serverVariables);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setServerVariable(String name, ServerVariable serverVariable) {
-        serverVariables.set(name, serverVariable);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setServerVariable(String name, ServerVariable serverVariable) {
+		serverVariables._set(name, serverVariable);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeServerVariable(String name) {
-        serverVariables.remove(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeServerVariable(String name) {
+		serverVariables._remove(name);
+	}
 
-    // VariablesExtension
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Object> getVariablesExtensions() {
-        return variablesExtensions.get();
-    }
+	// VariablesExtension
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Object> getVariablesExtensions() {
+		return variablesExtensions._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Object> getVariablesExtensions(boolean elaborate) {
-        return variablesExtensions.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Object> getVariablesExtensions(boolean elaborate) {
+		return variablesExtensions._get(elaborate);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasVariablesExtension(String name) {
-        return variablesExtensions.containsKey(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasVariablesExtension(String name) {
+		return variablesExtensions.containsKey(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Object getVariablesExtension(String name) {
-        return variablesExtensions.get(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Object getVariablesExtension(String name) {
+		return variablesExtensions._get(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setVariablesExtensions(Map<String, Object> variablesExtensions) {
-        this.variablesExtensions.set(variablesExtensions);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setVariablesExtensions(Map<String, Object> variablesExtensions) {
+		this.variablesExtensions._set(variablesExtensions);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setVariablesExtension(String name, Object variablesExtension) {
-        variablesExtensions.set(name, variablesExtension);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setVariablesExtension(String name, Object variablesExtension) {
+		variablesExtensions._set(name, variablesExtension);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeVariablesExtension(String name) {
-        variablesExtensions.remove(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeVariablesExtension(String name) {
+		variablesExtensions._remove(name);
+	}
 
-    // Extension
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Object> getExtensions() {
-        return extensions.get();
-    }
+	// Extension
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Object> getExtensions() {
+		return extensions._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Object> getExtensions(boolean elaborate) {
-        return extensions.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Object> getExtensions(boolean elaborate) {
+		return extensions._get(elaborate);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasExtension(String name) {
-        return extensions.containsKey(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasExtension(String name) {
+		return extensions.containsKey(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Object getExtension(String name) {
-        return extensions.get(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Object getExtension(String name) {
+		return extensions._get(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setExtensions(Map<String, Object> extensions) {
-        this.extensions.set(extensions);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setExtensions(Map<String, Object> extensions) {
+		this.extensions._set(extensions);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setExtension(String name, Object extension) {
-        extensions.set(name, extension);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setExtension(String name, Object extension) {
+		extensions._set(name, extension);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeExtension(String name) {
-        extensions.remove(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeExtension(String name) {
+		extensions._remove(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    protected void elaborateChildren() {
-        super.elaborateChildren();
-        url = createChild("url", this, StringOverlay.factory);
-        description = createChild("description", this, StringOverlay.factory);
-        serverVariables = createChildMap("variables", this, ServerVariableImpl.factory, "(?!x-)[a-zA-Z0-9\\._-]+");
-        variablesExtensions = createChildMap("variables", this, ObjectOverlay.factory, "x-.+");
-        extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	protected void elaborateChildren() {
+		super.elaborateChildren();
+		url = createChild("url", this, StringOverlay.factory);
+		description = createChild("description", this, StringOverlay.factory);
+		serverVariables = createChildMap("variables", this, ServerVariableImpl.factory, "(?!x-)[a-zA-Z0-9\\._-]+");
+		variablesExtensions = createChildMap("variables", this, ObjectOverlay.factory, "x-.+");
+		extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
+	}
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public static OverlayFactory<Server> factory = new OverlayFactory<Server>() {
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public static OverlayFactory<Server> factory = new OverlayFactory<Server>() {
 
-        @Override
-        protected Class<? extends IJsonOverlay<? super Server>> getOverlayClass() {
-            return ServerImpl.class;
-        }
+		@Override
+		protected Class<? extends AbstractJsonOverlay<? super Server>> getOverlayClass() {
+			return ServerImpl.class;
+		}
 
-        @Override
-        public JsonOverlay<Server> _create(Server server, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            IJsonOverlay<?> overlay;
-            overlay = new ServerImpl(server, parent, refReg);
-            @SuppressWarnings("unchecked") JsonOverlay<Server> castOverlay = (JsonOverlay<Server>) overlay;
-            return castOverlay;
-        }
+		@Override
+		public JsonOverlay<Server> _create(Server server, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+			AbstractJsonOverlay<?> overlay;
+			overlay = new ServerImpl(server, parent, refReg);
+			@SuppressWarnings("unchecked")
+			JsonOverlay<Server> castOverlay = (JsonOverlay<Server>) overlay;
+			return castOverlay;
+		}
 
-        @Override
-        public JsonOverlay<Server> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            IJsonOverlay<?> overlay;
-            overlay = new ServerImpl(json, parent, refReg);
-            @SuppressWarnings("unchecked") JsonOverlay<Server> castOverlay = (JsonOverlay<Server>) overlay;
-            return castOverlay;
-        }
-    };
+		@Override
+		public JsonOverlay<Server> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+			AbstractJsonOverlay<?> overlay;
+			overlay = new ServerImpl(json, parent, refReg);
+			@SuppressWarnings("unchecked")
+			JsonOverlay<Server> castOverlay = (JsonOverlay<Server>) overlay;
+			return castOverlay;
+		}
+	};
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private static Class<? extends Server> getSubtypeOf(Server server) {
-        return Server.class;
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private static Class<? extends Server> getSubtypeOf(Server server) {
+		return Server.class;
+	}
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private static Class<? extends Server> getSubtypeOf(JsonNode json) {
-        return Server.class;
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private static Class<? extends Server> getSubtypeOf(JsonNode json) {
+		return Server.class;
+	}
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ServerVariableImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ServerVariableImpl.java
@@ -1,228 +1,229 @@
 package com.reprezen.kaizen.oasparser.ovl3;
 
-import com.reprezen.jsonoverlay.StringOverlay;
-import com.reprezen.jsonoverlay.ChildListOverlay;
-import com.reprezen.jsonoverlay.ReferenceRegistry;
-import com.reprezen.jsonoverlay.PrimitiveOverlay;
-import com.reprezen.jsonoverlay.ChildMapOverlay;
 import java.util.Collection;
-import com.reprezen.jsonoverlay.ObjectOverlay;
-import com.reprezen.jsonoverlay.MapOverlay;
-import java.util.stream.Collectors;
-import com.reprezen.kaizen.oasparser.model3.*;
-import com.reprezen.jsonoverlay.OverlayFactory;
-import com.reprezen.jsonoverlay.PropertiesOverlay;
-import javax.annotation.Generated;
-import com.fasterxml.jackson.core.JsonPointer;
-import com.reprezen.jsonoverlay.IJsonOverlay;
-import com.reprezen.jsonoverlay.JsonOverlay;
 import java.util.Map;
-import com.reprezen.jsonoverlay.ListOverlay;
+
+import javax.annotation.Generated;
+
 import com.fasterxml.jackson.databind.JsonNode;
+import com.reprezen.jsonoverlay.AbstractJsonOverlay;
+import com.reprezen.jsonoverlay.ChildListOverlay;
+import com.reprezen.jsonoverlay.ChildMapOverlay;
 import com.reprezen.jsonoverlay.ChildOverlay;
+import com.reprezen.jsonoverlay.JsonOverlay;
+import com.reprezen.jsonoverlay.ObjectOverlay;
+import com.reprezen.jsonoverlay.OverlayFactory;
+import com.reprezen.jsonoverlay.PrimitiveOverlay;
+import com.reprezen.jsonoverlay.PropertiesOverlay;
+import com.reprezen.jsonoverlay.ReferenceRegistry;
+import com.reprezen.jsonoverlay.StringOverlay;
+import com.reprezen.kaizen.oasparser.model3.ServerVariable;
 
 public class ServerVariableImpl extends PropertiesOverlay<ServerVariable> implements ServerVariable {
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public ServerVariableImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        super(json, parent, refReg);
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public ServerVariableImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+		super(json, parent, refReg);
+	}
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public ServerVariableImpl(ServerVariable serverVariable, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        super(serverVariable, parent, refReg);
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public ServerVariableImpl(ServerVariable serverVariable, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+		super(serverVariable, parent, refReg);
+	}
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildListOverlay<Object> enumValues;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildListOverlay<Object> enumValues;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<Object> defaultValue;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<Object> defaultValue;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<String> description;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<String> description;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildMapOverlay<Object> extensions;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildMapOverlay<Object> extensions;
 
-    // EnumValue
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Collection<Object> getEnumValues() {
-        return enumValues.get();
-    }
+	// EnumValue
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Collection<Object> getEnumValues() {
+		return enumValues._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Collection<Object> getEnumValues(boolean elaborate) {
-        return enumValues.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Collection<Object> getEnumValues(boolean elaborate) {
+		return enumValues._get(elaborate);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasEnumValues() {
-        return enumValues.isPresent();
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasEnumValues() {
+		return enumValues._isPresent();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Object getEnumValue(int index) {
-        return enumValues.get(index);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Object getEnumValue(int index) {
+		return enumValues._get(index);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setEnumValues(Collection<Object> enumValues) {
-        this.enumValues.set(enumValues);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setEnumValues(Collection<Object> enumValues) {
+		this.enumValues._set(enumValues);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setEnumValue(int index, Object enumValue) {
-        enumValues.set(index, enumValue);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setEnumValue(int index, Object enumValue) {
+		enumValues._set(index, enumValue);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void addEnumValue(Object enumValue) {
-        enumValues.add(enumValue);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void addEnumValue(Object enumValue) {
+		enumValues._add(enumValue);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void insertEnumValue(int index, Object enumValue) {
-        enumValues.insert(index, enumValue);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void insertEnumValue(int index, Object enumValue) {
+		enumValues._insert(index, enumValue);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeEnumValue(int index) {
-        enumValues.remove(index);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeEnumValue(int index) {
+		enumValues._remove(index);
+	}
 
-    // Default
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Object getDefault() {
-        return defaultValue.get();
-    }
+	// Default
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Object getDefault() {
+		return defaultValue._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Object getDefault(boolean elaborate) {
-        return defaultValue.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Object getDefault(boolean elaborate) {
+		return defaultValue._get(elaborate);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setDefault(Object defaultValue) {
-        this.defaultValue.set(defaultValue);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setDefault(Object defaultValue) {
+		this.defaultValue._set(defaultValue);
+	}
 
-    // Description
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getDescription() {
-        return description.get();
-    }
+	// Description
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getDescription() {
+		return description._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getDescription(boolean elaborate) {
-        return description.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getDescription(boolean elaborate) {
+		return description._get(elaborate);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setDescription(String description) {
-        this.description.set(description);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setDescription(String description) {
+		this.description._set(description);
+	}
 
-    // Extension
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Object> getExtensions() {
-        return extensions.get();
-    }
+	// Extension
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Object> getExtensions() {
+		return extensions._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Object> getExtensions(boolean elaborate) {
-        return extensions.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Object> getExtensions(boolean elaborate) {
+		return extensions._get(elaborate);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasExtension(String name) {
-        return extensions.containsKey(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasExtension(String name) {
+		return extensions.containsKey(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Object getExtension(String name) {
-        return extensions.get(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Object getExtension(String name) {
+		return extensions._get(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setExtensions(Map<String, Object> extensions) {
-        this.extensions.set(extensions);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setExtensions(Map<String, Object> extensions) {
+		this.extensions._set(extensions);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setExtension(String name, Object extension) {
-        extensions.set(name, extension);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setExtension(String name, Object extension) {
+		extensions._set(name, extension);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeExtension(String name) {
-        extensions.remove(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeExtension(String name) {
+		extensions._remove(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    protected void elaborateChildren() {
-        super.elaborateChildren();
-        enumValues = createChildList("enum", this, PrimitiveOverlay.factory);
-        defaultValue = createChild("default", this, PrimitiveOverlay.factory);
-        description = createChild("description", this, StringOverlay.factory);
-        extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	protected void elaborateChildren() {
+		super.elaborateChildren();
+		enumValues = createChildList("enum", this, PrimitiveOverlay.factory);
+		defaultValue = createChild("default", this, PrimitiveOverlay.factory);
+		description = createChild("description", this, StringOverlay.factory);
+		extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
+	}
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public static OverlayFactory<ServerVariable> factory = new OverlayFactory<ServerVariable>() {
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public static OverlayFactory<ServerVariable> factory = new OverlayFactory<ServerVariable>() {
 
-        @Override
-        protected Class<? extends IJsonOverlay<? super ServerVariable>> getOverlayClass() {
-            return ServerVariableImpl.class;
-        }
+		@Override
+		protected Class<? extends AbstractJsonOverlay<? super ServerVariable>> getOverlayClass() {
+			return ServerVariableImpl.class;
+		}
 
-        @Override
-        public JsonOverlay<ServerVariable> _create(ServerVariable serverVariable, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            IJsonOverlay<?> overlay;
-            overlay = new ServerVariableImpl(serverVariable, parent, refReg);
-            @SuppressWarnings("unchecked") JsonOverlay<ServerVariable> castOverlay = (JsonOverlay<ServerVariable>) overlay;
-            return castOverlay;
-        }
+		@Override
+		public JsonOverlay<ServerVariable> _create(ServerVariable serverVariable, JsonOverlay<?> parent,
+				ReferenceRegistry refReg) {
+			AbstractJsonOverlay<?> overlay;
+			overlay = new ServerVariableImpl(serverVariable, parent, refReg);
+			@SuppressWarnings("unchecked")
+			JsonOverlay<ServerVariable> castOverlay = (JsonOverlay<ServerVariable>) overlay;
+			return castOverlay;
+		}
 
-        @Override
-        public JsonOverlay<ServerVariable> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            IJsonOverlay<?> overlay;
-            overlay = new ServerVariableImpl(json, parent, refReg);
-            @SuppressWarnings("unchecked") JsonOverlay<ServerVariable> castOverlay = (JsonOverlay<ServerVariable>) overlay;
-            return castOverlay;
-        }
-    };
+		@Override
+		public JsonOverlay<ServerVariable> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+			AbstractJsonOverlay<?> overlay;
+			overlay = new ServerVariableImpl(json, parent, refReg);
+			@SuppressWarnings("unchecked")
+			JsonOverlay<ServerVariable> castOverlay = (JsonOverlay<ServerVariable>) overlay;
+			return castOverlay;
+		}
+	};
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private static Class<? extends ServerVariable> getSubtypeOf(ServerVariable serverVariable) {
-        return ServerVariable.class;
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private static Class<? extends ServerVariable> getSubtypeOf(ServerVariable serverVariable) {
+		return ServerVariable.class;
+	}
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private static Class<? extends ServerVariable> getSubtypeOf(JsonNode json) {
-        return ServerVariable.class;
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private static Class<? extends ServerVariable> getSubtypeOf(JsonNode json) {
+		return ServerVariable.class;
+	}
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/TagImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/TagImpl.java
@@ -1,190 +1,190 @@
 package com.reprezen.kaizen.oasparser.ovl3;
 
-import com.reprezen.jsonoverlay.StringOverlay;
-import com.reprezen.jsonoverlay.ReferenceRegistry;
-import com.reprezen.jsonoverlay.ChildMapOverlay;
-import com.reprezen.jsonoverlay.ObjectOverlay;
-import com.reprezen.jsonoverlay.MapOverlay;
-import java.util.stream.Collectors;
-import com.reprezen.kaizen.oasparser.model3.*;
-import com.reprezen.jsonoverlay.OverlayFactory;
-import com.reprezen.kaizen.oasparser.ovl3.ExternalDocsImpl;
-import com.reprezen.jsonoverlay.PropertiesOverlay;
-import javax.annotation.Generated;
-import com.fasterxml.jackson.core.JsonPointer;
-import com.reprezen.jsonoverlay.IJsonOverlay;
-import com.reprezen.jsonoverlay.JsonOverlay;
 import java.util.Map;
+
+import javax.annotation.Generated;
+
 import com.fasterxml.jackson.databind.JsonNode;
+import com.reprezen.jsonoverlay.AbstractJsonOverlay;
+import com.reprezen.jsonoverlay.ChildMapOverlay;
 import com.reprezen.jsonoverlay.ChildOverlay;
+import com.reprezen.jsonoverlay.JsonOverlay;
+import com.reprezen.jsonoverlay.ObjectOverlay;
+import com.reprezen.jsonoverlay.OverlayFactory;
+import com.reprezen.jsonoverlay.PropertiesOverlay;
+import com.reprezen.jsonoverlay.ReferenceRegistry;
+import com.reprezen.jsonoverlay.StringOverlay;
 import com.reprezen.kaizen.oasparser.model3.ExternalDocs;
+import com.reprezen.kaizen.oasparser.model3.Tag;
 
 public class TagImpl extends PropertiesOverlay<Tag> implements Tag {
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public TagImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        super(json, parent, refReg);
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public TagImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+		super(json, parent, refReg);
+	}
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public TagImpl(Tag tag, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        super(tag, parent, refReg);
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public TagImpl(Tag tag, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+		super(tag, parent, refReg);
+	}
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<String> name;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<String> name;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<String> description;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<String> description;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<ExternalDocs> externalDocs;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<ExternalDocs> externalDocs;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildMapOverlay<Object> extensions;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildMapOverlay<Object> extensions;
 
-    // Name
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getName() {
-        return name.get();
-    }
+	// Name
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getName() {
+		return name._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getName(boolean elaborate) {
-        return name.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getName(boolean elaborate) {
+		return name._get(elaborate);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setName(String name) {
-        this.name.set(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setName(String name) {
+		this.name._set(name);
+	}
 
-    // Description
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getDescription() {
-        return description.get();
-    }
+	// Description
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getDescription() {
+		return description._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getDescription(boolean elaborate) {
-        return description.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getDescription(boolean elaborate) {
+		return description._get(elaborate);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setDescription(String description) {
-        this.description.set(description);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setDescription(String description) {
+		this.description._set(description);
+	}
 
-    // ExternalDocs
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public ExternalDocs getExternalDocs() {
-        return externalDocs.get();
-    }
+	// ExternalDocs
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public ExternalDocs getExternalDocs() {
+		return externalDocs._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public ExternalDocs getExternalDocs(boolean elaborate) {
-        return externalDocs.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public ExternalDocs getExternalDocs(boolean elaborate) {
+		return externalDocs._get(elaborate);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setExternalDocs(ExternalDocs externalDocs) {
-        this.externalDocs.set(externalDocs);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setExternalDocs(ExternalDocs externalDocs) {
+		this.externalDocs._set(externalDocs);
+	}
 
-    // Extension
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Object> getExtensions() {
-        return extensions.get();
-    }
+	// Extension
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Object> getExtensions() {
+		return extensions._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Object> getExtensions(boolean elaborate) {
-        return extensions.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Object> getExtensions(boolean elaborate) {
+		return extensions._get(elaborate);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasExtension(String name) {
-        return extensions.containsKey(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasExtension(String name) {
+		return extensions.containsKey(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Object getExtension(String name) {
-        return extensions.get(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Object getExtension(String name) {
+		return extensions._get(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setExtensions(Map<String, Object> extensions) {
-        this.extensions.set(extensions);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setExtensions(Map<String, Object> extensions) {
+		this.extensions._set(extensions);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setExtension(String name, Object extension) {
-        extensions.set(name, extension);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setExtension(String name, Object extension) {
+		extensions._set(name, extension);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeExtension(String name) {
-        extensions.remove(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeExtension(String name) {
+		extensions._remove(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    protected void elaborateChildren() {
-        super.elaborateChildren();
-        name = createChild("name", this, StringOverlay.factory);
-        description = createChild("description", this, StringOverlay.factory);
-        externalDocs = createChild("externalDocs", this, ExternalDocsImpl.factory);
-        extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	protected void elaborateChildren() {
+		super.elaborateChildren();
+		name = createChild("name", this, StringOverlay.factory);
+		description = createChild("description", this, StringOverlay.factory);
+		externalDocs = createChild("externalDocs", this, ExternalDocsImpl.factory);
+		extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
+	}
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public static OverlayFactory<Tag> factory = new OverlayFactory<Tag>() {
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public static OverlayFactory<Tag> factory = new OverlayFactory<Tag>() {
 
-        @Override
-        protected Class<? extends IJsonOverlay<? super Tag>> getOverlayClass() {
-            return TagImpl.class;
-        }
+		@Override
+		protected Class<? extends AbstractJsonOverlay<? super Tag>> getOverlayClass() {
+			return TagImpl.class;
+		}
 
-        @Override
-        public JsonOverlay<Tag> _create(Tag tag, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            IJsonOverlay<?> overlay;
-            overlay = new TagImpl(tag, parent, refReg);
-            @SuppressWarnings("unchecked") JsonOverlay<Tag> castOverlay = (JsonOverlay<Tag>) overlay;
-            return castOverlay;
-        }
+		@Override
+		public JsonOverlay<Tag> _create(Tag tag, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+			AbstractJsonOverlay<?> overlay;
+			overlay = new TagImpl(tag, parent, refReg);
+			@SuppressWarnings("unchecked")
+			JsonOverlay<Tag> castOverlay = (JsonOverlay<Tag>) overlay;
+			return castOverlay;
+		}
 
-        @Override
-        public JsonOverlay<Tag> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            IJsonOverlay<?> overlay;
-            overlay = new TagImpl(json, parent, refReg);
-            @SuppressWarnings("unchecked") JsonOverlay<Tag> castOverlay = (JsonOverlay<Tag>) overlay;
-            return castOverlay;
-        }
-    };
+		@Override
+		public JsonOverlay<Tag> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+			AbstractJsonOverlay<?> overlay;
+			overlay = new TagImpl(json, parent, refReg);
+			@SuppressWarnings("unchecked")
+			JsonOverlay<Tag> castOverlay = (JsonOverlay<Tag>) overlay;
+			return castOverlay;
+		}
+	};
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private static Class<? extends Tag> getSubtypeOf(Tag tag) {
-        return Tag.class;
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private static Class<? extends Tag> getSubtypeOf(Tag tag) {
+		return Tag.class;
+	}
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private static Class<? extends Tag> getSubtypeOf(JsonNode json) {
-        return Tag.class;
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private static Class<? extends Tag> getSubtypeOf(JsonNode json) {
+		return Tag.class;
+	}
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/XmlImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/XmlImpl.java
@@ -1,247 +1,248 @@
 package com.reprezen.kaizen.oasparser.ovl3;
 
-import com.reprezen.jsonoverlay.StringOverlay;
-import com.reprezen.jsonoverlay.ReferenceRegistry;
-import com.reprezen.jsonoverlay.ChildMapOverlay;
-import com.reprezen.jsonoverlay.ObjectOverlay;
+import java.util.Map;
+
+import javax.annotation.Generated;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.reprezen.jsonoverlay.AbstractJsonOverlay;
 import com.reprezen.jsonoverlay.BooleanOverlay;
-import com.reprezen.jsonoverlay.MapOverlay;
-import java.util.stream.Collectors;
-import com.reprezen.kaizen.oasparser.model3.*;
+import com.reprezen.jsonoverlay.ChildMapOverlay;
+import com.reprezen.jsonoverlay.ChildOverlay;
+import com.reprezen.jsonoverlay.JsonOverlay;
+import com.reprezen.jsonoverlay.ObjectOverlay;
 import com.reprezen.jsonoverlay.OverlayFactory;
 import com.reprezen.jsonoverlay.PropertiesOverlay;
-import javax.annotation.Generated;
-import com.fasterxml.jackson.core.JsonPointer;
-import com.reprezen.jsonoverlay.IJsonOverlay;
-import com.reprezen.jsonoverlay.JsonOverlay;
-import java.util.Map;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.reprezen.jsonoverlay.ChildOverlay;
+import com.reprezen.jsonoverlay.ReferenceRegistry;
+import com.reprezen.jsonoverlay.StringOverlay;
+import com.reprezen.kaizen.oasparser.model3.Xml;
 
 public class XmlImpl extends PropertiesOverlay<Xml> implements Xml {
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public XmlImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        super(json, parent, refReg);
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public XmlImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+		super(json, parent, refReg);
+	}
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public XmlImpl(Xml xml, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-        super(xml, parent, refReg);
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public XmlImpl(Xml xml, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+		super(xml, parent, refReg);
+	}
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<String> name;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<String> name;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<String> namespace;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<String> namespace;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<String> prefix;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<String> prefix;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<Boolean> attribute;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<Boolean> attribute;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildOverlay<Boolean> wrapped;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildOverlay<Boolean> wrapped;
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private ChildMapOverlay<Object> extensions;
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private ChildMapOverlay<Object> extensions;
 
-    // Name
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getName() {
-        return name.get();
-    }
+	// Name
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getName() {
+		return name._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getName(boolean elaborate) {
-        return name.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getName(boolean elaborate) {
+		return name._get(elaborate);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setName(String name) {
-        this.name.set(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setName(String name) {
+		this.name._set(name);
+	}
 
-    // Namespace
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getNamespace() {
-        return namespace.get();
-    }
+	// Namespace
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getNamespace() {
+		return namespace._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getNamespace(boolean elaborate) {
-        return namespace.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getNamespace(boolean elaborate) {
+		return namespace._get(elaborate);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setNamespace(String namespace) {
-        this.namespace.set(namespace);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setNamespace(String namespace) {
+		this.namespace._set(namespace);
+	}
 
-    // Prefix
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getPrefix() {
-        return prefix.get();
-    }
+	// Prefix
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getPrefix() {
+		return prefix._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public String getPrefix(boolean elaborate) {
-        return prefix.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public String getPrefix(boolean elaborate) {
+		return prefix._get(elaborate);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setPrefix(String prefix) {
-        this.prefix.set(prefix);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setPrefix(String prefix) {
+		this.prefix._set(prefix);
+	}
 
-    // Attribute
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Boolean getAttribute() {
-        return attribute.get();
-    }
+	// Attribute
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Boolean getAttribute() {
+		return attribute._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Boolean getAttribute(boolean elaborate) {
-        return attribute.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Boolean getAttribute(boolean elaborate) {
+		return attribute._get(elaborate);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean isAttribute() {
-        return attribute.get() != null ? attribute.get() : false;
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean isAttribute() {
+		return attribute._get() != null ? attribute._get() : false;
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setAttribute(Boolean attribute) {
-        this.attribute.set(attribute);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setAttribute(Boolean attribute) {
+		this.attribute._set(attribute);
+	}
 
-    // Wrapped
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Boolean getWrapped() {
-        return wrapped.get();
-    }
+	// Wrapped
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Boolean getWrapped() {
+		return wrapped._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Boolean getWrapped(boolean elaborate) {
-        return wrapped.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Boolean getWrapped(boolean elaborate) {
+		return wrapped._get(elaborate);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean isWrapped() {
-        return wrapped.get() != null ? wrapped.get() : false;
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean isWrapped() {
+		return wrapped._get() != null ? wrapped._get() : false;
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setWrapped(Boolean wrapped) {
-        this.wrapped.set(wrapped);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setWrapped(Boolean wrapped) {
+		this.wrapped._set(wrapped);
+	}
 
-    // Extension
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Object> getExtensions() {
-        return extensions.get();
-    }
+	// Extension
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Object> getExtensions() {
+		return extensions._get();
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Map<String, Object> getExtensions(boolean elaborate) {
-        return extensions.get(elaborate);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Map<String, Object> getExtensions(boolean elaborate) {
+		return extensions._get(elaborate);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public boolean hasExtension(String name) {
-        return extensions.containsKey(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public boolean hasExtension(String name) {
+		return extensions.containsKey(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public Object getExtension(String name) {
-        return extensions.get(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public Object getExtension(String name) {
+		return extensions._get(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setExtensions(Map<String, Object> extensions) {
-        this.extensions.set(extensions);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setExtensions(Map<String, Object> extensions) {
+		this.extensions._set(extensions);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void setExtension(String name, Object extension) {
-        extensions.set(name, extension);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void setExtension(String name, Object extension) {
+		extensions._set(name, extension);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public void removeExtension(String name) {
-        extensions.remove(name);
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public void removeExtension(String name) {
+		extensions._remove(name);
+	}
 
-    @Override
-    @Generated("com.reprezen.gen.CodeGenerator")
-    protected void elaborateChildren() {
-        super.elaborateChildren();
-        name = createChild("name", this, StringOverlay.factory);
-        namespace = createChild("namespace", this, StringOverlay.factory);
-        prefix = createChild("prefix", this, StringOverlay.factory);
-        attribute = createChild("attribute", this, BooleanOverlay.factory);
-        wrapped = createChild("wrapped", this, BooleanOverlay.factory);
-        extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
-    }
+	@Override
+	@Generated("com.reprezen.gen.CodeGenerator")
+	protected void elaborateChildren() {
+		super.elaborateChildren();
+		name = createChild("name", this, StringOverlay.factory);
+		namespace = createChild("namespace", this, StringOverlay.factory);
+		prefix = createChild("prefix", this, StringOverlay.factory);
+		attribute = createChild("attribute", this, BooleanOverlay.factory);
+		wrapped = createChild("wrapped", this, BooleanOverlay.factory);
+		extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
+	}
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    public static OverlayFactory<Xml> factory = new OverlayFactory<Xml>() {
+	@Generated("com.reprezen.gen.CodeGenerator")
+	public static OverlayFactory<Xml> factory = new OverlayFactory<Xml>() {
 
-        @Override
-        protected Class<? extends IJsonOverlay<? super Xml>> getOverlayClass() {
-            return XmlImpl.class;
-        }
+		@Override
+		protected Class<? extends AbstractJsonOverlay<? super Xml>> getOverlayClass() {
+			return XmlImpl.class;
+		}
 
-        @Override
-        public JsonOverlay<Xml> _create(Xml xml, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            IJsonOverlay<?> overlay;
-            overlay = new XmlImpl(xml, parent, refReg);
-            @SuppressWarnings("unchecked") JsonOverlay<Xml> castOverlay = (JsonOverlay<Xml>) overlay;
-            return castOverlay;
-        }
+		@Override
+		public JsonOverlay<Xml> _create(Xml xml, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+			AbstractJsonOverlay<?> overlay;
+			overlay = new XmlImpl(xml, parent, refReg);
+			@SuppressWarnings("unchecked")
+			JsonOverlay<Xml> castOverlay = (JsonOverlay<Xml>) overlay;
+			return castOverlay;
+		}
 
-        @Override
-        public JsonOverlay<Xml> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
-            IJsonOverlay<?> overlay;
-            overlay = new XmlImpl(json, parent, refReg);
-            @SuppressWarnings("unchecked") JsonOverlay<Xml> castOverlay = (JsonOverlay<Xml>) overlay;
-            return castOverlay;
-        }
-    };
+		@Override
+		public JsonOverlay<Xml> _create(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
+			AbstractJsonOverlay<?> overlay;
+			overlay = new XmlImpl(json, parent, refReg);
+			@SuppressWarnings("unchecked")
+			JsonOverlay<Xml> castOverlay = (JsonOverlay<Xml>) overlay;
+			return castOverlay;
+		}
+	};
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private static Class<? extends Xml> getSubtypeOf(Xml xml) {
-        return Xml.class;
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private static Class<? extends Xml> getSubtypeOf(Xml xml) {
+		return Xml.class;
+	}
 
-    @Generated("com.reprezen.gen.CodeGenerator")
-    private static Class<? extends Xml> getSubtypeOf(JsonNode json) {
-        return Xml.class;
-    }
+	@Generated("com.reprezen.gen.CodeGenerator")
+	private static Class<? extends Xml> getSubtypeOf(JsonNode json) {
+		return Xml.class;
+	}
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/types3.yaml
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/types3.yaml
@@ -35,7 +35,6 @@ types:
       paths:
         structure: map
         keyPattern: *pathPat
-        refable: true
       pathsExtension:
         name: PathsExtension 
         <<: *extDef
@@ -44,42 +43,33 @@ types:
         structure: map
         type: Schema
         keyPattern: *namePat
-        refable: true
       components/responses:
         structure: map
         keyPattern: *namePat
-        refable: true
       components/parameters:
         structure: map
         keyPattern: *namePat
-        refable: true
       components/examples:
         type: Example
         structure: map
         keyPattern: *namePat
-        refable: true
       components/requestBodies:
         name: RequestBody
         plural: RequestBodies
         structure: map
         keyPattern: *namePat
-        refable: true
       components/headers:
         structure: map
         keyPattern: *namePat
-        refable: true
       components/securitySchemes:
         structure: map
         keyPattern: *namePat
-        refable: true
       components/links:
         structure: map
         keyPattern: *namePat
-        refable: true
       components/callbacks:
         structure: map
         keyPattern: *noextNamePat
-        refable: true
       componentsExtension:
         name: ComponentsExtension
         <<: *extDef
@@ -227,7 +217,6 @@ types:
         keyDecls:
           - String name
           - String in
-        refable: true
       *extName: *extDef
         
   - name: Operation
@@ -244,13 +233,10 @@ types:
         keyDecls:
           - String name
           - String id
-        refable: true
-      requestBody:
-        refable: true
+      requestBody: {}
       responses:
         structure: map
         keyPattern: "default|(\\d\\d\\d)"
-        refable: true
       responsesExtension:
         name: ResponsesExtension
         <<: *extDef
@@ -258,7 +244,6 @@ types:
       callbacks:
         structure: map
         keyPattern: *noextNamePat
-        refable: true
       callbacksExtension:
         name: CallbacksExtension
         <<: *extDef
@@ -304,14 +289,12 @@ types:
       description: {}
       headers:
         structure: map
-        refable: true
       content:
         name: ContentMediaType
         type: MediaType
         structure: map
       links:
         structure: map
-        refable: true
       *extName: *extDef
 
   - name: Link
@@ -342,13 +325,11 @@ types:
 
   - name: MediaType
     fields:
-      schema:
-        refable: true
+      schema: {}
       examples:
         type: Example
         structure: map
         keyPattern: *namePat
-        refable: true
       example:
         type: Object
       encoding:
@@ -364,7 +345,6 @@ types:
         structure: map
         type: String
         selfKeyed: true
-        refable: true
       style: {}
       explode:
         type: Boolean
@@ -392,15 +372,13 @@ types:
         type: Boolean
       allowReserved:
         type: Boolean
-      schema:
-        refable: true
+      schema: {}
       example:
         type: Object
       examples:
         type: Example
         structure: map
         keyPattern: *namePat
-        refable: true
       content:
         name: ContentMediaType
         type: MediaType
@@ -413,7 +391,7 @@ types:
         
   - name: Schema
     imports:
-      impl: [ Optional, JsonPointer, IJsonOverlay ]
+      impl: [ Optional, JsonPointer]
     fields:
       title: {}
       multipleOf:
@@ -453,36 +431,29 @@ types:
         name: AllOfSchema
         type: Schema
         structure: collection
-        refable: true
       oneOf:
         name: OneOfSchema
         type: Schema
         structure: collection
-        refable: true
       anyOf:
         name: AnyOfSchema
         type: Schema
         structure: collection
-        refable: true
       not:
         name: NotSchema
         type: Schema
-        refable: true
       items:
         name: ItemsSchema
         type: Schema
-        refable: true
       properties:
         name: Property
         plural: Properties
         type: Schema
         structure: map
-        refable: true
       additionalPropertiesSchema:
         parentPath: additionalProperties
         type: Schema
         createTest: .isObject() 
-        refable: true
       additionalPropertiesBoolean:
         name: AdditionalProperties
         parentPath: additionalProperties

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val/ListValidator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val/ListValidator.java
@@ -11,6 +11,7 @@
 package com.reprezen.kaizen.oasparser.val;
 
 import com.reprezen.jsonoverlay.ListOverlay;
+import com.reprezen.jsonoverlay.Overlay;
 
 public class ListValidator<T extends ListOverlay<T>> extends OverlayValidator<ListOverlay<T>> {
 
@@ -23,7 +24,7 @@ public class ListValidator<T extends ListOverlay<T>> extends OverlayValidator<Li
 	@Override
 	public void validate(ListOverlay<T> overlay, ValidationResults results) {
 		int i = 0;
-		for (T value : overlay.get()) {
+		for (T value : Overlay.get(overlay)) {
 			elementValidator.validate(value, results, getElementCrumb(i++));
 		}
 	}

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val/MapValidator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val/MapValidator.java
@@ -12,6 +12,7 @@ package com.reprezen.kaizen.oasparser.val;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.reprezen.jsonoverlay.MapOverlay;
+import com.reprezen.jsonoverlay.Overlay;
 
 public class MapValidator<T extends MapOverlay<T>> extends OverlayValidator<MapOverlay<T>> {
 
@@ -24,8 +25,8 @@ public class MapValidator<T extends MapOverlay<T>> extends OverlayValidator<MapO
 	@Override
 	public void validate(MapOverlay<T> overlay, ValidationResults results) {
 		super.validate(overlay, results, ObjectNode.class);
-		for (T value : overlay.get().values()) {
-			elementValidator.validate(value, results, value.getPathInParent());
+		for (T value : Overlay.get(overlay).values()) {
+			elementValidator.validate(value, results, Overlay.getPathInParent(value));
 		}
 	}
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val/ObjectValidatorBase.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val/ObjectValidatorBase.java
@@ -14,7 +14,7 @@ import java.util.IdentityHashMap;
 import java.util.Map;
 
 import com.google.inject.Inject;
-import com.reprezen.jsonoverlay.IPropertiesOverlay;
+import com.reprezen.jsonoverlay.PropertiesOverlay;
 
 public abstract class ObjectValidatorBase<T> extends ValidatorBase<T> {
 	@Inject(optional = true)
@@ -35,8 +35,8 @@ public abstract class ObjectValidatorBase<T> extends ValidatorBase<T> {
 	public void validate(T value, ValidationResults results) {
 		if (!visit(value)) {
 			@SuppressWarnings("unchecked")
-			IPropertiesOverlay<T> propValue = (IPropertiesOverlay<T>) value;
-			if (propValue.isElaborated()) {
+			PropertiesOverlay<T> propValue = (PropertiesOverlay<T>) value;
+			if (propValue._isElaborated()) {
 				validateObject(value, results);
 				if (implValidator != null) {
 					implValidator.validateImpl(value, results);

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val/OverlayValidator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val/OverlayValidator.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.reprezen.jsonoverlay.JsonOverlay;
 import com.reprezen.jsonoverlay.ListOverlay;
 import com.reprezen.jsonoverlay.MapOverlay;
+import com.reprezen.jsonoverlay.Overlay;
 import com.reprezen.jsonoverlay.PropertiesOverlay;
 import com.reprezen.jsonoverlay.Reference;
 
@@ -35,7 +36,7 @@ public class OverlayValidator<T> extends ValidatorBase<T> {
 
 	public void validate(T object, ValidationResults results, Set<Class<? extends JsonNode>> allowedNodeTypes) {
 		JsonOverlay<?> overlay = (JsonOverlay<?>) object;
-		JsonNode json = overlay.toJson();
+		JsonNode json = Overlay.toJson(overlay);
 		boolean isValidJsonType = false;
 		for (Class<? extends JsonNode> type : allowedNodeTypes) {
 			if (type.isAssignableFrom(json.getClass())) {
@@ -61,26 +62,29 @@ public class OverlayValidator<T> extends ValidatorBase<T> {
 	}
 
 	private void checkReferences(ListOverlay<?> list, ValidationResults results) {
+		Overlay<?> listAdapter = Overlay.of(list);
 		for (int i = 0; i < list.size(); i++) {
-			if (list.isReference(i)) {
-				checkReference(list.getReference(i), results, Integer.toString(i));
+			if (listAdapter.isReference(i)) {
+				checkReference(listAdapter.getReference(i), results, Integer.toString(i));
 			}
 		}
 	}
 
-    private void checkReferences(MapOverlay<?> map, ValidationResults results) {
-		for (String key : map.get().keySet()) {
-			if (map.isReference(key)) {
-				checkReference(map.getReference(key), results, key);
+	private void checkReferences(MapOverlay<?> map, ValidationResults results) {
+		Overlay<?> mapAdapter = Overlay.of(map);
+		for (String key : map.keySet()) {
+			if (mapAdapter.isReference(key)) {
+				checkReference(mapAdapter.getReference(key), results, key);
 			}
 		}
 	}
 
 	private void checkReferences(PropertiesOverlay<?> props, ValidationResults results) {
-		if (props.isElaborated()) {
-			for (String path : props.getRefablePaths()) {
-				if (props.isReference(path)) {
-					checkReference(props.getReference(path), results, path);
+		if (props._isElaborated()) {
+			Overlay<?> propsAdapter = Overlay.of(props);
+			for (String name : propsAdapter.getPropertyNames()) {
+				if (propsAdapter.isReference(name)) {
+					checkReference(propsAdapter.getReference(name), results, name);
 				}
 			}
 		}

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val/ValidatorBase.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val/ValidatorBase.java
@@ -30,6 +30,7 @@ import javax.print.attribute.standard.Severity;
 
 import com.google.common.collect.Sets;
 import com.reprezen.jsonoverlay.JsonOverlay;
+import com.reprezen.jsonoverlay.Overlay;
 import com.reprezen.kaizen.oasparser.val.oasparser.fake.scheme.Handler;
 
 public abstract class ValidatorBase<T> implements Validator<T> {
@@ -324,6 +325,6 @@ public abstract class ValidatorBase<T> implements Validator<T> {
     }
 
     private boolean isPresent(Object value) {
-		return value instanceof JsonOverlay ? ((JsonOverlay<?>) value).isPresent() : value != null;
+		return value instanceof JsonOverlay ? Overlay.isPresent((JsonOverlay<?>) value) : value != null;
 	}
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/HeaderValidator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/HeaderValidator.java
@@ -13,7 +13,8 @@ package com.reprezen.kaizen.oasparser.val3;
 import static com.reprezen.kaizen.oasparser.val.Messages.m;
 
 import com.google.inject.Inject;
-import com.reprezen.jsonoverlay.IPropertiesOverlay;
+import com.reprezen.jsonoverlay.Overlay;
+import com.reprezen.jsonoverlay.PropertiesOverlay;
 import com.reprezen.kaizen.oasparser.model3.Header;
 import com.reprezen.kaizen.oasparser.model3.MediaType;
 import com.reprezen.kaizen.oasparser.model3.Path;
@@ -79,10 +80,10 @@ public class HeaderValidator extends ObjectValidatorBase<Header> {
     }
 
     private String getPathString(Header header) {
-        IPropertiesOverlay<?> parent = header.getParentPropertiesObject();
+        PropertiesOverlay<?> parent = Overlay.getParentPropertiesOverlay(header);
         while (parent != null && !(parent instanceof Path)) {
-            parent = parent.getParentPropertiesObject();
+            parent = Overlay.of(parent).getParentPropertiesOverlay();
         }
-        return parent != null && parent instanceof Path ? parent.getPathInParent() : null;
+        return parent != null && parent instanceof Path ? Overlay.getPathInParent(parent) : null;
     }
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/LinkValidator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/LinkValidator.java
@@ -17,6 +17,7 @@ import java.util.Map;
 
 import com.google.common.collect.Maps;
 import com.google.inject.Inject;
+import com.reprezen.jsonoverlay.Overlay;
 import com.reprezen.kaizen.oasparser.model3.Header;
 import com.reprezen.kaizen.oasparser.model3.Link;
 import com.reprezen.kaizen.oasparser.model3.OpenApi3;
@@ -57,7 +58,7 @@ public class LinkValidator extends ObjectValidatorBase<Link> {
 					m.msg("OpIdAndOpRefInLink|Link may not contain both 'operationRef' and 'operationId' properties"));
 		}
 		if (opId != null) {
-			op = findOperationById(link.getModel(), opId);
+			op = findOperationById(Overlay.getModel(link), opId);
 			if (op == null) {
 				results.addError(
 						m.msg("OpIdNotFound|OperationId in Link does not identify an operation in the containing model",
@@ -67,7 +68,7 @@ public class LinkValidator extends ObjectValidatorBase<Link> {
 		}
 		String relativePath = getRelativePath(operationRef, results);
 		if (relativePath != null) {
-			op = findOperationByPath(link.getModel(), relativePath, results);
+			op = findOperationByPath(Overlay.getModel(link), relativePath, results);
 			if (op == null) {
 				results.addError(m.msg(
 						"OpPathNotFound|Relative OperationRef in Link does not identify a GET operation in the containing model",

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/MediaTypeValidator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/MediaTypeValidator.java
@@ -15,6 +15,7 @@ import static com.reprezen.kaizen.oasparser.val.Messages.m;
 import java.util.Set;
 
 import com.google.inject.Inject;
+import com.reprezen.jsonoverlay.Overlay;
 import com.reprezen.kaizen.oasparser.model3.EncodingProperty;
 import com.reprezen.kaizen.oasparser.model3.Example;
 import com.reprezen.kaizen.oasparser.model3.MediaType;
@@ -49,7 +50,7 @@ public class MediaTypeValidator extends ObjectValidatorBase<MediaType> {
 		// TODO Q: do allOf, anyOf, oneOf schemas participate? what about
 		// additionalProperties?
 		Schema schema = mediaType.getSchema(false);
-		if (schema.isElaborated()) {
+		if (Overlay.isElaborated(schema)) {
 			Set<String> propNames = schema.getProperties(false).keySet();
 			for (String encodingPropertyName : mediaType.getEncodingProperties(false).keySet()) {
 				if (!propNames.contains(encodingPropertyName)) {

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/ParameterValidator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/ParameterValidator.java
@@ -13,7 +13,8 @@ package com.reprezen.kaizen.oasparser.val3;
 import static com.reprezen.kaizen.oasparser.val.Messages.m;
 
 import com.google.inject.Inject;
-import com.reprezen.jsonoverlay.IPropertiesOverlay;
+import com.reprezen.jsonoverlay.Overlay;
+import com.reprezen.jsonoverlay.PropertiesOverlay;
 import com.reprezen.kaizen.oasparser.model3.MediaType;
 import com.reprezen.kaizen.oasparser.model3.Parameter;
 import com.reprezen.kaizen.oasparser.model3.Path;
@@ -79,10 +80,10 @@ public class ParameterValidator extends ObjectValidatorBase<Parameter> {
     }
 
     private String getPathString(Parameter parameter) {
-        IPropertiesOverlay<?> parent = parameter.getParentPropertiesObject();
+        PropertiesOverlay<?> parent = Overlay.getParentPropertiesOverlay(parameter);
         while (parent != null && !(parent instanceof Path)) {
-            parent = parent.getParentPropertiesObject();
+            parent = Overlay.of(parent).getParentPropertiesOverlay();
         }
-        return parent != null && parent instanceof Path ? parent.getPathInParent() : null;
+        return parent != null && parent instanceof Path ? Overlay.getPathInParent(parent) : null;
     }
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/SchemaValidator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/SchemaValidator.java
@@ -13,6 +13,7 @@ package com.reprezen.kaizen.oasparser.val3;
 import static com.reprezen.kaizen.oasparser.val.Messages.m;
 
 import com.google.inject.Inject;
+import com.reprezen.jsonoverlay.Overlay;
 import com.reprezen.kaizen.oasparser.model3.Example;
 import com.reprezen.kaizen.oasparser.model3.ExternalDocs;
 import com.reprezen.kaizen.oasparser.model3.Schema;
@@ -50,10 +51,10 @@ public class SchemaValidator extends ObjectValidatorBase<Schema> {
         validateList(schema.getAllOfSchemas(false), schema.hasAllOfSchemas(), results, false, "allOf", this);
         validateList(schema.getOneOfSchemas(false), schema.hasOneOfSchemas(), results, false, "oneOf", this);
         validateList(schema.getAnyOfSchemas(false), schema.hasAnyOfSchemas(), results, false, "anyOf", this);
-        if (schema.getNotSchema(false) != null && schema.getNotSchema(false).isPresent()) {
+        if (schema.getNotSchema(false) != null && Overlay.isPresent(schema.getNotSchema(false))) {
             validate(schema.getNotSchema(false), results, "not");
         }
-        if (schema.getItemsSchema(false) != null && schema.getItemsSchema(false).isPresent()) {
+        if (schema.getItemsSchema(false) != null && Overlay.isPresent(schema.getItemsSchema(false))) {
             validate(schema.getItemsSchema(false), results, "items");
         }
         validateMap(schema.getProperties(false), results, false, "properties", null, this);

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/SecurityRequirementValidator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/SecurityRequirementValidator.java
@@ -15,6 +15,7 @@ import static com.reprezen.kaizen.oasparser.val.Messages.m;
 import java.util.Map.Entry;
 import java.util.Set;
 
+import com.reprezen.jsonoverlay.Overlay;
 import com.reprezen.kaizen.oasparser.model3.OpenApi3;
 import com.reprezen.kaizen.oasparser.model3.SecurityParameter;
 import com.reprezen.kaizen.oasparser.model3.SecurityRequirement;
@@ -26,7 +27,7 @@ public class SecurityRequirementValidator extends ObjectValidatorBase<SecurityRe
 
 	@Override
 	public void validateObject(SecurityRequirement securityRequirement, ValidationResults results) {
-		OpenApi3 model = (OpenApi3) securityRequirement.getModel();
+		OpenApi3 model = Overlay.getModel(securityRequirement);
 		Set<String> definedSchemes = model.getSecuritySchemes(false).keySet();
 		for (Entry<String, ? extends SecurityParameter> entry : securityRequirement.getRequirements(false).entrySet()) {
 			if (!definedSchemes.contains(entry.getKey())) {

--- a/kaizen-openapi-parser/src/test/java/com/reprezen/swaggerparser/test/BigParseTest.java
+++ b/kaizen-openapi-parser/src/test/java/com/reprezen/swaggerparser/test/BigParseTest.java
@@ -28,10 +28,11 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import com.google.common.base.Predicate;
-import com.reprezen.jsonoverlay.IJsonOverlay;
+import com.reprezen.jsonoverlay.AbstractJsonOverlay;
+import com.reprezen.jsonoverlay.JsonOverlay;
+import com.reprezen.jsonoverlay.Overlay;
 import com.reprezen.kaizen.oasparser.OpenApiParser;
 import com.reprezen.kaizen.oasparser.model3.OpenApi3;
-import com.reprezen.kaizen.oasparser.ovl3.OpenApi3Impl;
 import com.reprezen.swaggerparser.test.JsonTreeWalker.WalkMethod;
 
 /**
@@ -67,12 +68,12 @@ public class BigParseTest extends Assert {
 		WalkMethod valueChecker = new WalkMethod() {
 			@Override
 			public void run(JsonNode node, JsonPointer path) {
-				IJsonOverlay<?> overlay = ((OpenApi3Impl) model).find(path);
+				AbstractJsonOverlay<?> overlay = Overlay.find((JsonOverlay<OpenApi3>) model, path);
+				Object value = overlay != null ? Overlay.get(overlay) : null;
 				assertNotNull("No overlay object found for path: " + path, overlay);
 				Object fromJson = getValue(node);
-				String msg = String.format("Wrong overlay value for path '%s': expected '%s', got '%s'", path, fromJson,
-						overlay.get());
-				assertEquals(msg, fromJson, overlay.get());
+				String msg = String.format("Wrong overlay value for path '%s': expected '%s', got '%s'", path, fromJson, value);
+				assertEquals(msg, fromJson, value);
 			}
 		};
 		JsonTreeWalker.walkTree(tree, valueNodePredicate, valueChecker);

--- a/kaizen-openapi-parser/src/test/java/com/reprezen/swaggerparser/test/Issue131Test.java
+++ b/kaizen-openapi-parser/src/test/java/com/reprezen/swaggerparser/test/Issue131Test.java
@@ -4,6 +4,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import com.google.common.io.Resources;
+import com.reprezen.jsonoverlay.Overlay;
 import com.reprezen.kaizen.oasparser.OpenApiParser;
 import com.reprezen.kaizen.oasparser.model3.OpenApi3;
 import com.reprezen.kaizen.oasparser.model3.Schema;
@@ -13,8 +14,8 @@ public class Issue131Test extends Assert {
 	@Test
 	public void testSchemaRefs() {
 		OpenApi3 model = (OpenApi3) new OpenApiParser().parse(Resources.getResource("models/issue131.yaml"), true);
-		assertEquals("SampleData", model.find("/components/schemas/SampleData").getPathInParent());
-		assertEquals("MoreData", model.find("/components/schemas/MoreData").getPathInParent());
+		assertEquals("SampleData", Overlay.getPathInParent(Overlay.find(model, "/components/schemas/SampleData")));
+		assertEquals("MoreData",Overlay.getPathInParent(Overlay.find(model,"/components/schemas/MoreData")));
 		Schema direct = model.getSchema("SampleData");
 		Schema viaMoreData = model.getSchema("MoreData").getProperty("master");
 		Schema viaPath = model.getPath("/sampledatamanagement/v1/sampledata/custom/{id}").getGet().getResponse("200")

--- a/kaizen-openapi-parser/src/test/java/com/reprezen/swaggerparser/test/OverlayAdapterTests.java
+++ b/kaizen-openapi-parser/src/test/java/com/reprezen/swaggerparser/test/OverlayAdapterTests.java
@@ -1,0 +1,94 @@
+package com.reprezen.swaggerparser.test;
+
+import java.net.URL;
+import java.util.Collection;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.reprezen.jsonoverlay.ListOverlay;
+import com.reprezen.jsonoverlay.MapOverlay;
+import com.reprezen.jsonoverlay.Overlay;
+import com.reprezen.kaizen.oasparser.OpenApiParser;
+import com.reprezen.kaizen.oasparser.model3.Info;
+import com.reprezen.kaizen.oasparser.model3.OpenApi3;
+import com.reprezen.kaizen.oasparser.model3.Operation;
+import com.reprezen.kaizen.oasparser.model3.Parameter;
+import com.reprezen.kaizen.oasparser.model3.Path;
+import com.reprezen.kaizen.oasparser.model3.Response;
+import com.reprezen.kaizen.oasparser.model3.Schema;
+import com.reprezen.kaizen.oasparser.ovl3.PathImpl;
+
+public class OverlayAdapterTests extends Assert {
+
+	private OpenApi3 model;
+
+	@Before
+	public void setup() {
+		this.model = parseLocalModel("linksTest");
+	}
+
+	@Test
+	public void testPropertiesAdapter() {
+		assertTrue(model == Overlay.of(model).get());
+		assertTrue(model.getInfo() == new Overlay<Info>(model.getInfo()).get());
+	}
+
+	@Test
+	public void testFieldAdapter() {
+		assertEquals(model.getOpenApi(), Overlay.of(model, "openApi", String.class).get());
+		@SuppressWarnings("unchecked")
+		Map<String, PathImpl> pathsMapOverlay = (Map<String, PathImpl>) Overlay.of(model, "paths", Map.class).get();
+		assertTrue(model.getPath("/2.0/users/{username}") == pathsMapOverlay.get("/2.0/users/{username}"));
+	}
+
+	@Test
+	public void testMapAdapter() {
+		Overlay<?> mapOverlay = Overlay.of(model, "paths", Map.class);
+		assertTrue(mapOverlay.getMapOverlay() instanceof MapOverlay);
+		@SuppressWarnings("unchecked")
+		MapOverlay<Path> castMapOverlay = (MapOverlay<Path>) mapOverlay.getMapOverlay();
+		Path path = Overlay.of(castMapOverlay, "/2.0/users/{username}").get();
+		assertTrue(model.getPath("/2.0/users/{username}") == path);
+	}
+
+	@Test
+	public void testListAdapter() {
+		Operation method = model.getPath("/2.0/repositories/{username}/{slug}").getGet();
+		Overlay<?> listOverlay = Overlay.of(method, "parameters", Collection.class);
+		assertTrue(listOverlay.getListOverlay() instanceof ListOverlay);
+		@SuppressWarnings("unchecked")
+		ListOverlay<Parameter> castListOverlay = (ListOverlay<Parameter>) listOverlay.getListOverlay();
+		Parameter param = Overlay.of(castListOverlay, 1).get();
+		assertTrue(method.getParameter(1) == param);
+	}
+
+	@Test
+	public void testReferences() {
+		// props reference
+		Response resp200 = model.getPath("/2.0/users/{username}").getGet().getResponse("200");
+		assertFalse(Overlay.of(resp200).isReference("description"));
+		assertTrue(Overlay.of(resp200.getContentMediaType("application/json")).isReference("schema"));
+		assertEquals("#/components/schemas/user",
+				Overlay.of(resp200.getContentMediaType("application/json")).getReference("schema").getRefString());
+
+		// map reference
+		assertFalse(Overlay.of(model, "schemas", Schema.class).isReference("user"));
+		assertTrue(Overlay.of(model.getSchema("repository").getProperties()).isReference("owner"));
+		assertEquals("#/components/schemas/user",
+				Overlay.of(model.getSchema("repository").getProperties()).getReference("owner").getRefString());
+
+		// list reference
+		Collection<Parameter> params = model.getPath("/2.0/repositories/{username}/{slug}").getGet().getParameters();
+		assertFalse(Overlay.of(params).isReference(1));
+		assertTrue(Overlay.of(params).isReference(0));
+		assertEquals("#/components/parameters/username", Overlay.of(params).getReference(0).getRefString());
+	}
+
+	private static OpenApi3 parseLocalModel(String name) {
+		URL url = SimpleSerializationTest.class.getResource("/models/" + name + ".yaml");
+		return (OpenApi3) new OpenApiParser().parse(url);
+	}
+}

--- a/kaizen-openapi-parser/src/test/java/com/reprezen/swaggerparser/test/SimpleSerializationTest.java
+++ b/kaizen-openapi-parser/src/test/java/com/reprezen/swaggerparser/test/SimpleSerializationTest.java
@@ -35,6 +35,7 @@ import com.fasterxml.jackson.dataformat.yaml.YAMLMapper;
 import com.google.common.base.Charsets;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Queues;
+import com.reprezen.jsonoverlay.Overlay;
 import com.reprezen.jsonoverlay.SerializationOptions.Option;
 import com.reprezen.kaizen.oasparser.OpenApiParser;
 import com.reprezen.kaizen.oasparser.model3.OpenApi3;
@@ -90,7 +91,7 @@ public class SimpleSerializationTest extends Assert {
 		public void serializeExample() throws IOException, JSONException {
 			if (!exampleUrl.toString().contains("callback-example")) {
 				OpenApi3 model = (OpenApi3) new OpenApiParser().parse(exampleUrl);
-				JsonNode serialized = ((OpenApi3Impl) model).toJson();
+				JsonNode serialized = Overlay.toJson((OpenApi3Impl) model);
 				JsonNode expected = yamlMapper.readTree(exampleUrl);
 				JSONAssert.assertEquals(mapper.writeValueAsString(expected), mapper.writeValueAsString(serialized),
 						JSONCompareMode.STRICT);
@@ -104,20 +105,20 @@ public class SimpleSerializationTest extends Assert {
 		public void toJsonNoticesChanges() throws JsonProcessingException {
 			OpenApi3 model = parseLocalModel("simpleTest");
 			assertEquals("simple model", model.getInfo().getTitle());
-			assertEquals("simple model", model.toJson().at("/info/title").asText());
+			assertEquals("simple model", Overlay.toJson(model).at("/info/title").asText());
 			// this changes the overlay value but does not refresh cached JSON - just marks
 			// it as out-of-date
 			model.getInfo().setTitle("changed title");
 			assertEquals("changed title", model.getInfo().getTitle());
-			assertEquals("changed title", model.toJson().at("/info/title").asText());
+			assertEquals("changed title", Overlay.toJson(model).at("/info/title").asText());
 		}
 
 		@Test
 		public void toJsonFollowsRefs() {
 			OpenApi3 model = parseLocalModel("simpleTest");
 			Schema xSchema = model.getSchema("X");
-			assertEquals("#/components/schemas/Y", xSchema.toJson().at("/properties/y/$ref").asText());
-			assertEquals("integer", xSchema.toJson(Option.FOLLOW_REFS).at("/properties/y/type").asText());
+			assertEquals("#/components/schemas/Y", Overlay.toJson(xSchema).at("/properties/y/$ref").asText());
+			assertEquals("integer", Overlay.toJson(xSchema, Option.FOLLOW_REFS).at("/properties/y/type").asText());
 		}
 	}
 

--- a/kaizen-openapi-parser/src/test/resources/models/linksTest.yaml
+++ b/kaizen-openapi-parser/src/test/resources/models/linksTest.yaml
@@ -6,12 +6,8 @@ paths:
   /2.0/users/{username}: 
     get: 
       operationId: getUserByName
-      parameters: 
-      - name: username
-        in: path
-        required: true
-        schema:
-          type: string
+      parameters:
+        - $ref: "#/components/parameters/username" 
       responses: 
         '200':
           description: The User
@@ -26,11 +22,7 @@ paths:
     get:
       operationId: getRepositoriesByOwner
       parameters:
-        - name: username
-          in: path
-          required: true
-          schema:
-            type: string
+        - $ref: "#/components/parameters/username" 
       responses:
         '200':
           description: repositories owned by the supplied user
@@ -47,11 +39,7 @@ paths:
     get: 
       operationId: getRepository
       parameters: 
-        - name: username
-          in: path
-          required: true
-          schema:
-            type: string
+        - $ref: "#/components/parameters/username" 
         - name: slug
           in: path
           required: true
@@ -71,11 +59,7 @@ paths:
     get: 
       operationId: getPullRequestsByRepository
       parameters: 
-      - name: username
-        in: path
-        required: true
-        schema:
-          type: string
+      - $ref: "#/components/parameters/username" 
       - name: slug
         in: path
         required: true
@@ -102,11 +86,7 @@ paths:
     get: 
       operationId: getPullRequestsById
       parameters: 
-      - name: username
-        in: path
-        required: true
-        schema:
-          type: string
+      - $ref: "#/components/parameters/username" 
       - name: slug
         in: path
         required: true
@@ -131,11 +111,7 @@ paths:
     post: 
       operationId: mergePullRequest
       parameters: 
-      - name: username
-        in: path
-        required: true
-        schema:
-          type: string
+      - $ref: "#/components/parameters/username" 
       - name: slug
         in: path
         required: true
@@ -150,6 +126,14 @@ paths:
         '204':
           description: the PR was successfully merged
 components:
+  parameters:
+    username:
+      name: username
+      in: path
+      required: true
+      schema:
+        type: string
+    
   links:
     UserRepositories:
       # returns array of '#/components/schemas/repository'


### PR DESCRIPTION
Significant API impact:
* Generic overlay functionality formerly available via methods inherited
  by generated classes no longer appear there, resulting in a much
  cleaner API. The functionality is now available via a new adapter
  class, `Overlay`, which can be applied to any overlay object.
* Above includes access to reference information, so formerly generated
  API methods to inspect references for selected objects

With this change we will adopt semantic versioning for this project going forward.