### PR TITLE
[#153] Use v2 of JsonOverlay

### DIFF
--- a/kaizen-openapi-parser/pom.xml
+++ b/kaizen-openapi-parser/pom.xml
@@ -8,7 +8,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.reprezen.kaizen</groupId>
     <artifactId>openapi-parser</artifactId>
-    <version>${openapi-parser-version}</version>
+    <version>2.0.0-SNAPSHOT</version>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>KaiZen OpenAPI Parser by RepreZen</description>
     <url>https://github.com/RepreZen/KaiZen-OpenAPI-Parser</url>
@@ -249,8 +249,7 @@
         </plugins>
     </build>
     <properties>
-        <openapi-parser-version>1.0.0-SNAPSHOT</openapi-parser-version>
-        <json-overlay-version>[1.0,2.0)</json-overlay-version>
+        <json-overlay-version>[2.0,3.0)</json-overlay-version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Callback.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Callback.java
@@ -10,46 +10,40 @@ import com.reprezen.jsonoverlay.IModelPart;
 public interface Callback extends IJsonOverlay<Callback>, IModelPart<OpenApi3, Callback> {
 
 	// CallbackPath
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Map<String, Path> getCallbackPaths();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Map<String, Path> getCallbackPaths(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasCallbackPath(String expression);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Path getCallbackPath(String expression);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setCallbackPaths(Map<String, Path> callbackPaths);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setCallbackPath(String expression, Path callbackPath);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeCallbackPath(String expression);
 
 	// Extension
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Map<String, Object> getExtensions();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Map<String, Object> getExtensions(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasExtension(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Object getExtension(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setExtensions(Map<String, Object> extensions);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setExtension(String name, Object extension);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeExtension(String name);
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Contact.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Contact.java
@@ -10,54 +10,42 @@ import com.reprezen.jsonoverlay.IModelPart;
 public interface Contact extends IJsonOverlay<Contact>, IModelPart<OpenApi3, Contact> {
 
 	// Name
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	String getName();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	String getName(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setName(String name);
 
 	// Url
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	String getUrl();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	String getUrl(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setUrl(String url);
 
 	// Email
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	String getEmail();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	String getEmail(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setEmail(String email);
 
 	// Extension
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Map<String, Object> getExtensions();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Map<String, Object> getExtensions(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasExtension(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Object getExtension(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setExtensions(Map<String, Object> extensions);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setExtension(String name, Object extension);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeExtension(String name);
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/EncodingProperty.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/EncodingProperty.java
@@ -10,79 +10,64 @@ import com.reprezen.jsonoverlay.IModelPart;
 public interface EncodingProperty extends IJsonOverlay<EncodingProperty>, IModelPart<OpenApi3, EncodingProperty> {
 
 	// ContentType
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	String getContentType();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	String getContentType(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setContentType(String contentType);
 
 	// Header
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Map<String, String> getHeaders();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Map<String, String> getHeaders(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasHeader(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	String getHeader(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setHeaders(Map<String, String> headers);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setHeader(String name, String header);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeHeader(String name);
 
 	// Style
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	String getStyle();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	String getStyle(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setStyle(String style);
 
 	// Explode
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Boolean getExplode();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Boolean getExplode(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean isExplode();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setExplode(Boolean explode);
 
 	// Extension
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Map<String, Object> getExtensions();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Map<String, Object> getExtensions(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasExtension(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Object getExtension(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setExtensions(Map<String, Object> extensions);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setExtension(String name, Object extension);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeExtension(String name);
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Example.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Example.java
@@ -10,64 +10,49 @@ import com.reprezen.jsonoverlay.IModelPart;
 public interface Example extends IJsonOverlay<Example>, IModelPart<OpenApi3, Example> {
 
 	// Summary
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	String getSummary();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	String getSummary(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setSummary(String summary);
 
 	// Description
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	String getDescription();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	String getDescription(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setDescription(String description);
 
 	// Value
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Object getValue();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Object getValue(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setValue(Object value);
 
 	// ExternalValue
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	String getExternalValue();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	String getExternalValue(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setExternalValue(String externalValue);
 
 	// Extension
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Map<String, Object> getExtensions();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Map<String, Object> getExtensions(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasExtension(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Object getExtension(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setExtensions(Map<String, Object> extensions);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setExtension(String name, Object extension);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeExtension(String name);
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/ExternalDocs.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/ExternalDocs.java
@@ -10,44 +10,35 @@ import com.reprezen.jsonoverlay.IModelPart;
 public interface ExternalDocs extends IJsonOverlay<ExternalDocs>, IModelPart<OpenApi3, ExternalDocs> {
 
 	// Description
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	String getDescription();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	String getDescription(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setDescription(String description);
 
 	// Url
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	String getUrl();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	String getUrl(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setUrl(String url);
 
 	// Extension
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Map<String, Object> getExtensions();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Map<String, Object> getExtensions(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasExtension(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Object getExtension(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setExtensions(Map<String, Object> extensions);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setExtension(String name, Object extension);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeExtension(String name);
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Header.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Header.java
@@ -10,193 +10,154 @@ import com.reprezen.jsonoverlay.IModelPart;
 public interface Header extends IJsonOverlay<Header>, IModelPart<OpenApi3, Header> {
 
 	// Name
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	String getName();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	String getName(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setName(String name);
 
 	// In
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	String getIn();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	String getIn(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setIn(String in);
 
 	// Description
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	String getDescription();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	String getDescription(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setDescription(String description);
 
 	// Required
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Boolean getRequired();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Boolean getRequired(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean isRequired();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setRequired(Boolean required);
 
 	// Deprecated
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Boolean getDeprecated();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Boolean getDeprecated(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean isDeprecated();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setDeprecated(Boolean deprecated);
 
 	// AllowEmptyValue
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Boolean getAllowEmptyValue();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Boolean getAllowEmptyValue(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean isAllowEmptyValue();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setAllowEmptyValue(Boolean allowEmptyValue);
 
 	// Style
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	String getStyle();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	String getStyle(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setStyle(String style);
 
 	// Explode
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Boolean getExplode();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Boolean getExplode(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean isExplode();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setExplode(Boolean explode);
 
 	// AllowReserved
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Boolean getAllowReserved();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Boolean getAllowReserved(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean isAllowReserved();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setAllowReserved(Boolean allowReserved);
 
 	// Schema
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Schema getSchema();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Schema getSchema(boolean elaborate);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setSchema(Schema schema);
 
 	// Example
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Object getExample();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Object getExample(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setExample(Object example);
 
 	// Example
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Map<String, Example> getExamples();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Map<String, Example> getExamples(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasExample(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Example getExample(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setExamples(Map<String, Example> examples);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setExample(String name, Example example);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeExample(String name);
 
 	// ContentMediaType
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Map<String, MediaType> getContentMediaTypes();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Map<String, MediaType> getContentMediaTypes(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasContentMediaType(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	MediaType getContentMediaType(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setContentMediaTypes(Map<String, MediaType> contentMediaTypes);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setContentMediaType(String name, MediaType contentMediaType);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeContentMediaType(String name);
 
 	// Extension
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Map<String, Object> getExtensions();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Map<String, Object> getExtensions(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasExtension(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Object getExtension(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setExtensions(Map<String, Object> extensions);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setExtension(String name, Object extension);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeExtension(String name);
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Info.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Info.java
@@ -10,84 +10,69 @@ import com.reprezen.jsonoverlay.IModelPart;
 public interface Info extends IJsonOverlay<Info>, IModelPart<OpenApi3, Info> {
 
 	// Title
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	String getTitle();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	String getTitle(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setTitle(String title);
 
 	// Description
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	String getDescription();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	String getDescription(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setDescription(String description);
 
 	// TermsOfService
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	String getTermsOfService();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	String getTermsOfService(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setTermsOfService(String termsOfService);
 
 	// Contact
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Contact getContact();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Contact getContact(boolean elaborate);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setContact(Contact contact);
 
 	// License
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	License getLicense();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	License getLicense(boolean elaborate);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setLicense(License license);
 
 	// Version
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	String getVersion();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	String getVersion(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setVersion(String version);
 
 	// Extension
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Map<String, Object> getExtensions();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Map<String, Object> getExtensions(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasExtension(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Object getExtension(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setExtensions(Map<String, Object> extensions);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setExtension(String name, Object extension);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeExtension(String name);
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/License.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/License.java
@@ -10,44 +10,35 @@ import com.reprezen.jsonoverlay.IModelPart;
 public interface License extends IJsonOverlay<License>, IModelPart<OpenApi3, License> {
 
 	// Name
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	String getName();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	String getName(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setName(String name);
 
 	// Url
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	String getUrl();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	String getUrl(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setUrl(String url);
 
 	// Extension
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Map<String, Object> getExtensions();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Map<String, Object> getExtensions(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasExtension(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Object getExtension(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setExtensions(Map<String, Object> extensions);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setExtension(String name, Object extension);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeExtension(String name);
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Link.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Link.java
@@ -10,108 +10,90 @@ import com.reprezen.jsonoverlay.IModelPart;
 public interface Link extends IJsonOverlay<Link>, IModelPart<OpenApi3, Link> {
 
 	// OperationId
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	String getOperationId();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	String getOperationId(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setOperationId(String operationId);
 
 	// OperationRef
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	String getOperationRef();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	String getOperationRef(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setOperationRef(String operationRef);
 
 	// Parameter
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Map<String, String> getParameters();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Map<String, String> getParameters(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasParameter(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	String getParameter(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setParameters(Map<String, String> parameters);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setParameter(String name, String parameter);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeParameter(String name);
 
 	// Header
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Map<String, Header> getHeaders();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Map<String, Header> getHeaders(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasHeader(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Header getHeader(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setHeaders(Map<String, Header> headers);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setHeader(String name, Header header);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeHeader(String name);
 
 	// Description
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	String getDescription();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	String getDescription(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setDescription(String description);
 
 	// Server
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Server getServer();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Server getServer(boolean elaborate);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setServer(Server server);
 
 	// Extension
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Map<String, Object> getExtensions();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Map<String, Object> getExtensions(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasExtension(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Object getExtension(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setExtensions(Map<String, Object> extensions);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setExtension(String name, Object extension);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeExtension(String name);
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/MediaType.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/MediaType.java
@@ -10,88 +10,76 @@ import com.reprezen.jsonoverlay.IModelPart;
 public interface MediaType extends IJsonOverlay<MediaType>, IModelPart<OpenApi3, MediaType> {
 
 	// Schema
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Schema getSchema();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Schema getSchema(boolean elaborate);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setSchema(Schema schema);
 
 	// Example
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Map<String, Example> getExamples();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Map<String, Example> getExamples(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasExample(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Example getExample(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setExamples(Map<String, Example> examples);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setExample(String name, Example example);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeExample(String name);
 
 	// Example
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Object getExample();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Object getExample(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setExample(Object example);
 
 	// EncodingProperty
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Map<String, EncodingProperty> getEncodingProperties();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Map<String, EncodingProperty> getEncodingProperties(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasEncodingProperty(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	EncodingProperty getEncodingProperty(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setEncodingProperties(Map<String, EncodingProperty> encodingProperties);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setEncodingProperty(String name, EncodingProperty encodingProperty);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeEncodingProperty(String name);
 
 	// Extension
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Map<String, Object> getExtensions();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Map<String, Object> getExtensions(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasExtension(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Object getExtension(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setExtensions(Map<String, Object> extensions);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setExtension(String name, Object extension);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeExtension(String name);
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/OAuthFlow.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/OAuthFlow.java
@@ -10,98 +10,80 @@ import com.reprezen.jsonoverlay.IModelPart;
 public interface OAuthFlow extends IJsonOverlay<OAuthFlow>, IModelPart<OpenApi3, OAuthFlow> {
 
 	// AuthorizationUrl
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	String getAuthorizationUrl();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	String getAuthorizationUrl(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setAuthorizationUrl(String authorizationUrl);
 
 	// TokenUrl
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	String getTokenUrl();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	String getTokenUrl(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setTokenUrl(String tokenUrl);
 
 	// RefreshUrl
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	String getRefreshUrl();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	String getRefreshUrl(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setRefreshUrl(String refreshUrl);
 
 	// Scope
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Map<String, String> getScopes();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Map<String, String> getScopes(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasScope(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	String getScope(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setScopes(Map<String, String> scopes);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setScope(String name, String scope);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeScope(String name);
 
 	// ScopesExtension
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Map<String, Object> getScopesExtensions();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Map<String, Object> getScopesExtensions(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasScopesExtension(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Object getScopesExtension(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setScopesExtensions(Map<String, Object> scopesExtensions);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setScopesExtension(String name, Object scopesExtension);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeScopesExtension(String name);
 
 	// Extension
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Map<String, Object> getExtensions();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Map<String, Object> getExtensions(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasExtension(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Object getExtension(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setExtensions(Map<String, Object> extensions);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setExtension(String name, Object extension);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeExtension(String name);
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/OpenApi3.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/OpenApi3.java
@@ -21,402 +21,351 @@ public interface OpenApi3 extends IJsonOverlay<OpenApi3>, IModelPart<OpenApi3, O
 	public Collection<ValidationResults.ValidationItem> getValidationItems();
 
 	// OpenApi
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	String getOpenApi();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	String getOpenApi(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setOpenApi(String openApi);
 
 	// Info
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Info getInfo();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Info getInfo(boolean elaborate);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setInfo(Info info);
 
 	// Server
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Collection<Server> getServers();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Collection<Server> getServers(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasServers();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Server getServer(int index);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setServers(Collection<Server> servers);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setServer(int index, Server server);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void addServer(Server server);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void insertServer(int index, Server server);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeServer(int index);
 
 	// Path
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Map<String, Path> getPaths();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Map<String, Path> getPaths(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasPath(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Path getPath(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setPaths(Map<String, Path> paths);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setPath(String name, Path path);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removePath(String name);
 
 	// PathsExtension
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Map<String, Object> getPathsExtensions();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Map<String, Object> getPathsExtensions(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasPathsExtension(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Object getPathsExtension(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setPathsExtensions(Map<String, Object> pathsExtensions);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setPathsExtension(String name, Object pathsExtension);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removePathsExtension(String name);
 
 	// Schema
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Map<String, Schema> getSchemas();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Map<String, Schema> getSchemas(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasSchema(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Schema getSchema(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setSchemas(Map<String, Schema> schemas);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setSchema(String name, Schema schema);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeSchema(String name);
 
 	// Response
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Map<String, Response> getResponses();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Map<String, Response> getResponses(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasResponse(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Response getResponse(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setResponses(Map<String, Response> responses);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setResponse(String name, Response response);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeResponse(String name);
 
 	// Parameter
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Map<String, Parameter> getParameters();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Map<String, Parameter> getParameters(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasParameter(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Parameter getParameter(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setParameters(Map<String, Parameter> parameters);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setParameter(String name, Parameter parameter);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeParameter(String name);
 
 	// Example
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Map<String, Example> getExamples();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Map<String, Example> getExamples(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasExample(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Example getExample(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setExamples(Map<String, Example> examples);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setExample(String name, Example example);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeExample(String name);
 
 	// RequestBody
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Map<String, RequestBody> getRequestBodies();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Map<String, RequestBody> getRequestBodies(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasRequestBody(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	RequestBody getRequestBody(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setRequestBodies(Map<String, RequestBody> requestBodies);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setRequestBody(String name, RequestBody requestBody);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeRequestBody(String name);
 
 	// Header
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Map<String, Header> getHeaders();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Map<String, Header> getHeaders(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasHeader(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Header getHeader(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setHeaders(Map<String, Header> headers);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setHeader(String name, Header header);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeHeader(String name);
 
 	// SecurityScheme
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Map<String, SecurityScheme> getSecuritySchemes();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Map<String, SecurityScheme> getSecuritySchemes(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasSecurityScheme(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	SecurityScheme getSecurityScheme(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setSecuritySchemes(Map<String, SecurityScheme> securitySchemes);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setSecurityScheme(String name, SecurityScheme securityScheme);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeSecurityScheme(String name);
 
 	// Link
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Map<String, Link> getLinks();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Map<String, Link> getLinks(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasLink(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Link getLink(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setLinks(Map<String, Link> links);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setLink(String name, Link link);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeLink(String name);
 
 	// Callback
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Map<String, Callback> getCallbacks();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Map<String, Callback> getCallbacks(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasCallback(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Callback getCallback(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setCallbacks(Map<String, Callback> callbacks);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setCallback(String name, Callback callback);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeCallback(String name);
 
 	// ComponentsExtension
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Map<String, Object> getComponentsExtensions();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Map<String, Object> getComponentsExtensions(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasComponentsExtension(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Object getComponentsExtension(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setComponentsExtensions(Map<String, Object> componentsExtensions);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setComponentsExtension(String name, Object componentsExtension);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeComponentsExtension(String name);
 
 	// SecurityRequirement
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Collection<SecurityRequirement> getSecurityRequirements();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Collection<SecurityRequirement> getSecurityRequirements(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasSecurityRequirements();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	SecurityRequirement getSecurityRequirement(int index);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setSecurityRequirements(Collection<SecurityRequirement> securityRequirements);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setSecurityRequirement(int index, SecurityRequirement securityRequirement);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void addSecurityRequirement(SecurityRequirement securityRequirement);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void insertSecurityRequirement(int index, SecurityRequirement securityRequirement);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeSecurityRequirement(int index);
 
 	// Tag
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Collection<Tag> getTags();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Collection<Tag> getTags(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasTags();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Tag getTag(int index);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setTags(Collection<Tag> tags);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setTag(int index, Tag tag);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void addTag(Tag tag);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void insertTag(int index, Tag tag);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeTag(int index);
 
 	// ExternalDocs
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	ExternalDocs getExternalDocs();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	ExternalDocs getExternalDocs(boolean elaborate);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setExternalDocs(ExternalDocs externalDocs);
 
 	// Extension
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Map<String, Object> getExtensions();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Map<String, Object> getExtensions(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasExtension(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Object getExtension(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setExtensions(Map<String, Object> extensions);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setExtension(String name, Object extension);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeExtension(String name);
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Operation.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Operation.java
@@ -11,287 +11,248 @@ import com.reprezen.jsonoverlay.IModelPart;
 public interface Operation extends IJsonOverlay<Operation>, IModelPart<OpenApi3, Operation> {
 
 	// Tag
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Collection<String> getTags();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Collection<String> getTags(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasTags();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	String getTag(int index);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setTags(Collection<String> tags);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setTag(int index, String tag);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void addTag(String tag);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void insertTag(int index, String tag);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeTag(int index);
 
 	// Summary
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	String getSummary();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	String getSummary(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setSummary(String summary);
 
 	// Description
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	String getDescription();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	String getDescription(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setDescription(String description);
 
 	// ExternalDocs
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	ExternalDocs getExternalDocs();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	ExternalDocs getExternalDocs(boolean elaborate);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setExternalDocs(ExternalDocs externalDocs);
 
 	// OperationId
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	String getOperationId();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	String getOperationId(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setOperationId(String operationId);
 
 	// Parameter
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Collection<Parameter> getParameters();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Collection<Parameter> getParameters(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasParameters();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Parameter getParameter(int index);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setParameters(Collection<Parameter> parameters);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setParameter(int index, Parameter parameter);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void addParameter(Parameter parameter);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void insertParameter(int index, Parameter parameter);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeParameter(int index);
 
 	// RequestBody
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	RequestBody getRequestBody();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	RequestBody getRequestBody(boolean elaborate);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setRequestBody(RequestBody requestBody);
 
 	// Response
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Map<String, Response> getResponses();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Map<String, Response> getResponses(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasResponse(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Response getResponse(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setResponses(Map<String, Response> responses);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setResponse(String name, Response response);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeResponse(String name);
 
 	// ResponsesExtension
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Map<String, Object> getResponsesExtensions();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Map<String, Object> getResponsesExtensions(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasResponsesExtension(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Object getResponsesExtension(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setResponsesExtensions(Map<String, Object> responsesExtensions);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setResponsesExtension(String name, Object responsesExtension);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeResponsesExtension(String name);
 
 	// Callback
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Map<String, Callback> getCallbacks();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Map<String, Callback> getCallbacks(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasCallback(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Callback getCallback(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setCallbacks(Map<String, Callback> callbacks);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setCallback(String name, Callback callback);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeCallback(String name);
 
 	// CallbacksExtension
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Map<String, Object> getCallbacksExtensions();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Map<String, Object> getCallbacksExtensions(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasCallbacksExtension(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Object getCallbacksExtension(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setCallbacksExtensions(Map<String, Object> callbacksExtensions);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setCallbacksExtension(String name, Object callbacksExtension);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeCallbacksExtension(String name);
 
 	// Deprecated
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Boolean getDeprecated();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Boolean getDeprecated(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean isDeprecated();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setDeprecated(Boolean deprecated);
 
 	// SecurityRequirement
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Collection<SecurityRequirement> getSecurityRequirements();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Collection<SecurityRequirement> getSecurityRequirements(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasSecurityRequirements();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	SecurityRequirement getSecurityRequirement(int index);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setSecurityRequirements(Collection<SecurityRequirement> securityRequirements);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setSecurityRequirement(int index, SecurityRequirement securityRequirement);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void addSecurityRequirement(SecurityRequirement securityRequirement);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void insertSecurityRequirement(int index, SecurityRequirement securityRequirement);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeSecurityRequirement(int index);
 
 	// Server
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Collection<Server> getServers();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Collection<Server> getServers(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasServers();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Server getServer(int index);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setServers(Collection<Server> servers);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setServer(int index, Server server);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void addServer(Server server);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void insertServer(int index, Server server);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeServer(int index);
 
 	// Extension
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Map<String, Object> getExtensions();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Map<String, Object> getExtensions(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasExtension(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Object getExtension(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setExtensions(Map<String, Object> extensions);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setExtension(String name, Object extension);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeExtension(String name);
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Parameter.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Parameter.java
@@ -10,193 +10,154 @@ import com.reprezen.jsonoverlay.IModelPart;
 public interface Parameter extends IJsonOverlay<Parameter>, IModelPart<OpenApi3, Parameter> {
 
 	// Name
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	String getName();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	String getName(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setName(String name);
 
 	// In
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	String getIn();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	String getIn(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setIn(String in);
 
 	// Description
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	String getDescription();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	String getDescription(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setDescription(String description);
 
 	// Required
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Boolean getRequired();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Boolean getRequired(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean isRequired();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setRequired(Boolean required);
 
 	// Deprecated
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Boolean getDeprecated();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Boolean getDeprecated(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean isDeprecated();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setDeprecated(Boolean deprecated);
 
 	// AllowEmptyValue
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Boolean getAllowEmptyValue();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Boolean getAllowEmptyValue(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean isAllowEmptyValue();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setAllowEmptyValue(Boolean allowEmptyValue);
 
 	// Style
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	String getStyle();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	String getStyle(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setStyle(String style);
 
 	// Explode
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Boolean getExplode();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Boolean getExplode(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean isExplode();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setExplode(Boolean explode);
 
 	// AllowReserved
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Boolean getAllowReserved();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Boolean getAllowReserved(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean isAllowReserved();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setAllowReserved(Boolean allowReserved);
 
 	// Schema
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Schema getSchema();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Schema getSchema(boolean elaborate);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setSchema(Schema schema);
 
 	// Example
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Object getExample();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Object getExample(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setExample(Object example);
 
 	// Example
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Map<String, Example> getExamples();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Map<String, Example> getExamples(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasExample(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Example getExample(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setExamples(Map<String, Example> examples);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setExample(String name, Example example);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeExample(String name);
 
 	// ContentMediaType
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Map<String, MediaType> getContentMediaTypes();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Map<String, MediaType> getContentMediaTypes(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasContentMediaType(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	MediaType getContentMediaType(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setContentMediaTypes(Map<String, MediaType> contentMediaTypes);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setContentMediaType(String name, MediaType contentMediaType);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeContentMediaType(String name);
 
 	// Extension
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Map<String, Object> getExtensions();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Map<String, Object> getExtensions(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasExtension(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Object getExtension(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setExtensions(Map<String, Object> extensions);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setExtension(String name, Object extension);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeExtension(String name);
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Path.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Path.java
@@ -11,202 +11,184 @@ import com.reprezen.jsonoverlay.IModelPart;
 public interface Path extends IJsonOverlay<Path>, IModelPart<OpenApi3, Path> {
 
 	// Summary
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	String getSummary();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	String getSummary(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setSummary(String summary);
 
 	// Description
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	String getDescription();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	String getDescription(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setDescription(String description);
 
 	// Operation
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Map<String, Operation> getOperations();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Map<String, Operation> getOperations(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasOperation(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Operation getOperation(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setOperations(Map<String, Operation> operations);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setOperation(String name, Operation operation);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeOperation(String name);
 
 	// Get
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Operation getGet();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Operation getGet(boolean elaborate);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setGet(Operation get);
 
 	// Put
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Operation getPut();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Operation getPut(boolean elaborate);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setPut(Operation put);
 
 	// Post
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Operation getPost();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Operation getPost(boolean elaborate);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setPost(Operation post);
 
 	// Delete
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Operation getDelete();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Operation getDelete(boolean elaborate);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setDelete(Operation delete);
 
 	// Options
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Operation getOptions();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Operation getOptions(boolean elaborate);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setOptions(Operation options);
 
 	// Head
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Operation getHead();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Operation getHead(boolean elaborate);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setHead(Operation head);
 
 	// Patch
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Operation getPatch();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Operation getPatch(boolean elaborate);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setPatch(Operation patch);
 
 	// Trace
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Operation getTrace();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Operation getTrace(boolean elaborate);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setTrace(Operation trace);
 
 	// Server
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Collection<Server> getServers();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Collection<Server> getServers(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasServers();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Server getServer(int index);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setServers(Collection<Server> servers);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setServer(int index, Server server);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void addServer(Server server);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void insertServer(int index, Server server);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeServer(int index);
 
 	// Parameter
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Collection<Parameter> getParameters();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Collection<Parameter> getParameters(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasParameters();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Parameter getParameter(int index);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setParameters(Collection<Parameter> parameters);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setParameter(int index, Parameter parameter);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void addParameter(Parameter parameter);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void insertParameter(int index, Parameter parameter);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeParameter(int index);
 
 	// Extension
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Map<String, Object> getExtensions();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Map<String, Object> getExtensions(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasExtension(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Object getExtension(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setExtensions(Map<String, Object> extensions);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setExtension(String name, Object extension);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeExtension(String name);
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/RequestBody.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/RequestBody.java
@@ -10,69 +10,57 @@ import com.reprezen.jsonoverlay.IModelPart;
 public interface RequestBody extends IJsonOverlay<RequestBody>, IModelPart<OpenApi3, RequestBody> {
 
 	// Description
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	String getDescription();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	String getDescription(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setDescription(String description);
 
 	// ContentMediaType
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Map<String, MediaType> getContentMediaTypes();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Map<String, MediaType> getContentMediaTypes(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasContentMediaType(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	MediaType getContentMediaType(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setContentMediaTypes(Map<String, MediaType> contentMediaTypes);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setContentMediaType(String name, MediaType contentMediaType);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeContentMediaType(String name);
 
 	// Required
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Boolean getRequired();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Boolean getRequired(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean isRequired();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setRequired(Boolean required);
 
 	// Extension
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Map<String, Object> getExtensions();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Map<String, Object> getExtensions(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasExtension(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Object getExtension(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setExtensions(Map<String, Object> extensions);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setExtension(String name, Object extension);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeExtension(String name);
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Response.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Response.java
@@ -10,100 +10,85 @@ import com.reprezen.jsonoverlay.IModelPart;
 public interface Response extends IJsonOverlay<Response>, IModelPart<OpenApi3, Response> {
 
 	// Description
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	String getDescription();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	String getDescription(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setDescription(String description);
 
 	// Header
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Map<String, Header> getHeaders();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Map<String, Header> getHeaders(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasHeader(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Header getHeader(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setHeaders(Map<String, Header> headers);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setHeader(String name, Header header);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeHeader(String name);
 
 	// ContentMediaType
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Map<String, MediaType> getContentMediaTypes();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Map<String, MediaType> getContentMediaTypes(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasContentMediaType(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	MediaType getContentMediaType(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setContentMediaTypes(Map<String, MediaType> contentMediaTypes);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setContentMediaType(String name, MediaType contentMediaType);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeContentMediaType(String name);
 
 	// Link
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Map<String, Link> getLinks();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Map<String, Link> getLinks(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasLink(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Link getLink(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setLinks(Map<String, Link> links);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setLink(String name, Link link);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeLink(String name);
 
 	// Extension
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Map<String, Object> getExtensions();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Map<String, Object> getExtensions(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasExtension(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Object getExtension(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setExtensions(Map<String, Object> extensions);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setExtension(String name, Object extension);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeExtension(String name);
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Schema.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Schema.java
@@ -11,532 +11,433 @@ import com.reprezen.jsonoverlay.IModelPart;
 public interface Schema extends IJsonOverlay<Schema>, IModelPart<OpenApi3, Schema> {
 
 	// Title
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	String getTitle();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	String getTitle(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setTitle(String title);
 
 	// MultipleOf
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Number getMultipleOf();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Number getMultipleOf(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setMultipleOf(Number multipleOf);
 
 	// Maximum
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Number getMaximum();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Number getMaximum(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setMaximum(Number maximum);
 
 	// ExclusiveMaximum
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Boolean getExclusiveMaximum();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Boolean getExclusiveMaximum(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean isExclusiveMaximum();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setExclusiveMaximum(Boolean exclusiveMaximum);
 
 	// Minimum
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Number getMinimum();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Number getMinimum(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setMinimum(Number minimum);
 
 	// ExclusiveMinimum
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Boolean getExclusiveMinimum();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Boolean getExclusiveMinimum(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean isExclusiveMinimum();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setExclusiveMinimum(Boolean exclusiveMinimum);
 
 	// MaxLength
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Integer getMaxLength();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Integer getMaxLength(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setMaxLength(Integer maxLength);
 
 	// MinLength
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Integer getMinLength();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Integer getMinLength(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setMinLength(Integer minLength);
 
 	// Pattern
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	String getPattern();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	String getPattern(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setPattern(String pattern);
 
 	// MaxItems
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Integer getMaxItems();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Integer getMaxItems(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setMaxItems(Integer maxItems);
 
 	// MinItems
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Integer getMinItems();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Integer getMinItems(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setMinItems(Integer minItems);
 
 	// UniqueItems
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Boolean getUniqueItems();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Boolean getUniqueItems(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean isUniqueItems();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setUniqueItems(Boolean uniqueItems);
 
 	// MaxProperties
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Integer getMaxProperties();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Integer getMaxProperties(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setMaxProperties(Integer maxProperties);
 
 	// MinProperties
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Integer getMinProperties();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Integer getMinProperties(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setMinProperties(Integer minProperties);
 
 	// RequiredField
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Collection<String> getRequiredFields();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Collection<String> getRequiredFields(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasRequiredFields();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	String getRequiredField(int index);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setRequiredFields(Collection<String> requiredFields);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setRequiredField(int index, String requiredField);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void addRequiredField(String requiredField);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void insertRequiredField(int index, String requiredField);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeRequiredField(int index);
 
 	// Enum
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Collection<Object> getEnums();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Collection<Object> getEnums(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasEnums();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Object getEnum(int index);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setEnums(Collection<Object> enums);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setEnum(int index, Object enumValue);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void addEnum(Object enumValue);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void insertEnum(int index, Object enumValue);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeEnum(int index);
 
 	// Type
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	String getType();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	String getType(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setType(String type);
 
 	// AllOfSchema
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Collection<Schema> getAllOfSchemas();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Collection<Schema> getAllOfSchemas(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasAllOfSchemas();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Schema getAllOfSchema(int index);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setAllOfSchemas(Collection<Schema> allOfSchemas);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setAllOfSchema(int index, Schema allOfSchema);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void addAllOfSchema(Schema allOfSchema);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void insertAllOfSchema(int index, Schema allOfSchema);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeAllOfSchema(int index);
 
 	// OneOfSchema
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Collection<Schema> getOneOfSchemas();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Collection<Schema> getOneOfSchemas(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasOneOfSchemas();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Schema getOneOfSchema(int index);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setOneOfSchemas(Collection<Schema> oneOfSchemas);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setOneOfSchema(int index, Schema oneOfSchema);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void addOneOfSchema(Schema oneOfSchema);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void insertOneOfSchema(int index, Schema oneOfSchema);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeOneOfSchema(int index);
 
 	// AnyOfSchema
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Collection<Schema> getAnyOfSchemas();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Collection<Schema> getAnyOfSchemas(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasAnyOfSchemas();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Schema getAnyOfSchema(int index);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setAnyOfSchemas(Collection<Schema> anyOfSchemas);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setAnyOfSchema(int index, Schema anyOfSchema);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void addAnyOfSchema(Schema anyOfSchema);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void insertAnyOfSchema(int index, Schema anyOfSchema);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeAnyOfSchema(int index);
 
 	// NotSchema
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Schema getNotSchema();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Schema getNotSchema(boolean elaborate);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setNotSchema(Schema notSchema);
 
 	// ItemsSchema
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Schema getItemsSchema();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Schema getItemsSchema(boolean elaborate);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setItemsSchema(Schema itemsSchema);
 
 	// Property
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Map<String, Schema> getProperties();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Map<String, Schema> getProperties(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasProperty(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Schema getProperty(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setProperties(Map<String, Schema> properties);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setProperty(String name, Schema property);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeProperty(String name);
 
 	// AdditionalPropertiesSchema
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Schema getAdditionalPropertiesSchema();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Schema getAdditionalPropertiesSchema(boolean elaborate);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setAdditionalPropertiesSchema(Schema additionalPropertiesSchema);
 
 	// AdditionalProperties
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Boolean getAdditionalProperties();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Boolean getAdditionalProperties(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean isAdditionalProperties();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setAdditionalProperties(Boolean additionalProperties);
 
 	// Description
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	String getDescription();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	String getDescription(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setDescription(String description);
 
 	// Format
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	String getFormat();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	String getFormat(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setFormat(String format);
 
 	// Default
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Object getDefault();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Object getDefault(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setDefault(Object defaultValue);
 
 	// Nullable
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Boolean getNullable();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Boolean getNullable(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean isNullable();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setNullable(Boolean nullable);
 
 	// Discriminator
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	String getDiscriminator();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	String getDiscriminator(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setDiscriminator(String discriminator);
 
 	// ReadOnly
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Boolean getReadOnly();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Boolean getReadOnly(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean isReadOnly();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setReadOnly(Boolean readOnly);
 
 	// WriteOnly
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Boolean getWriteOnly();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Boolean getWriteOnly(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean isWriteOnly();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setWriteOnly(Boolean writeOnly);
 
 	// Xml
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Xml getXml();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Xml getXml(boolean elaborate);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setXml(Xml xml);
 
 	// ExternalDocs
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	ExternalDocs getExternalDocs();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	ExternalDocs getExternalDocs(boolean elaborate);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setExternalDocs(ExternalDocs externalDocs);
 
 	// Example
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Map<String, Example> getExamples();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Map<String, Example> getExamples(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasExample(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Example getExample(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setExamples(Map<String, Example> examples);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setExample(String name, Example example);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeExample(String name);
 
 	// Example
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Object getExample();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Object getExample(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setExample(Object example);
 
 	// Deprecated
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Boolean getDeprecated();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Boolean getDeprecated(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean isDeprecated();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setDeprecated(Boolean deprecated);
 
 	// Extension
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Map<String, Object> getExtensions();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Map<String, Object> getExtensions(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasExtension(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Object getExtension(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setExtensions(Map<String, Object> extensions);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setExtension(String name, Object extension);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeExtension(String name);
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/SecurityParameter.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/SecurityParameter.java
@@ -10,30 +10,27 @@ import com.reprezen.jsonoverlay.IModelPart;
 public interface SecurityParameter extends IJsonOverlay<SecurityParameter>, IModelPart<OpenApi3, SecurityParameter> {
 
 	// Parameter
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Collection<String> getParameters();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Collection<String> getParameters(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasParameters();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	String getParameter(int index);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setParameters(Collection<String> parameters);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setParameter(int index, String parameter);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void addParameter(String parameter);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void insertParameter(int index, String parameter);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeParameter(int index);
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/SecurityRequirement.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/SecurityRequirement.java
@@ -11,24 +11,21 @@ public interface SecurityRequirement
 		extends IJsonOverlay<SecurityRequirement>, IModelPart<OpenApi3, SecurityRequirement> {
 
 	// Requirement
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Map<String, SecurityParameter> getRequirements();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Map<String, SecurityParameter> getRequirements(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasRequirement(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	SecurityParameter getRequirement(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setRequirements(Map<String, SecurityParameter> requirements);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setRequirement(String name, SecurityParameter requirement);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeRequirement(String name);
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/SecurityScheme.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/SecurityScheme.java
@@ -10,156 +10,129 @@ import com.reprezen.jsonoverlay.IModelPart;
 public interface SecurityScheme extends IJsonOverlay<SecurityScheme>, IModelPart<OpenApi3, SecurityScheme> {
 
 	// Type
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	String getType();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	String getType(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setType(String type);
 
 	// Description
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	String getDescription();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	String getDescription(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setDescription(String description);
 
 	// Name
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	String getName();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	String getName(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setName(String name);
 
 	// In
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	String getIn();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	String getIn(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setIn(String in);
 
 	// Scheme
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	String getScheme();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	String getScheme(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setScheme(String scheme);
 
 	// BearerFormat
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	String getBearerFormat();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	String getBearerFormat(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setBearerFormat(String bearerFormat);
 
 	// ImplicitOAuthFlow
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	OAuthFlow getImplicitOAuthFlow();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	OAuthFlow getImplicitOAuthFlow(boolean elaborate);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setImplicitOAuthFlow(OAuthFlow implicitOAuthFlow);
 
 	// PasswordOAuthFlow
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	OAuthFlow getPasswordOAuthFlow();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	OAuthFlow getPasswordOAuthFlow(boolean elaborate);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setPasswordOAuthFlow(OAuthFlow passwordOAuthFlow);
 
 	// ClientCredentialsOAuthFlow
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	OAuthFlow getClientCredentialsOAuthFlow();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	OAuthFlow getClientCredentialsOAuthFlow(boolean elaborate);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setClientCredentialsOAuthFlow(OAuthFlow clientCredentialsOAuthFlow);
 
 	// AuthorizationCodeOAuthFlow
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	OAuthFlow getAuthorizationCodeOAuthFlow();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	OAuthFlow getAuthorizationCodeOAuthFlow(boolean elaborate);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setAuthorizationCodeOAuthFlow(OAuthFlow authorizationCodeOAuthFlow);
 
 	// OAuthFlowsExtension
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Map<String, Object> getOAuthFlowsExtensions();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Map<String, Object> getOAuthFlowsExtensions(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasOAuthFlowsExtension(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Object getOAuthFlowsExtension(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setOAuthFlowsExtensions(Map<String, Object> oAuthFlowsExtensions);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setOAuthFlowsExtension(String name, Object oAuthFlowsExtension);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeOAuthFlowsExtension(String name);
 
 	// OpenIdConnectUrl
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	String getOpenIdConnectUrl();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	String getOpenIdConnectUrl(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setOpenIdConnectUrl(String openIdConnectUrl);
 
 	// Extension
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Map<String, Object> getExtensions();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Map<String, Object> getExtensions(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasExtension(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Object getExtension(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setExtensions(Map<String, Object> extensions);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setExtension(String name, Object extension);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeExtension(String name);
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Server.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Server.java
@@ -10,88 +10,73 @@ import com.reprezen.jsonoverlay.IModelPart;
 public interface Server extends IJsonOverlay<Server>, IModelPart<OpenApi3, Server> {
 
 	// Url
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	String getUrl();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	String getUrl(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setUrl(String url);
 
 	// Description
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	String getDescription();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	String getDescription(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setDescription(String description);
 
 	// ServerVariable
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Map<String, ServerVariable> getServerVariables();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Map<String, ServerVariable> getServerVariables(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasServerVariable(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	ServerVariable getServerVariable(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setServerVariables(Map<String, ServerVariable> serverVariables);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setServerVariable(String name, ServerVariable serverVariable);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeServerVariable(String name);
 
 	// VariablesExtension
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Map<String, Object> getVariablesExtensions();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Map<String, Object> getVariablesExtensions(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasVariablesExtension(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Object getVariablesExtension(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setVariablesExtensions(Map<String, Object> variablesExtensions);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setVariablesExtension(String name, Object variablesExtension);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeVariablesExtension(String name);
 
 	// Extension
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Map<String, Object> getExtensions();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Map<String, Object> getExtensions(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasExtension(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Object getExtension(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setExtensions(Map<String, Object> extensions);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setExtension(String name, Object extension);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeExtension(String name);
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/ServerVariable.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/ServerVariable.java
@@ -11,72 +11,60 @@ import com.reprezen.jsonoverlay.IModelPart;
 public interface ServerVariable extends IJsonOverlay<ServerVariable>, IModelPart<OpenApi3, ServerVariable> {
 
 	// EnumValue
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Collection<Object> getEnumValues();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Collection<Object> getEnumValues(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasEnumValues();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Object getEnumValue(int index);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setEnumValues(Collection<Object> enumValues);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setEnumValue(int index, Object enumValue);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void addEnumValue(Object enumValue);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void insertEnumValue(int index, Object enumValue);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeEnumValue(int index);
 
 	// Default
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Object getDefault();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Object getDefault(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setDefault(Object defaultValue);
 
 	// Description
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	String getDescription();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	String getDescription(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setDescription(String description);
 
 	// Extension
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Map<String, Object> getExtensions();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Map<String, Object> getExtensions(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasExtension(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Object getExtension(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setExtensions(Map<String, Object> extensions);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setExtension(String name, Object extension);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeExtension(String name);
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Tag.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Tag.java
@@ -10,54 +10,45 @@ import com.reprezen.jsonoverlay.IModelPart;
 public interface Tag extends IJsonOverlay<Tag>, IModelPart<OpenApi3, Tag> {
 
 	// Name
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	String getName();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	String getName(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setName(String name);
 
 	// Description
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	String getDescription();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	String getDescription(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setDescription(String description);
 
 	// ExternalDocs
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	ExternalDocs getExternalDocs();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	ExternalDocs getExternalDocs(boolean elaborate);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setExternalDocs(ExternalDocs externalDocs);
 
 	// Extension
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Map<String, Object> getExtensions();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Map<String, Object> getExtensions(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasExtension(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Object getExtension(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setExtensions(Map<String, Object> extensions);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setExtension(String name, Object extension);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeExtension(String name);
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Xml.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/model3/Xml.java
@@ -10,80 +10,62 @@ import com.reprezen.jsonoverlay.IModelPart;
 public interface Xml extends IJsonOverlay<Xml>, IModelPart<OpenApi3, Xml> {
 
 	// Name
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	String getName();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	String getName(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setName(String name);
 
 	// Namespace
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	String getNamespace();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	String getNamespace(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setNamespace(String namespace);
 
 	// Prefix
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	String getPrefix();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	String getPrefix(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setPrefix(String prefix);
 
 	// Attribute
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Boolean getAttribute();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Boolean getAttribute(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean isAttribute();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setAttribute(Boolean attribute);
 
 	// Wrapped
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Boolean getWrapped();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Boolean getWrapped(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean isWrapped();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setWrapped(Boolean wrapped);
 
 	// Extension
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Map<String, Object> getExtensions();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
-	Map<String, Object> getExtensions(boolean elaborate);
-
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	boolean hasExtension(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	Object getExtension(String name);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setExtensions(Map<String, Object> extensions);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void setExtension(String name, Object extension);
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	void removeExtension(String name);
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/CallbackImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/CallbackImpl.java
@@ -17,117 +17,105 @@ import com.reprezen.kaizen.oasparser.model3.Path;
 
 public class CallbackImpl extends PropertiesOverlay<Callback> implements Callback {
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public CallbackImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
 		super(json, parent, refReg);
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public CallbackImpl(Callback callback, JsonOverlay<?> parent, ReferenceRegistry refReg) {
 		super(callback, parent, refReg);
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildMapOverlay<Path> callbackPaths;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildMapOverlay<Object> extensions;
 
 	// CallbackPath
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Map<String, Path> getCallbackPaths() {
 		return callbackPaths._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Map<String, Path> getCallbackPaths(boolean elaborate) {
-		return callbackPaths._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasCallbackPath(String expression) {
 		return callbackPaths.containsKey(expression);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Path getCallbackPath(String expression) {
 		return callbackPaths._get(expression);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setCallbackPaths(Map<String, Path> callbackPaths) {
 		this.callbackPaths._set(callbackPaths);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setCallbackPath(String expression, Path callbackPath) {
 		callbackPaths._set(expression, callbackPath);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeCallbackPath(String expression) {
 		callbackPaths._remove(expression);
 	}
 
 	// Extension
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Map<String, Object> getExtensions() {
 		return extensions._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Map<String, Object> getExtensions(boolean elaborate) {
-		return extensions._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasExtension(String name) {
 		return extensions.containsKey(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Object getExtension(String name) {
 		return extensions._get(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setExtensions(Map<String, Object> extensions) {
 		this.extensions._set(extensions);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setExtension(String name, Object extension) {
 		extensions._set(name, extension);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeExtension(String name) {
 		extensions._remove(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	protected void elaborateChildren() {
 		super.elaborateChildren();
 		callbackPaths = createChildMap("", this, PathImpl.factory, "(?!x-).*");
 		extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public static OverlayFactory<Callback> factory = new OverlayFactory<Callback>() {
 
 		@Override
@@ -154,12 +142,12 @@ public class CallbackImpl extends PropertiesOverlay<Callback> implements Callbac
 		}
 	};
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private static Class<? extends Callback> getSubtypeOf(Callback callback) {
 		return Callback.class;
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private static Class<? extends Callback> getSubtypeOf(JsonNode json) {
 		return Callback.class;
 	}

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ContactImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ContactImpl.java
@@ -18,130 +18,106 @@ import com.reprezen.kaizen.oasparser.model3.Contact;
 
 public class ContactImpl extends PropertiesOverlay<Contact> implements Contact {
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public ContactImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
 		super(json, parent, refReg);
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public ContactImpl(Contact contact, JsonOverlay<?> parent, ReferenceRegistry refReg) {
 		super(contact, parent, refReg);
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<String> name;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<String> url;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<String> email;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildMapOverlay<Object> extensions;
 
 	// Name
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public String getName() {
 		return name._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public String getName(boolean elaborate) {
-		return name._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setName(String name) {
 		this.name._set(name);
 	}
 
 	// Url
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public String getUrl() {
 		return url._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public String getUrl(boolean elaborate) {
-		return url._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setUrl(String url) {
 		this.url._set(url);
 	}
 
 	// Email
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public String getEmail() {
 		return email._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public String getEmail(boolean elaborate) {
-		return email._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setEmail(String email) {
 		this.email._set(email);
 	}
 
 	// Extension
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Map<String, Object> getExtensions() {
 		return extensions._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Map<String, Object> getExtensions(boolean elaborate) {
-		return extensions._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasExtension(String name) {
 		return extensions.containsKey(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Object getExtension(String name) {
 		return extensions._get(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setExtensions(Map<String, Object> extensions) {
 		this.extensions._set(extensions);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setExtension(String name, Object extension) {
 		extensions._set(name, extension);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeExtension(String name) {
 		extensions._remove(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	protected void elaborateChildren() {
 		super.elaborateChildren();
 		name = createChild("name", this, StringOverlay.factory);
@@ -150,7 +126,7 @@ public class ContactImpl extends PropertiesOverlay<Contact> implements Contact {
 		extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public static OverlayFactory<Contact> factory = new OverlayFactory<Contact>() {
 
 		@Override
@@ -177,12 +153,12 @@ public class ContactImpl extends PropertiesOverlay<Contact> implements Contact {
 		}
 	};
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private static Class<? extends Contact> getSubtypeOf(Contact contact) {
 		return Contact.class;
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private static Class<? extends Contact> getSubtypeOf(JsonNode json) {
 		return Contact.class;
 	}

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/EncodingPropertyImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/EncodingPropertyImpl.java
@@ -19,182 +19,152 @@ import com.reprezen.kaizen.oasparser.model3.EncodingProperty;
 
 public class EncodingPropertyImpl extends PropertiesOverlay<EncodingProperty> implements EncodingProperty {
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public EncodingPropertyImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
 		super(json, parent, refReg);
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public EncodingPropertyImpl(EncodingProperty encodingProperty, JsonOverlay<?> parent, ReferenceRegistry refReg) {
 		super(encodingProperty, parent, refReg);
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<String> contentType;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildMapOverlay<String> headers;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<String> style;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<Boolean> explode;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildMapOverlay<Object> extensions;
 
 	// ContentType
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public String getContentType() {
 		return contentType._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public String getContentType(boolean elaborate) {
-		return contentType._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setContentType(String contentType) {
 		this.contentType._set(contentType);
 	}
 
 	// Header
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Map<String, String> getHeaders() {
 		return headers._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Map<String, String> getHeaders(boolean elaborate) {
-		return headers._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasHeader(String name) {
 		return headers.containsKey(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public String getHeader(String name) {
 		return headers._get(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setHeaders(Map<String, String> headers) {
 		this.headers._set(headers);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setHeader(String name, String header) {
 		headers._set(name, header);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeHeader(String name) {
 		headers._remove(name);
 	}
 
 	// Style
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public String getStyle() {
 		return style._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public String getStyle(boolean elaborate) {
-		return style._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setStyle(String style) {
 		this.style._set(style);
 	}
 
 	// Explode
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Boolean getExplode() {
 		return explode._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Boolean getExplode(boolean elaborate) {
-		return explode._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean isExplode() {
 		return explode._get() != null ? explode._get() : false;
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setExplode(Boolean explode) {
 		this.explode._set(explode);
 	}
 
 	// Extension
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Map<String, Object> getExtensions() {
 		return extensions._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Map<String, Object> getExtensions(boolean elaborate) {
-		return extensions._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasExtension(String name) {
 		return extensions.containsKey(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Object getExtension(String name) {
 		return extensions._get(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setExtensions(Map<String, Object> extensions) {
 		this.extensions._set(extensions);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setExtension(String name, Object extension) {
 		extensions._set(name, extension);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeExtension(String name) {
 		extensions._remove(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	protected void elaborateChildren() {
 		super.elaborateChildren();
 		contentType = createChild("contentType", this, StringOverlay.factory);
@@ -204,7 +174,7 @@ public class EncodingPropertyImpl extends PropertiesOverlay<EncodingProperty> im
 		extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public static OverlayFactory<EncodingProperty> factory = new OverlayFactory<EncodingProperty>() {
 
 		@Override
@@ -232,12 +202,12 @@ public class EncodingPropertyImpl extends PropertiesOverlay<EncodingProperty> im
 		}
 	};
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private static Class<? extends EncodingProperty> getSubtypeOf(EncodingProperty encodingProperty) {
 		return EncodingProperty.class;
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private static Class<? extends EncodingProperty> getSubtypeOf(JsonNode json) {
 		return EncodingProperty.class;
 	}

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ExampleImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ExampleImpl.java
@@ -18,152 +18,122 @@ import com.reprezen.kaizen.oasparser.model3.Example;
 
 public class ExampleImpl extends PropertiesOverlay<Example> implements Example {
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public ExampleImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
 		super(json, parent, refReg);
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public ExampleImpl(Example example, JsonOverlay<?> parent, ReferenceRegistry refReg) {
 		super(example, parent, refReg);
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<String> summary;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<String> description;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<Object> value;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<String> externalValue;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildMapOverlay<Object> extensions;
 
 	// Summary
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public String getSummary() {
 		return summary._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public String getSummary(boolean elaborate) {
-		return summary._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setSummary(String summary) {
 		this.summary._set(summary);
 	}
 
 	// Description
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public String getDescription() {
 		return description._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public String getDescription(boolean elaborate) {
-		return description._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setDescription(String description) {
 		this.description._set(description);
 	}
 
 	// Value
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Object getValue() {
 		return value._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Object getValue(boolean elaborate) {
-		return value._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setValue(Object value) {
 		this.value._set(value);
 	}
 
 	// ExternalValue
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public String getExternalValue() {
 		return externalValue._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public String getExternalValue(boolean elaborate) {
-		return externalValue._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setExternalValue(String externalValue) {
 		this.externalValue._set(externalValue);
 	}
 
 	// Extension
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Map<String, Object> getExtensions() {
 		return extensions._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Map<String, Object> getExtensions(boolean elaborate) {
-		return extensions._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasExtension(String name) {
 		return extensions.containsKey(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Object getExtension(String name) {
 		return extensions._get(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setExtensions(Map<String, Object> extensions) {
 		this.extensions._set(extensions);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setExtension(String name, Object extension) {
 		extensions._set(name, extension);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeExtension(String name) {
 		extensions._remove(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	protected void elaborateChildren() {
 		super.elaborateChildren();
 		summary = createChild("summary", this, StringOverlay.factory);
@@ -173,7 +143,7 @@ public class ExampleImpl extends PropertiesOverlay<Example> implements Example {
 		extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public static OverlayFactory<Example> factory = new OverlayFactory<Example>() {
 
 		@Override
@@ -200,12 +170,12 @@ public class ExampleImpl extends PropertiesOverlay<Example> implements Example {
 		}
 	};
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private static Class<? extends Example> getSubtypeOf(Example example) {
 		return Example.class;
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private static Class<? extends Example> getSubtypeOf(JsonNode json) {
 		return Example.class;
 	}

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ExternalDocsImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ExternalDocsImpl.java
@@ -18,108 +18,90 @@ import com.reprezen.kaizen.oasparser.model3.ExternalDocs;
 
 public class ExternalDocsImpl extends PropertiesOverlay<ExternalDocs> implements ExternalDocs {
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public ExternalDocsImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
 		super(json, parent, refReg);
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public ExternalDocsImpl(ExternalDocs externalDocs, JsonOverlay<?> parent, ReferenceRegistry refReg) {
 		super(externalDocs, parent, refReg);
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<String> description;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<String> url;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildMapOverlay<Object> extensions;
 
 	// Description
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public String getDescription() {
 		return description._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public String getDescription(boolean elaborate) {
-		return description._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setDescription(String description) {
 		this.description._set(description);
 	}
 
 	// Url
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public String getUrl() {
 		return url._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public String getUrl(boolean elaborate) {
-		return url._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setUrl(String url) {
 		this.url._set(url);
 	}
 
 	// Extension
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Map<String, Object> getExtensions() {
 		return extensions._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Map<String, Object> getExtensions(boolean elaborate) {
-		return extensions._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasExtension(String name) {
 		return extensions.containsKey(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Object getExtension(String name) {
 		return extensions._get(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setExtensions(Map<String, Object> extensions) {
 		this.extensions._set(extensions);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setExtension(String name, Object extension) {
 		extensions._set(name, extension);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeExtension(String name) {
 		extensions._remove(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	protected void elaborateChildren() {
 		super.elaborateChildren();
 		description = createChild("description", this, StringOverlay.factory);
@@ -127,7 +109,7 @@ public class ExternalDocsImpl extends PropertiesOverlay<ExternalDocs> implements
 		extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public static OverlayFactory<ExternalDocs> factory = new OverlayFactory<ExternalDocs>() {
 
 		@Override
@@ -155,12 +137,12 @@ public class ExternalDocsImpl extends PropertiesOverlay<ExternalDocs> implements
 		}
 	};
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private static Class<? extends ExternalDocs> getSubtypeOf(ExternalDocs externalDocs) {
 		return ExternalDocs.class;
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private static Class<? extends ExternalDocs> getSubtypeOf(JsonNode json) {
 		return ExternalDocs.class;
 	}

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/HeaderImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/HeaderImpl.java
@@ -22,428 +22,350 @@ import com.reprezen.kaizen.oasparser.model3.Schema;
 
 public class HeaderImpl extends PropertiesOverlay<Header> implements Header {
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public HeaderImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
 		super(json, parent, refReg);
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public HeaderImpl(Header header, JsonOverlay<?> parent, ReferenceRegistry refReg) {
 		super(header, parent, refReg);
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<String> name;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<String> in;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<String> description;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<Boolean> required;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<Boolean> deprecated;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<Boolean> allowEmptyValue;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<String> style;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<Boolean> explode;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<Boolean> allowReserved;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<Schema> schema;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<Object> example;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildMapOverlay<Example> examples;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildMapOverlay<MediaType> contentMediaTypes;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildMapOverlay<Object> extensions;
 
 	// Name
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public String getName() {
 		return name._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public String getName(boolean elaborate) {
-		return name._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setName(String name) {
 		this.name._set(name);
 	}
 
 	// In
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public String getIn() {
 		return in._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public String getIn(boolean elaborate) {
-		return in._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setIn(String in) {
 		this.in._set(in);
 	}
 
 	// Description
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public String getDescription() {
 		return description._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public String getDescription(boolean elaborate) {
-		return description._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setDescription(String description) {
 		this.description._set(description);
 	}
 
 	// Required
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Boolean getRequired() {
 		return required._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Boolean getRequired(boolean elaborate) {
-		return required._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean isRequired() {
 		return required._get() != null ? required._get() : false;
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setRequired(Boolean required) {
 		this.required._set(required);
 	}
 
 	// Deprecated
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Boolean getDeprecated() {
 		return deprecated._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Boolean getDeprecated(boolean elaborate) {
-		return deprecated._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean isDeprecated() {
 		return deprecated._get() != null ? deprecated._get() : false;
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setDeprecated(Boolean deprecated) {
 		this.deprecated._set(deprecated);
 	}
 
 	// AllowEmptyValue
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Boolean getAllowEmptyValue() {
 		return allowEmptyValue._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Boolean getAllowEmptyValue(boolean elaborate) {
-		return allowEmptyValue._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean isAllowEmptyValue() {
 		return allowEmptyValue._get() != null ? allowEmptyValue._get() : false;
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setAllowEmptyValue(Boolean allowEmptyValue) {
 		this.allowEmptyValue._set(allowEmptyValue);
 	}
 
 	// Style
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public String getStyle() {
 		return style._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public String getStyle(boolean elaborate) {
-		return style._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setStyle(String style) {
 		this.style._set(style);
 	}
 
 	// Explode
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Boolean getExplode() {
 		return explode._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Boolean getExplode(boolean elaborate) {
-		return explode._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean isExplode() {
 		return explode._get() != null ? explode._get() : false;
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setExplode(Boolean explode) {
 		this.explode._set(explode);
 	}
 
 	// AllowReserved
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Boolean getAllowReserved() {
 		return allowReserved._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Boolean getAllowReserved(boolean elaborate) {
-		return allowReserved._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean isAllowReserved() {
 		return allowReserved._get() != null ? allowReserved._get() : false;
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setAllowReserved(Boolean allowReserved) {
 		this.allowReserved._set(allowReserved);
 	}
 
 	// Schema
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Schema getSchema() {
 		return schema._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Schema getSchema(boolean elaborate) {
 		return schema._get(elaborate);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setSchema(Schema schema) {
 		this.schema._set(schema);
 	}
 
 	// Example
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Object getExample() {
 		return example._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Object getExample(boolean elaborate) {
-		return example._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setExample(Object example) {
 		this.example._set(example);
 	}
 
 	// Example
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Map<String, Example> getExamples() {
 		return examples._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Map<String, Example> getExamples(boolean elaborate) {
-		return examples._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasExample(String name) {
 		return examples.containsKey(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Example getExample(String name) {
 		return examples._get(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setExamples(Map<String, Example> examples) {
 		this.examples._set(examples);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setExample(String name, Example example) {
 		examples._set(name, example);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeExample(String name) {
 		examples._remove(name);
 	}
 
 	// ContentMediaType
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Map<String, MediaType> getContentMediaTypes() {
 		return contentMediaTypes._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Map<String, MediaType> getContentMediaTypes(boolean elaborate) {
-		return contentMediaTypes._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasContentMediaType(String name) {
 		return contentMediaTypes.containsKey(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public MediaType getContentMediaType(String name) {
 		return contentMediaTypes._get(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setContentMediaTypes(Map<String, MediaType> contentMediaTypes) {
 		this.contentMediaTypes._set(contentMediaTypes);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setContentMediaType(String name, MediaType contentMediaType) {
 		contentMediaTypes._set(name, contentMediaType);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeContentMediaType(String name) {
 		contentMediaTypes._remove(name);
 	}
 
 	// Extension
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Map<String, Object> getExtensions() {
 		return extensions._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Map<String, Object> getExtensions(boolean elaborate) {
-		return extensions._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasExtension(String name) {
 		return extensions.containsKey(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Object getExtension(String name) {
 		return extensions._get(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setExtensions(Map<String, Object> extensions) {
 		this.extensions._set(extensions);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setExtension(String name, Object extension) {
 		extensions._set(name, extension);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeExtension(String name) {
 		extensions._remove(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	protected void elaborateChildren() {
 		super.elaborateChildren();
 		name = createChild("name", this, StringOverlay.factory);
@@ -462,7 +384,7 @@ public class HeaderImpl extends PropertiesOverlay<Header> implements Header {
 		extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public static OverlayFactory<Header> factory = new OverlayFactory<Header>() {
 
 		@Override
@@ -489,12 +411,12 @@ public class HeaderImpl extends PropertiesOverlay<Header> implements Header {
 		}
 	};
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private static Class<? extends Header> getSubtypeOf(Header header) {
 		return Header.class;
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private static Class<? extends Header> getSubtypeOf(JsonNode json) {
 		return Header.class;
 	}

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/InfoImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/InfoImpl.java
@@ -20,196 +20,166 @@ import com.reprezen.kaizen.oasparser.model3.License;
 
 public class InfoImpl extends PropertiesOverlay<Info> implements Info {
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public InfoImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
 		super(json, parent, refReg);
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public InfoImpl(Info info, JsonOverlay<?> parent, ReferenceRegistry refReg) {
 		super(info, parent, refReg);
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<String> title;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<String> description;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<String> termsOfService;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<Contact> contact;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<License> license;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<String> version;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildMapOverlay<Object> extensions;
 
 	// Title
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public String getTitle() {
 		return title._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public String getTitle(boolean elaborate) {
-		return title._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setTitle(String title) {
 		this.title._set(title);
 	}
 
 	// Description
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public String getDescription() {
 		return description._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public String getDescription(boolean elaborate) {
-		return description._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setDescription(String description) {
 		this.description._set(description);
 	}
 
 	// TermsOfService
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public String getTermsOfService() {
 		return termsOfService._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public String getTermsOfService(boolean elaborate) {
-		return termsOfService._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setTermsOfService(String termsOfService) {
 		this.termsOfService._set(termsOfService);
 	}
 
 	// Contact
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Contact getContact() {
 		return contact._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Contact getContact(boolean elaborate) {
 		return contact._get(elaborate);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setContact(Contact contact) {
 		this.contact._set(contact);
 	}
 
 	// License
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public License getLicense() {
 		return license._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public License getLicense(boolean elaborate) {
 		return license._get(elaborate);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setLicense(License license) {
 		this.license._set(license);
 	}
 
 	// Version
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public String getVersion() {
 		return version._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public String getVersion(boolean elaborate) {
-		return version._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setVersion(String version) {
 		this.version._set(version);
 	}
 
 	// Extension
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Map<String, Object> getExtensions() {
 		return extensions._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Map<String, Object> getExtensions(boolean elaborate) {
-		return extensions._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasExtension(String name) {
 		return extensions.containsKey(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Object getExtension(String name) {
 		return extensions._get(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setExtensions(Map<String, Object> extensions) {
 		this.extensions._set(extensions);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setExtension(String name, Object extension) {
 		extensions._set(name, extension);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeExtension(String name) {
 		extensions._remove(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	protected void elaborateChildren() {
 		super.elaborateChildren();
 		title = createChild("title", this, StringOverlay.factory);
@@ -221,7 +191,7 @@ public class InfoImpl extends PropertiesOverlay<Info> implements Info {
 		extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public static OverlayFactory<Info> factory = new OverlayFactory<Info>() {
 
 		@Override
@@ -248,12 +218,12 @@ public class InfoImpl extends PropertiesOverlay<Info> implements Info {
 		}
 	};
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private static Class<? extends Info> getSubtypeOf(Info info) {
 		return Info.class;
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private static Class<? extends Info> getSubtypeOf(JsonNode json) {
 		return Info.class;
 	}

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/LicenseImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/LicenseImpl.java
@@ -20,108 +20,90 @@ public class LicenseImpl extends PropertiesOverlay<License> implements License {
 
 	JsonNode initJson = jsonMissing();
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public LicenseImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
 		super(json, parent, refReg);
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public LicenseImpl(License license, JsonOverlay<?> parent, ReferenceRegistry refReg) {
 		super(license, parent, refReg);
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<String> name;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<String> url;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildMapOverlay<Object> extensions;
 
 	// Name
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public String getName() {
 		return name._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public String getName(boolean elaborate) {
-		return name._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setName(String name) {
 		this.name._set(name);
 	}
 
 	// Url
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public String getUrl() {
 		return url._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public String getUrl(boolean elaborate) {
-		return url._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setUrl(String url) {
 		this.url._set(url);
 	}
 
 	// Extension
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Map<String, Object> getExtensions() {
 		return extensions._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Map<String, Object> getExtensions(boolean elaborate) {
-		return extensions._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasExtension(String name) {
 		return extensions.containsKey(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Object getExtension(String name) {
 		return extensions._get(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setExtensions(Map<String, Object> extensions) {
 		this.extensions._set(extensions);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setExtension(String name, Object extension) {
 		extensions._set(name, extension);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeExtension(String name) {
 		extensions._remove(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	protected void elaborateChildren() {
 		super.elaborateChildren();
 		name = createChild("name", this, StringOverlay.factory);
@@ -129,7 +111,7 @@ public class LicenseImpl extends PropertiesOverlay<License> implements License {
 		extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public static OverlayFactory<License> factory = new OverlayFactory<License>() {
 
 		@Override
@@ -156,12 +138,12 @@ public class LicenseImpl extends PropertiesOverlay<License> implements License {
 		}
 	};
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private static Class<? extends License> getSubtypeOf(License license) {
 		return License.class;
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private static Class<? extends License> getSubtypeOf(JsonNode json) {
 		return License.class;
 	}

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/LinkImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/LinkImpl.java
@@ -20,244 +20,208 @@ import com.reprezen.kaizen.oasparser.model3.Server;
 
 public class LinkImpl extends PropertiesOverlay<Link> implements Link {
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public LinkImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
 		super(json, parent, refReg);
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public LinkImpl(Link link, JsonOverlay<?> parent, ReferenceRegistry refReg) {
 		super(link, parent, refReg);
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<String> operationId;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<String> operationRef;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildMapOverlay<String> parameters;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildMapOverlay<Header> headers;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<String> description;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<Server> server;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildMapOverlay<Object> extensions;
 
 	// OperationId
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public String getOperationId() {
 		return operationId._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public String getOperationId(boolean elaborate) {
-		return operationId._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setOperationId(String operationId) {
 		this.operationId._set(operationId);
 	}
 
 	// OperationRef
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public String getOperationRef() {
 		return operationRef._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public String getOperationRef(boolean elaborate) {
-		return operationRef._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setOperationRef(String operationRef) {
 		this.operationRef._set(operationRef);
 	}
 
 	// Parameter
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Map<String, String> getParameters() {
 		return parameters._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Map<String, String> getParameters(boolean elaborate) {
-		return parameters._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasParameter(String name) {
 		return parameters.containsKey(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public String getParameter(String name) {
 		return parameters._get(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setParameters(Map<String, String> parameters) {
 		this.parameters._set(parameters);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setParameter(String name, String parameter) {
 		parameters._set(name, parameter);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeParameter(String name) {
 		parameters._remove(name);
 	}
 
 	// Header
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Map<String, Header> getHeaders() {
 		return headers._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Map<String, Header> getHeaders(boolean elaborate) {
-		return headers._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasHeader(String name) {
 		return headers.containsKey(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Header getHeader(String name) {
 		return headers._get(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setHeaders(Map<String, Header> headers) {
 		this.headers._set(headers);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setHeader(String name, Header header) {
 		headers._set(name, header);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeHeader(String name) {
 		headers._remove(name);
 	}
 
 	// Description
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public String getDescription() {
 		return description._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public String getDescription(boolean elaborate) {
-		return description._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setDescription(String description) {
 		this.description._set(description);
 	}
 
 	// Server
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Server getServer() {
 		return server._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Server getServer(boolean elaborate) {
 		return server._get(elaborate);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setServer(Server server) {
 		this.server._set(server);
 	}
 
 	// Extension
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Map<String, Object> getExtensions() {
 		return extensions._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Map<String, Object> getExtensions(boolean elaborate) {
-		return extensions._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasExtension(String name) {
 		return extensions.containsKey(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Object getExtension(String name) {
 		return extensions._get(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setExtensions(Map<String, Object> extensions) {
 		this.extensions._set(extensions);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setExtension(String name, Object extension) {
 		extensions._set(name, extension);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeExtension(String name) {
 		extensions._remove(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	protected void elaborateChildren() {
 		super.elaborateChildren();
 		operationId = createChild("operationId", this, StringOverlay.factory);
@@ -269,7 +233,7 @@ public class LinkImpl extends PropertiesOverlay<Link> implements Link {
 		extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public static OverlayFactory<Link> factory = new OverlayFactory<Link>() {
 
 		@Override
@@ -296,12 +260,12 @@ public class LinkImpl extends PropertiesOverlay<Link> implements Link {
 		}
 	};
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private static Class<? extends Link> getSubtypeOf(Link link) {
 		return Link.class;
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private static Class<? extends Link> getSubtypeOf(JsonNode json) {
 		return Link.class;
 	}

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/MediaTypeImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/MediaTypeImpl.java
@@ -20,200 +20,176 @@ import com.reprezen.kaizen.oasparser.model3.Schema;
 
 public class MediaTypeImpl extends PropertiesOverlay<MediaType> implements MediaType {
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public MediaTypeImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
 		super(json, parent, refReg);
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public MediaTypeImpl(MediaType mediaType, JsonOverlay<?> parent, ReferenceRegistry refReg) {
 		super(mediaType, parent, refReg);
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<Schema> schema;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildMapOverlay<Example> examples;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<Object> example;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildMapOverlay<EncodingProperty> encodingProperties;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildMapOverlay<Object> extensions;
 
 	// Schema
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Schema getSchema() {
 		return schema._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Schema getSchema(boolean elaborate) {
 		return schema._get(elaborate);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setSchema(Schema schema) {
 		this.schema._set(schema);
 	}
 
 	// Example
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Map<String, Example> getExamples() {
 		return examples._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Map<String, Example> getExamples(boolean elaborate) {
-		return examples._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasExample(String name) {
 		return examples.containsKey(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Example getExample(String name) {
 		return examples._get(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setExamples(Map<String, Example> examples) {
 		this.examples._set(examples);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setExample(String name, Example example) {
 		examples._set(name, example);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeExample(String name) {
 		examples._remove(name);
 	}
 
 	// Example
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Object getExample() {
 		return example._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Object getExample(boolean elaborate) {
-		return example._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setExample(Object example) {
 		this.example._set(example);
 	}
 
 	// EncodingProperty
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Map<String, EncodingProperty> getEncodingProperties() {
 		return encodingProperties._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Map<String, EncodingProperty> getEncodingProperties(boolean elaborate) {
-		return encodingProperties._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasEncodingProperty(String name) {
 		return encodingProperties.containsKey(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public EncodingProperty getEncodingProperty(String name) {
 		return encodingProperties._get(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setEncodingProperties(Map<String, EncodingProperty> encodingProperties) {
 		this.encodingProperties._set(encodingProperties);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setEncodingProperty(String name, EncodingProperty encodingProperty) {
 		encodingProperties._set(name, encodingProperty);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeEncodingProperty(String name) {
 		encodingProperties._remove(name);
 	}
 
 	// Extension
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Map<String, Object> getExtensions() {
 		return extensions._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Map<String, Object> getExtensions(boolean elaborate) {
-		return extensions._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasExtension(String name) {
 		return extensions.containsKey(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Object getExtension(String name) {
 		return extensions._get(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setExtensions(Map<String, Object> extensions) {
 		this.extensions._set(extensions);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setExtension(String name, Object extension) {
 		extensions._set(name, extension);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeExtension(String name) {
 		extensions._remove(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	protected void elaborateChildren() {
 		super.elaborateChildren();
 		schema = createChild("schema", this, SchemaImpl.factory);
@@ -223,7 +199,7 @@ public class MediaTypeImpl extends PropertiesOverlay<MediaType> implements Media
 		extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public static OverlayFactory<MediaType> factory = new OverlayFactory<MediaType>() {
 
 		@Override
@@ -250,12 +226,12 @@ public class MediaTypeImpl extends PropertiesOverlay<MediaType> implements Media
 		}
 	};
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private static Class<? extends MediaType> getSubtypeOf(MediaType mediaType) {
 		return MediaType.class;
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private static Class<? extends MediaType> getSubtypeOf(JsonNode json) {
 		return MediaType.class;
 	}

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/OAuthFlowImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/OAuthFlowImpl.java
@@ -18,222 +18,186 @@ import com.reprezen.kaizen.oasparser.model3.OAuthFlow;
 
 public class OAuthFlowImpl extends PropertiesOverlay<OAuthFlow> implements OAuthFlow {
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public OAuthFlowImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
 		super(json, parent, refReg);
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public OAuthFlowImpl(OAuthFlow oAuthFlow, JsonOverlay<?> parent, ReferenceRegistry refReg) {
 		super(oAuthFlow, parent, refReg);
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<String> authorizationUrl;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<String> tokenUrl;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<String> refreshUrl;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildMapOverlay<String> scopes;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildMapOverlay<Object> scopesExtensions;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildMapOverlay<Object> extensions;
 
 	// AuthorizationUrl
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public String getAuthorizationUrl() {
 		return authorizationUrl._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public String getAuthorizationUrl(boolean elaborate) {
-		return authorizationUrl._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setAuthorizationUrl(String authorizationUrl) {
 		this.authorizationUrl._set(authorizationUrl);
 	}
 
 	// TokenUrl
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public String getTokenUrl() {
 		return tokenUrl._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public String getTokenUrl(boolean elaborate) {
-		return tokenUrl._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setTokenUrl(String tokenUrl) {
 		this.tokenUrl._set(tokenUrl);
 	}
 
 	// RefreshUrl
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public String getRefreshUrl() {
 		return refreshUrl._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public String getRefreshUrl(boolean elaborate) {
-		return refreshUrl._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setRefreshUrl(String refreshUrl) {
 		this.refreshUrl._set(refreshUrl);
 	}
 
 	// Scope
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Map<String, String> getScopes() {
 		return scopes._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Map<String, String> getScopes(boolean elaborate) {
-		return scopes._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasScope(String name) {
 		return scopes.containsKey(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public String getScope(String name) {
 		return scopes._get(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setScopes(Map<String, String> scopes) {
 		this.scopes._set(scopes);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setScope(String name, String scope) {
 		scopes._set(name, scope);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeScope(String name) {
 		scopes._remove(name);
 	}
 
 	// ScopesExtension
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Map<String, Object> getScopesExtensions() {
 		return scopesExtensions._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Map<String, Object> getScopesExtensions(boolean elaborate) {
-		return scopesExtensions._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasScopesExtension(String name) {
 		return scopesExtensions.containsKey(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Object getScopesExtension(String name) {
 		return scopesExtensions._get(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setScopesExtensions(Map<String, Object> scopesExtensions) {
 		this.scopesExtensions._set(scopesExtensions);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setScopesExtension(String name, Object scopesExtension) {
 		scopesExtensions._set(name, scopesExtension);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeScopesExtension(String name) {
 		scopesExtensions._remove(name);
 	}
 
 	// Extension
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Map<String, Object> getExtensions() {
 		return extensions._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Map<String, Object> getExtensions(boolean elaborate) {
-		return extensions._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasExtension(String name) {
 		return extensions.containsKey(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Object getExtension(String name) {
 		return extensions._get(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setExtensions(Map<String, Object> extensions) {
 		this.extensions._set(extensions);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setExtension(String name, Object extension) {
 		extensions._set(name, extension);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeExtension(String name) {
 		extensions._remove(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	protected void elaborateChildren() {
 		super.elaborateChildren();
 		authorizationUrl = createChild("authorizationUrl", this, StringOverlay.factory);
@@ -244,7 +208,7 @@ public class OAuthFlowImpl extends PropertiesOverlay<OAuthFlow> implements OAuth
 		extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public static OverlayFactory<OAuthFlow> factory = new OverlayFactory<OAuthFlow>() {
 
 		@Override
@@ -271,12 +235,12 @@ public class OAuthFlowImpl extends PropertiesOverlay<OAuthFlow> implements OAuth
 		}
 	};
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private static Class<? extends OAuthFlow> getSubtypeOf(OAuthFlow oAuthFlow) {
 		return OAuthFlow.class;
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private static Class<? extends OAuthFlow> getSubtypeOf(JsonNode json) {
 		return OAuthFlow.class;
 	}

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/OpenApi3Impl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/OpenApi3Impl.java
@@ -82,856 +82,754 @@ public class OpenApi3Impl extends PropertiesOverlay<OpenApi3> implements OpenApi
 		return getValidationResults().getItems();
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public OpenApi3Impl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
 		super(json, parent, refReg);
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public OpenApi3Impl(OpenApi3 openApi3, JsonOverlay<?> parent, ReferenceRegistry refReg) {
 		super(openApi3, parent, refReg);
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<String> openApi;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<Info> info;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildListOverlay<Server> servers;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildMapOverlay<Path> paths;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildMapOverlay<Object> pathsExtensions;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildMapOverlay<Schema> schemas;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildMapOverlay<Response> responses;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildMapOverlay<Parameter> parameters;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildMapOverlay<Example> examples;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildMapOverlay<RequestBody> requestBodies;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildMapOverlay<Header> headers;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildMapOverlay<SecurityScheme> securitySchemes;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildMapOverlay<Link> links;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildMapOverlay<Callback> callbacks;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildMapOverlay<Object> componentsExtensions;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildListOverlay<SecurityRequirement> securityRequirements;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildListOverlay<Tag> tags;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<ExternalDocs> externalDocs;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildMapOverlay<Object> extensions;
 
 	// OpenApi
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public String getOpenApi() {
 		return openApi._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public String getOpenApi(boolean elaborate) {
-		return openApi._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setOpenApi(String openApi) {
 		this.openApi._set(openApi);
 	}
 
 	// Info
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Info getInfo() {
 		return info._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Info getInfo(boolean elaborate) {
 		return info._get(elaborate);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setInfo(Info info) {
 		this.info._set(info);
 	}
 
 	// Server
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Collection<Server> getServers() {
 		return servers._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Collection<Server> getServers(boolean elaborate) {
-		return servers._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasServers() {
 		return servers._isPresent();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Server getServer(int index) {
 		return servers._get(index);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setServers(Collection<Server> servers) {
 		this.servers._set(servers);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setServer(int index, Server server) {
 		servers._set(index, server);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void addServer(Server server) {
 		servers._add(server);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void insertServer(int index, Server server) {
 		servers._insert(index, server);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeServer(int index) {
 		servers._remove(index);
 	}
 
 	// Path
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Map<String, Path> getPaths() {
 		return paths._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Map<String, Path> getPaths(boolean elaborate) {
-		return paths._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasPath(String name) {
 		return paths.containsKey(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Path getPath(String name) {
 		return paths._get(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setPaths(Map<String, Path> paths) {
 		this.paths._set(paths);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setPath(String name, Path path) {
 		paths._set(name, path);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removePath(String name) {
 		paths._remove(name);
 	}
 
 	// PathsExtension
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Map<String, Object> getPathsExtensions() {
 		return pathsExtensions._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Map<String, Object> getPathsExtensions(boolean elaborate) {
-		return pathsExtensions._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasPathsExtension(String name) {
 		return pathsExtensions.containsKey(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Object getPathsExtension(String name) {
 		return pathsExtensions._get(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setPathsExtensions(Map<String, Object> pathsExtensions) {
 		this.pathsExtensions._set(pathsExtensions);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setPathsExtension(String name, Object pathsExtension) {
 		pathsExtensions._set(name, pathsExtension);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removePathsExtension(String name) {
 		pathsExtensions._remove(name);
 	}
 
 	// Schema
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Map<String, Schema> getSchemas() {
 		return schemas._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Map<String, Schema> getSchemas(boolean elaborate) {
-		return schemas._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasSchema(String name) {
 		return schemas.containsKey(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Schema getSchema(String name) {
 		return schemas._get(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setSchemas(Map<String, Schema> schemas) {
 		this.schemas._set(schemas);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setSchema(String name, Schema schema) {
 		schemas._set(name, schema);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeSchema(String name) {
 		schemas._remove(name);
 	}
 
 	// Response
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Map<String, Response> getResponses() {
 		return responses._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Map<String, Response> getResponses(boolean elaborate) {
-		return responses._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasResponse(String name) {
 		return responses.containsKey(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Response getResponse(String name) {
 		return responses._get(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setResponses(Map<String, Response> responses) {
 		this.responses._set(responses);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setResponse(String name, Response response) {
 		responses._set(name, response);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeResponse(String name) {
 		responses._remove(name);
 	}
 
 	// Parameter
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Map<String, Parameter> getParameters() {
 		return parameters._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Map<String, Parameter> getParameters(boolean elaborate) {
-		return parameters._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasParameter(String name) {
 		return parameters.containsKey(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Parameter getParameter(String name) {
 		return parameters._get(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setParameters(Map<String, Parameter> parameters) {
 		this.parameters._set(parameters);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setParameter(String name, Parameter parameter) {
 		parameters._set(name, parameter);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeParameter(String name) {
 		parameters._remove(name);
 	}
 
 	// Example
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Map<String, Example> getExamples() {
 		return examples._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Map<String, Example> getExamples(boolean elaborate) {
-		return examples._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasExample(String name) {
 		return examples.containsKey(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Example getExample(String name) {
 		return examples._get(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setExamples(Map<String, Example> examples) {
 		this.examples._set(examples);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setExample(String name, Example example) {
 		examples._set(name, example);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeExample(String name) {
 		examples._remove(name);
 	}
 
 	// RequestBody
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Map<String, RequestBody> getRequestBodies() {
 		return requestBodies._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Map<String, RequestBody> getRequestBodies(boolean elaborate) {
-		return requestBodies._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasRequestBody(String name) {
 		return requestBodies.containsKey(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public RequestBody getRequestBody(String name) {
 		return requestBodies._get(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setRequestBodies(Map<String, RequestBody> requestBodies) {
 		this.requestBodies._set(requestBodies);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setRequestBody(String name, RequestBody requestBody) {
 		requestBodies._set(name, requestBody);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeRequestBody(String name) {
 		requestBodies._remove(name);
 	}
 
 	// Header
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Map<String, Header> getHeaders() {
 		return headers._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Map<String, Header> getHeaders(boolean elaborate) {
-		return headers._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasHeader(String name) {
 		return headers.containsKey(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Header getHeader(String name) {
 		return headers._get(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setHeaders(Map<String, Header> headers) {
 		this.headers._set(headers);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setHeader(String name, Header header) {
 		headers._set(name, header);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeHeader(String name) {
 		headers._remove(name);
 	}
 
 	// SecurityScheme
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Map<String, SecurityScheme> getSecuritySchemes() {
 		return securitySchemes._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Map<String, SecurityScheme> getSecuritySchemes(boolean elaborate) {
-		return securitySchemes._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasSecurityScheme(String name) {
 		return securitySchemes.containsKey(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public SecurityScheme getSecurityScheme(String name) {
 		return securitySchemes._get(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setSecuritySchemes(Map<String, SecurityScheme> securitySchemes) {
 		this.securitySchemes._set(securitySchemes);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setSecurityScheme(String name, SecurityScheme securityScheme) {
 		securitySchemes._set(name, securityScheme);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeSecurityScheme(String name) {
 		securitySchemes._remove(name);
 	}
 
 	// Link
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Map<String, Link> getLinks() {
 		return links._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Map<String, Link> getLinks(boolean elaborate) {
-		return links._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasLink(String name) {
 		return links.containsKey(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Link getLink(String name) {
 		return links._get(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setLinks(Map<String, Link> links) {
 		this.links._set(links);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setLink(String name, Link link) {
 		links._set(name, link);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeLink(String name) {
 		links._remove(name);
 	}
 
 	// Callback
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Map<String, Callback> getCallbacks() {
 		return callbacks._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Map<String, Callback> getCallbacks(boolean elaborate) {
-		return callbacks._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasCallback(String name) {
 		return callbacks.containsKey(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Callback getCallback(String name) {
 		return callbacks._get(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setCallbacks(Map<String, Callback> callbacks) {
 		this.callbacks._set(callbacks);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setCallback(String name, Callback callback) {
 		callbacks._set(name, callback);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeCallback(String name) {
 		callbacks._remove(name);
 	}
 
 	// ComponentsExtension
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Map<String, Object> getComponentsExtensions() {
 		return componentsExtensions._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Map<String, Object> getComponentsExtensions(boolean elaborate) {
-		return componentsExtensions._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasComponentsExtension(String name) {
 		return componentsExtensions.containsKey(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Object getComponentsExtension(String name) {
 		return componentsExtensions._get(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setComponentsExtensions(Map<String, Object> componentsExtensions) {
 		this.componentsExtensions._set(componentsExtensions);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setComponentsExtension(String name, Object componentsExtension) {
 		componentsExtensions._set(name, componentsExtension);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeComponentsExtension(String name) {
 		componentsExtensions._remove(name);
 	}
 
 	// SecurityRequirement
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Collection<SecurityRequirement> getSecurityRequirements() {
 		return securityRequirements._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Collection<SecurityRequirement> getSecurityRequirements(boolean elaborate) {
-		return securityRequirements._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasSecurityRequirements() {
 		return securityRequirements._isPresent();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public SecurityRequirement getSecurityRequirement(int index) {
 		return securityRequirements._get(index);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setSecurityRequirements(Collection<SecurityRequirement> securityRequirements) {
 		this.securityRequirements._set(securityRequirements);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setSecurityRequirement(int index, SecurityRequirement securityRequirement) {
 		securityRequirements._set(index, securityRequirement);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void addSecurityRequirement(SecurityRequirement securityRequirement) {
 		securityRequirements._add(securityRequirement);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void insertSecurityRequirement(int index, SecurityRequirement securityRequirement) {
 		securityRequirements._insert(index, securityRequirement);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeSecurityRequirement(int index) {
 		securityRequirements._remove(index);
 	}
 
 	// Tag
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Collection<Tag> getTags() {
 		return tags._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Collection<Tag> getTags(boolean elaborate) {
-		return tags._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasTags() {
 		return tags._isPresent();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Tag getTag(int index) {
 		return tags._get(index);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setTags(Collection<Tag> tags) {
 		this.tags._set(tags);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setTag(int index, Tag tag) {
 		tags._set(index, tag);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void addTag(Tag tag) {
 		tags._add(tag);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void insertTag(int index, Tag tag) {
 		tags._insert(index, tag);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeTag(int index) {
 		tags._remove(index);
 	}
 
 	// ExternalDocs
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public ExternalDocs getExternalDocs() {
 		return externalDocs._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public ExternalDocs getExternalDocs(boolean elaborate) {
 		return externalDocs._get(elaborate);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setExternalDocs(ExternalDocs externalDocs) {
 		this.externalDocs._set(externalDocs);
 	}
 
 	// Extension
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Map<String, Object> getExtensions() {
 		return extensions._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Map<String, Object> getExtensions(boolean elaborate) {
-		return extensions._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasExtension(String name) {
 		return extensions.containsKey(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Object getExtension(String name) {
 		return extensions._get(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setExtensions(Map<String, Object> extensions) {
 		this.extensions._set(extensions);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setExtension(String name, Object extension) {
 		extensions._set(name, extension);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeExtension(String name) {
 		extensions._remove(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	protected void elaborateChildren() {
 		super.elaborateChildren();
 		openApi = createChild("openapi", this, StringOverlay.factory);
@@ -956,7 +854,7 @@ public class OpenApi3Impl extends PropertiesOverlay<OpenApi3> implements OpenApi
 		extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public static OverlayFactory<OpenApi3> factory = new OverlayFactory<OpenApi3>() {
 
 		@Override
@@ -983,12 +881,12 @@ public class OpenApi3Impl extends PropertiesOverlay<OpenApi3> implements OpenApi
 		}
 	};
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private static Class<? extends OpenApi3> getSubtypeOf(OpenApi3 openApi3) {
 		return OpenApi3.class;
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private static Class<? extends OpenApi3> getSubtypeOf(JsonNode json) {
 		return OpenApi3.class;
 	}

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/OperationImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/OperationImpl.java
@@ -28,618 +28,540 @@ import com.reprezen.kaizen.oasparser.model3.Server;
 
 public class OperationImpl extends PropertiesOverlay<Operation> implements Operation {
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public OperationImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
 		super(json, parent, refReg);
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public OperationImpl(Operation operation, JsonOverlay<?> parent, ReferenceRegistry refReg) {
 		super(operation, parent, refReg);
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildListOverlay<String> tags;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<String> summary;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<String> description;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<ExternalDocs> externalDocs;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<String> operationId;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildListOverlay<Parameter> parameters;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<RequestBody> requestBody;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildMapOverlay<Response> responses;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildMapOverlay<Object> responsesExtensions;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildMapOverlay<Callback> callbacks;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildMapOverlay<Object> callbacksExtensions;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<Boolean> deprecated;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildListOverlay<SecurityRequirement> securityRequirements;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildListOverlay<Server> servers;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildMapOverlay<Object> extensions;
 
 	// Tag
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Collection<String> getTags() {
 		return tags._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Collection<String> getTags(boolean elaborate) {
-		return tags._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasTags() {
 		return tags._isPresent();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public String getTag(int index) {
 		return tags._get(index);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setTags(Collection<String> tags) {
 		this.tags._set(tags);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setTag(int index, String tag) {
 		tags._set(index, tag);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void addTag(String tag) {
 		tags._add(tag);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void insertTag(int index, String tag) {
 		tags._insert(index, tag);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeTag(int index) {
 		tags._remove(index);
 	}
 
 	// Summary
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public String getSummary() {
 		return summary._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public String getSummary(boolean elaborate) {
-		return summary._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setSummary(String summary) {
 		this.summary._set(summary);
 	}
 
 	// Description
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public String getDescription() {
 		return description._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public String getDescription(boolean elaborate) {
-		return description._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setDescription(String description) {
 		this.description._set(description);
 	}
 
 	// ExternalDocs
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public ExternalDocs getExternalDocs() {
 		return externalDocs._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public ExternalDocs getExternalDocs(boolean elaborate) {
 		return externalDocs._get(elaborate);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setExternalDocs(ExternalDocs externalDocs) {
 		this.externalDocs._set(externalDocs);
 	}
 
 	// OperationId
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public String getOperationId() {
 		return operationId._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public String getOperationId(boolean elaborate) {
-		return operationId._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setOperationId(String operationId) {
 		this.operationId._set(operationId);
 	}
 
 	// Parameter
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Collection<Parameter> getParameters() {
 		return parameters._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Collection<Parameter> getParameters(boolean elaborate) {
-		return parameters._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasParameters() {
 		return parameters._isPresent();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Parameter getParameter(int index) {
 		return parameters._get(index);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setParameters(Collection<Parameter> parameters) {
 		this.parameters._set(parameters);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setParameter(int index, Parameter parameter) {
 		parameters._set(index, parameter);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void addParameter(Parameter parameter) {
 		parameters._add(parameter);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void insertParameter(int index, Parameter parameter) {
 		parameters._insert(index, parameter);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeParameter(int index) {
 		parameters._remove(index);
 	}
 
 	// RequestBody
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public RequestBody getRequestBody() {
 		return requestBody._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public RequestBody getRequestBody(boolean elaborate) {
 		return requestBody._get(elaborate);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setRequestBody(RequestBody requestBody) {
 		this.requestBody._set(requestBody);
 	}
 
 	// Response
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Map<String, Response> getResponses() {
 		return responses._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Map<String, Response> getResponses(boolean elaborate) {
-		return responses._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasResponse(String name) {
 		return responses.containsKey(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Response getResponse(String name) {
 		return responses._get(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setResponses(Map<String, Response> responses) {
 		this.responses._set(responses);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setResponse(String name, Response response) {
 		responses._set(name, response);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeResponse(String name) {
 		responses._remove(name);
 	}
 
 	// ResponsesExtension
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Map<String, Object> getResponsesExtensions() {
 		return responsesExtensions._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Map<String, Object> getResponsesExtensions(boolean elaborate) {
-		return responsesExtensions._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasResponsesExtension(String name) {
 		return responsesExtensions.containsKey(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Object getResponsesExtension(String name) {
 		return responsesExtensions._get(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setResponsesExtensions(Map<String, Object> responsesExtensions) {
 		this.responsesExtensions._set(responsesExtensions);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setResponsesExtension(String name, Object responsesExtension) {
 		responsesExtensions._set(name, responsesExtension);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeResponsesExtension(String name) {
 		responsesExtensions._remove(name);
 	}
 
 	// Callback
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Map<String, Callback> getCallbacks() {
 		return callbacks._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Map<String, Callback> getCallbacks(boolean elaborate) {
-		return callbacks._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasCallback(String name) {
 		return callbacks.containsKey(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Callback getCallback(String name) {
 		return callbacks._get(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setCallbacks(Map<String, Callback> callbacks) {
 		this.callbacks._set(callbacks);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setCallback(String name, Callback callback) {
 		callbacks._set(name, callback);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeCallback(String name) {
 		callbacks._remove(name);
 	}
 
 	// CallbacksExtension
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Map<String, Object> getCallbacksExtensions() {
 		return callbacksExtensions._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Map<String, Object> getCallbacksExtensions(boolean elaborate) {
-		return callbacksExtensions._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasCallbacksExtension(String name) {
 		return callbacksExtensions.containsKey(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Object getCallbacksExtension(String name) {
 		return callbacksExtensions._get(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setCallbacksExtensions(Map<String, Object> callbacksExtensions) {
 		this.callbacksExtensions._set(callbacksExtensions);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setCallbacksExtension(String name, Object callbacksExtension) {
 		callbacksExtensions._set(name, callbacksExtension);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeCallbacksExtension(String name) {
 		callbacksExtensions._remove(name);
 	}
 
 	// Deprecated
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Boolean getDeprecated() {
 		return deprecated._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Boolean getDeprecated(boolean elaborate) {
-		return deprecated._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean isDeprecated() {
 		return deprecated._get() != null ? deprecated._get() : false;
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setDeprecated(Boolean deprecated) {
 		this.deprecated._set(deprecated);
 	}
 
 	// SecurityRequirement
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Collection<SecurityRequirement> getSecurityRequirements() {
 		return securityRequirements._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Collection<SecurityRequirement> getSecurityRequirements(boolean elaborate) {
-		return securityRequirements._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasSecurityRequirements() {
 		return securityRequirements._isPresent();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public SecurityRequirement getSecurityRequirement(int index) {
 		return securityRequirements._get(index);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setSecurityRequirements(Collection<SecurityRequirement> securityRequirements) {
 		this.securityRequirements._set(securityRequirements);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setSecurityRequirement(int index, SecurityRequirement securityRequirement) {
 		securityRequirements._set(index, securityRequirement);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void addSecurityRequirement(SecurityRequirement securityRequirement) {
 		securityRequirements._add(securityRequirement);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void insertSecurityRequirement(int index, SecurityRequirement securityRequirement) {
 		securityRequirements._insert(index, securityRequirement);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeSecurityRequirement(int index) {
 		securityRequirements._remove(index);
 	}
 
 	// Server
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Collection<Server> getServers() {
 		return servers._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Collection<Server> getServers(boolean elaborate) {
-		return servers._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasServers() {
 		return servers._isPresent();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Server getServer(int index) {
 		return servers._get(index);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setServers(Collection<Server> servers) {
 		this.servers._set(servers);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setServer(int index, Server server) {
 		servers._set(index, server);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void addServer(Server server) {
 		servers._add(server);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void insertServer(int index, Server server) {
 		servers._insert(index, server);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeServer(int index) {
 		servers._remove(index);
 	}
 
 	// Extension
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Map<String, Object> getExtensions() {
 		return extensions._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Map<String, Object> getExtensions(boolean elaborate) {
-		return extensions._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasExtension(String name) {
 		return extensions.containsKey(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Object getExtension(String name) {
 		return extensions._get(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setExtensions(Map<String, Object> extensions) {
 		this.extensions._set(extensions);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setExtension(String name, Object extension) {
 		extensions._set(name, extension);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeExtension(String name) {
 		extensions._remove(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	protected void elaborateChildren() {
 		super.elaborateChildren();
 		tags = createChildList("tags", this, StringOverlay.factory);
@@ -659,7 +581,7 @@ public class OperationImpl extends PropertiesOverlay<Operation> implements Opera
 		extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public static OverlayFactory<Operation> factory = new OverlayFactory<Operation>() {
 
 		@Override
@@ -686,12 +608,12 @@ public class OperationImpl extends PropertiesOverlay<Operation> implements Opera
 		}
 	};
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private static Class<? extends Operation> getSubtypeOf(Operation operation) {
 		return Operation.class;
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private static Class<? extends Operation> getSubtypeOf(JsonNode json) {
 		return Operation.class;
 	}

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ParameterImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ParameterImpl.java
@@ -22,428 +22,350 @@ import com.reprezen.kaizen.oasparser.model3.Schema;
 
 public class ParameterImpl extends PropertiesOverlay<Parameter> implements Parameter {
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public ParameterImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
 		super(json, parent, refReg);
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public ParameterImpl(Parameter parameter, JsonOverlay<?> parent, ReferenceRegistry refReg) {
 		super(parameter, parent, refReg);
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<String> name;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<String> in;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<String> description;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<Boolean> required;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<Boolean> deprecated;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<Boolean> allowEmptyValue;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<String> style;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<Boolean> explode;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<Boolean> allowReserved;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<Schema> schema;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<Object> example;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildMapOverlay<Example> examples;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildMapOverlay<MediaType> contentMediaTypes;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildMapOverlay<Object> extensions;
 
 	// Name
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public String getName() {
 		return name._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public String getName(boolean elaborate) {
-		return name._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setName(String name) {
 		this.name._set(name);
 	}
 
 	// In
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public String getIn() {
 		return in._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public String getIn(boolean elaborate) {
-		return in._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setIn(String in) {
 		this.in._set(in);
 	}
 
 	// Description
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public String getDescription() {
 		return description._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public String getDescription(boolean elaborate) {
-		return description._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setDescription(String description) {
 		this.description._set(description);
 	}
 
 	// Required
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Boolean getRequired() {
 		return required._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Boolean getRequired(boolean elaborate) {
-		return required._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean isRequired() {
 		return required._get() != null ? required._get() : false;
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setRequired(Boolean required) {
 		this.required._set(required);
 	}
 
 	// Deprecated
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Boolean getDeprecated() {
 		return deprecated._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Boolean getDeprecated(boolean elaborate) {
-		return deprecated._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean isDeprecated() {
 		return deprecated._get() != null ? deprecated._get() : false;
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setDeprecated(Boolean deprecated) {
 		this.deprecated._set(deprecated);
 	}
 
 	// AllowEmptyValue
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Boolean getAllowEmptyValue() {
 		return allowEmptyValue._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Boolean getAllowEmptyValue(boolean elaborate) {
-		return allowEmptyValue._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean isAllowEmptyValue() {
 		return allowEmptyValue._get() != null ? allowEmptyValue._get() : false;
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setAllowEmptyValue(Boolean allowEmptyValue) {
 		this.allowEmptyValue._set(allowEmptyValue);
 	}
 
 	// Style
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public String getStyle() {
 		return style._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public String getStyle(boolean elaborate) {
-		return style._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setStyle(String style) {
 		this.style._set(style);
 	}
 
 	// Explode
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Boolean getExplode() {
 		return explode._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Boolean getExplode(boolean elaborate) {
-		return explode._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean isExplode() {
 		return explode._get() != null ? explode._get() : false;
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setExplode(Boolean explode) {
 		this.explode._set(explode);
 	}
 
 	// AllowReserved
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Boolean getAllowReserved() {
 		return allowReserved._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Boolean getAllowReserved(boolean elaborate) {
-		return allowReserved._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean isAllowReserved() {
 		return allowReserved._get() != null ? allowReserved._get() : false;
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setAllowReserved(Boolean allowReserved) {
 		this.allowReserved._set(allowReserved);
 	}
 
 	// Schema
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Schema getSchema() {
 		return schema._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Schema getSchema(boolean elaborate) {
 		return schema._get(elaborate);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setSchema(Schema schema) {
 		this.schema._set(schema);
 	}
 
 	// Example
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Object getExample() {
 		return example._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Object getExample(boolean elaborate) {
-		return example._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setExample(Object example) {
 		this.example._set(example);
 	}
 
 	// Example
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Map<String, Example> getExamples() {
 		return examples._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Map<String, Example> getExamples(boolean elaborate) {
-		return examples._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasExample(String name) {
 		return examples.containsKey(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Example getExample(String name) {
 		return examples._get(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setExamples(Map<String, Example> examples) {
 		this.examples._set(examples);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setExample(String name, Example example) {
 		examples._set(name, example);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeExample(String name) {
 		examples._remove(name);
 	}
 
 	// ContentMediaType
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Map<String, MediaType> getContentMediaTypes() {
 		return contentMediaTypes._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Map<String, MediaType> getContentMediaTypes(boolean elaborate) {
-		return contentMediaTypes._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasContentMediaType(String name) {
 		return contentMediaTypes.containsKey(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public MediaType getContentMediaType(String name) {
 		return contentMediaTypes._get(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setContentMediaTypes(Map<String, MediaType> contentMediaTypes) {
 		this.contentMediaTypes._set(contentMediaTypes);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setContentMediaType(String name, MediaType contentMediaType) {
 		contentMediaTypes._set(name, contentMediaType);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeContentMediaType(String name) {
 		contentMediaTypes._remove(name);
 	}
 
 	// Extension
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Map<String, Object> getExtensions() {
 		return extensions._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Map<String, Object> getExtensions(boolean elaborate) {
-		return extensions._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasExtension(String name) {
 		return extensions.containsKey(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Object getExtension(String name) {
 		return extensions._get(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setExtensions(Map<String, Object> extensions) {
 		this.extensions._set(extensions);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setExtension(String name, Object extension) {
 		extensions._set(name, extension);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeExtension(String name) {
 		extensions._remove(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	protected void elaborateChildren() {
 		super.elaborateChildren();
 		name = createChild("name", this, StringOverlay.factory);
@@ -462,7 +384,7 @@ public class ParameterImpl extends PropertiesOverlay<Parameter> implements Param
 		extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public static OverlayFactory<Parameter> factory = new OverlayFactory<Parameter>() {
 
 		@Override
@@ -489,12 +411,12 @@ public class ParameterImpl extends PropertiesOverlay<Parameter> implements Param
 		}
 	};
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private static Class<? extends Parameter> getSubtypeOf(Parameter parameter) {
 		return Parameter.class;
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private static Class<? extends Parameter> getSubtypeOf(JsonNode json) {
 		return Parameter.class;
 	}

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/PathImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/PathImpl.java
@@ -143,270 +143,234 @@ public class PathImpl extends PropertiesOverlay<Path> implements Path {
 		operations._set("trace", (OperationImpl) trace);
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public PathImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
 		super(json, parent, refReg);
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public PathImpl(Path path, JsonOverlay<?> parent, ReferenceRegistry refReg) {
 		super(path, parent, refReg);
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<String> summary;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<String> description;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildMapOverlay<Operation> operations;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildListOverlay<Server> servers;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildListOverlay<Parameter> parameters;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildMapOverlay<Object> extensions;
 
 	// Summary
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public String getSummary() {
 		return summary._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public String getSummary(boolean elaborate) {
-		return summary._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setSummary(String summary) {
 		this.summary._set(summary);
 	}
 
 	// Description
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public String getDescription() {
 		return description._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public String getDescription(boolean elaborate) {
-		return description._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setDescription(String description) {
 		this.description._set(description);
 	}
 
 	// Operation
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Map<String, Operation> getOperations() {
 		return operations._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Map<String, Operation> getOperations(boolean elaborate) {
-		return operations._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasOperation(String name) {
 		return operations.containsKey(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Operation getOperation(String name) {
 		return operations._get(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setOperations(Map<String, Operation> operations) {
 		this.operations._set(operations);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setOperation(String name, Operation operation) {
 		operations._set(name, operation);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeOperation(String name) {
 		operations._remove(name);
 	}
 
 	// Server
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Collection<Server> getServers() {
 		return servers._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Collection<Server> getServers(boolean elaborate) {
-		return servers._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasServers() {
 		return servers._isPresent();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Server getServer(int index) {
 		return servers._get(index);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setServers(Collection<Server> servers) {
 		this.servers._set(servers);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setServer(int index, Server server) {
 		servers._set(index, server);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void addServer(Server server) {
 		servers._add(server);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void insertServer(int index, Server server) {
 		servers._insert(index, server);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeServer(int index) {
 		servers._remove(index);
 	}
 
 	// Parameter
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Collection<Parameter> getParameters() {
 		return parameters._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Collection<Parameter> getParameters(boolean elaborate) {
-		return parameters._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasParameters() {
 		return parameters._isPresent();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Parameter getParameter(int index) {
 		return parameters._get(index);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setParameters(Collection<Parameter> parameters) {
 		this.parameters._set(parameters);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setParameter(int index, Parameter parameter) {
 		parameters._set(index, parameter);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void addParameter(Parameter parameter) {
 		parameters._add(parameter);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void insertParameter(int index, Parameter parameter) {
 		parameters._insert(index, parameter);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeParameter(int index) {
 		parameters._remove(index);
 	}
 
 	// Extension
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Map<String, Object> getExtensions() {
 		return extensions._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Map<String, Object> getExtensions(boolean elaborate) {
-		return extensions._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasExtension(String name) {
 		return extensions.containsKey(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Object getExtension(String name) {
 		return extensions._get(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setExtensions(Map<String, Object> extensions) {
 		this.extensions._set(extensions);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setExtension(String name, Object extension) {
 		extensions._set(name, extension);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeExtension(String name) {
 		extensions._remove(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	protected void elaborateChildren() {
 		super.elaborateChildren();
 		summary = createChild("summary", this, StringOverlay.factory);
@@ -417,7 +381,7 @@ public class PathImpl extends PropertiesOverlay<Path> implements Path {
 		extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public static OverlayFactory<Path> factory = new OverlayFactory<Path>() {
 
 		@Override
@@ -444,12 +408,12 @@ public class PathImpl extends PropertiesOverlay<Path> implements Path {
 		}
 	};
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private static Class<? extends Path> getSubtypeOf(Path path) {
 		return Path.class;
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private static Class<? extends Path> getSubtypeOf(JsonNode json) {
 		return Path.class;
 	}

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/RequestBodyImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/RequestBodyImpl.java
@@ -20,160 +20,136 @@ import com.reprezen.kaizen.oasparser.model3.RequestBody;
 
 public class RequestBodyImpl extends PropertiesOverlay<RequestBody> implements RequestBody {
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public RequestBodyImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
 		super(json, parent, refReg);
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public RequestBodyImpl(RequestBody requestBody, JsonOverlay<?> parent, ReferenceRegistry refReg) {
 		super(requestBody, parent, refReg);
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<String> description;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildMapOverlay<MediaType> contentMediaTypes;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<Boolean> required;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildMapOverlay<Object> extensions;
 
 	// Description
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public String getDescription() {
 		return description._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public String getDescription(boolean elaborate) {
-		return description._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setDescription(String description) {
 		this.description._set(description);
 	}
 
 	// ContentMediaType
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Map<String, MediaType> getContentMediaTypes() {
 		return contentMediaTypes._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Map<String, MediaType> getContentMediaTypes(boolean elaborate) {
-		return contentMediaTypes._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasContentMediaType(String name) {
 		return contentMediaTypes.containsKey(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public MediaType getContentMediaType(String name) {
 		return contentMediaTypes._get(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setContentMediaTypes(Map<String, MediaType> contentMediaTypes) {
 		this.contentMediaTypes._set(contentMediaTypes);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setContentMediaType(String name, MediaType contentMediaType) {
 		contentMediaTypes._set(name, contentMediaType);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeContentMediaType(String name) {
 		contentMediaTypes._remove(name);
 	}
 
 	// Required
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Boolean getRequired() {
 		return required._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Boolean getRequired(boolean elaborate) {
-		return required._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean isRequired() {
 		return required._get() != null ? required._get() : false;
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setRequired(Boolean required) {
 		this.required._set(required);
 	}
 
 	// Extension
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Map<String, Object> getExtensions() {
 		return extensions._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Map<String, Object> getExtensions(boolean elaborate) {
-		return extensions._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasExtension(String name) {
 		return extensions.containsKey(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Object getExtension(String name) {
 		return extensions._get(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setExtensions(Map<String, Object> extensions) {
 		this.extensions._set(extensions);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setExtension(String name, Object extension) {
 		extensions._set(name, extension);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeExtension(String name) {
 		extensions._remove(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	protected void elaborateChildren() {
 		super.elaborateChildren();
 		description = createChild("description", this, StringOverlay.factory);
@@ -182,7 +158,7 @@ public class RequestBodyImpl extends PropertiesOverlay<RequestBody> implements R
 		extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public static OverlayFactory<RequestBody> factory = new OverlayFactory<RequestBody>() {
 
 		@Override
@@ -210,12 +186,12 @@ public class RequestBodyImpl extends PropertiesOverlay<RequestBody> implements R
 		}
 	};
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private static Class<? extends RequestBody> getSubtypeOf(RequestBody requestBody) {
 		return RequestBody.class;
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private static Class<? extends RequestBody> getSubtypeOf(JsonNode json) {
 		return RequestBody.class;
 	}

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ResponseImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ResponseImpl.java
@@ -21,224 +21,194 @@ import com.reprezen.kaizen.oasparser.model3.Response;
 
 public class ResponseImpl extends PropertiesOverlay<Response> implements Response {
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public ResponseImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
 		super(json, parent, refReg);
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public ResponseImpl(Response response, JsonOverlay<?> parent, ReferenceRegistry refReg) {
 		super(response, parent, refReg);
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<String> description;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildMapOverlay<Header> headers;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildMapOverlay<MediaType> contentMediaTypes;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildMapOverlay<Link> links;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildMapOverlay<Object> extensions;
 
 	// Description
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public String getDescription() {
 		return description._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public String getDescription(boolean elaborate) {
-		return description._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setDescription(String description) {
 		this.description._set(description);
 	}
 
 	// Header
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Map<String, Header> getHeaders() {
 		return headers._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Map<String, Header> getHeaders(boolean elaborate) {
-		return headers._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasHeader(String name) {
 		return headers.containsKey(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Header getHeader(String name) {
 		return headers._get(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setHeaders(Map<String, Header> headers) {
 		this.headers._set(headers);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setHeader(String name, Header header) {
 		headers._set(name, header);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeHeader(String name) {
 		headers._remove(name);
 	}
 
 	// ContentMediaType
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Map<String, MediaType> getContentMediaTypes() {
 		return contentMediaTypes._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Map<String, MediaType> getContentMediaTypes(boolean elaborate) {
-		return contentMediaTypes._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasContentMediaType(String name) {
 		return contentMediaTypes.containsKey(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public MediaType getContentMediaType(String name) {
 		return contentMediaTypes._get(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setContentMediaTypes(Map<String, MediaType> contentMediaTypes) {
 		this.contentMediaTypes._set(contentMediaTypes);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setContentMediaType(String name, MediaType contentMediaType) {
 		contentMediaTypes._set(name, contentMediaType);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeContentMediaType(String name) {
 		contentMediaTypes._remove(name);
 	}
 
 	// Link
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Map<String, Link> getLinks() {
 		return links._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Map<String, Link> getLinks(boolean elaborate) {
-		return links._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasLink(String name) {
 		return links.containsKey(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Link getLink(String name) {
 		return links._get(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setLinks(Map<String, Link> links) {
 		this.links._set(links);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setLink(String name, Link link) {
 		links._set(name, link);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeLink(String name) {
 		links._remove(name);
 	}
 
 	// Extension
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Map<String, Object> getExtensions() {
 		return extensions._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Map<String, Object> getExtensions(boolean elaborate) {
-		return extensions._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasExtension(String name) {
 		return extensions.containsKey(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Object getExtension(String name) {
 		return extensions._get(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setExtensions(Map<String, Object> extensions) {
 		this.extensions._set(extensions);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setExtension(String name, Object extension) {
 		extensions._set(name, extension);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeExtension(String name) {
 		extensions._remove(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	protected void elaborateChildren() {
 		super.elaborateChildren();
 		description = createChild("description", this, StringOverlay.factory);
@@ -248,7 +218,7 @@ public class ResponseImpl extends PropertiesOverlay<Response> implements Respons
 		extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public static OverlayFactory<Response> factory = new OverlayFactory<Response>() {
 
 		@Override
@@ -275,12 +245,12 @@ public class ResponseImpl extends PropertiesOverlay<Response> implements Respons
 		}
 	};
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private static Class<? extends Response> getSubtypeOf(Response response) {
 		return Response.class;
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private static Class<? extends Response> getSubtypeOf(JsonNode json) {
 		return Response.class;
 	}

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/SchemaImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/SchemaImpl.java
@@ -36,1154 +36,956 @@ public class SchemaImpl extends PropertiesOverlay<Schema> implements Schema {
 		}
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public SchemaImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
 		super(json, parent, refReg);
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public SchemaImpl(Schema schema, JsonOverlay<?> parent, ReferenceRegistry refReg) {
 		super(schema, parent, refReg);
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<String> title;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<Number> multipleOf;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<Number> maximum;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<Boolean> exclusiveMaximum;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<Number> minimum;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<Boolean> exclusiveMinimum;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<Integer> maxLength;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<Integer> minLength;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<String> pattern;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<Integer> maxItems;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<Integer> minItems;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<Boolean> uniqueItems;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<Integer> maxProperties;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<Integer> minProperties;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildListOverlay<String> requiredFields;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildListOverlay<Object> enums;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<String> type;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildListOverlay<Schema> allOfSchemas;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildListOverlay<Schema> oneOfSchemas;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildListOverlay<Schema> anyOfSchemas;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<Schema> notSchema;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<Schema> itemsSchema;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildMapOverlay<Schema> properties;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<Schema> additionalPropertiesSchema;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<Boolean> additionalProperties;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<String> description;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<String> format;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<Object> defaultValue;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<Boolean> nullable;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<String> discriminator;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<Boolean> readOnly;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<Boolean> writeOnly;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<Xml> xml;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<ExternalDocs> externalDocs;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildMapOverlay<Example> examples;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<Object> example;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<Boolean> deprecated;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildMapOverlay<Object> extensions;
 
 	// Title
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public String getTitle() {
 		return title._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public String getTitle(boolean elaborate) {
-		return title._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setTitle(String title) {
 		this.title._set(title);
 	}
 
 	// MultipleOf
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Number getMultipleOf() {
 		return multipleOf._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Number getMultipleOf(boolean elaborate) {
-		return multipleOf._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setMultipleOf(Number multipleOf) {
 		this.multipleOf._set(multipleOf);
 	}
 
 	// Maximum
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Number getMaximum() {
 		return maximum._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Number getMaximum(boolean elaborate) {
-		return maximum._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setMaximum(Number maximum) {
 		this.maximum._set(maximum);
 	}
 
 	// ExclusiveMaximum
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Boolean getExclusiveMaximum() {
 		return exclusiveMaximum._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Boolean getExclusiveMaximum(boolean elaborate) {
-		return exclusiveMaximum._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean isExclusiveMaximum() {
 		return exclusiveMaximum._get() != null ? exclusiveMaximum._get() : false;
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setExclusiveMaximum(Boolean exclusiveMaximum) {
 		this.exclusiveMaximum._set(exclusiveMaximum);
 	}
 
 	// Minimum
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Number getMinimum() {
 		return minimum._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Number getMinimum(boolean elaborate) {
-		return minimum._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setMinimum(Number minimum) {
 		this.minimum._set(minimum);
 	}
 
 	// ExclusiveMinimum
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Boolean getExclusiveMinimum() {
 		return exclusiveMinimum._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Boolean getExclusiveMinimum(boolean elaborate) {
-		return exclusiveMinimum._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean isExclusiveMinimum() {
 		return exclusiveMinimum._get() != null ? exclusiveMinimum._get() : false;
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setExclusiveMinimum(Boolean exclusiveMinimum) {
 		this.exclusiveMinimum._set(exclusiveMinimum);
 	}
 
 	// MaxLength
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Integer getMaxLength() {
 		return maxLength._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Integer getMaxLength(boolean elaborate) {
-		return maxLength._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setMaxLength(Integer maxLength) {
 		this.maxLength._set(maxLength);
 	}
 
 	// MinLength
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Integer getMinLength() {
 		return minLength._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Integer getMinLength(boolean elaborate) {
-		return minLength._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setMinLength(Integer minLength) {
 		this.minLength._set(minLength);
 	}
 
 	// Pattern
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public String getPattern() {
 		return pattern._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public String getPattern(boolean elaborate) {
-		return pattern._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setPattern(String pattern) {
 		this.pattern._set(pattern);
 	}
 
 	// MaxItems
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Integer getMaxItems() {
 		return maxItems._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Integer getMaxItems(boolean elaborate) {
-		return maxItems._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setMaxItems(Integer maxItems) {
 		this.maxItems._set(maxItems);
 	}
 
 	// MinItems
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Integer getMinItems() {
 		return minItems._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Integer getMinItems(boolean elaborate) {
-		return minItems._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setMinItems(Integer minItems) {
 		this.minItems._set(minItems);
 	}
 
 	// UniqueItems
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Boolean getUniqueItems() {
 		return uniqueItems._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Boolean getUniqueItems(boolean elaborate) {
-		return uniqueItems._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean isUniqueItems() {
 		return uniqueItems._get() != null ? uniqueItems._get() : false;
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setUniqueItems(Boolean uniqueItems) {
 		this.uniqueItems._set(uniqueItems);
 	}
 
 	// MaxProperties
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Integer getMaxProperties() {
 		return maxProperties._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Integer getMaxProperties(boolean elaborate) {
-		return maxProperties._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setMaxProperties(Integer maxProperties) {
 		this.maxProperties._set(maxProperties);
 	}
 
 	// MinProperties
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Integer getMinProperties() {
 		return minProperties._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Integer getMinProperties(boolean elaborate) {
-		return minProperties._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setMinProperties(Integer minProperties) {
 		this.minProperties._set(minProperties);
 	}
 
 	// RequiredField
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Collection<String> getRequiredFields() {
 		return requiredFields._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Collection<String> getRequiredFields(boolean elaborate) {
-		return requiredFields._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasRequiredFields() {
 		return requiredFields._isPresent();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public String getRequiredField(int index) {
 		return requiredFields._get(index);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setRequiredFields(Collection<String> requiredFields) {
 		this.requiredFields._set(requiredFields);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setRequiredField(int index, String requiredField) {
 		requiredFields._set(index, requiredField);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void addRequiredField(String requiredField) {
 		requiredFields._add(requiredField);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void insertRequiredField(int index, String requiredField) {
 		requiredFields._insert(index, requiredField);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeRequiredField(int index) {
 		requiredFields._remove(index);
 	}
 
 	// Enum
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Collection<Object> getEnums() {
 		return enums._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Collection<Object> getEnums(boolean elaborate) {
-		return enums._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasEnums() {
 		return enums._isPresent();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Object getEnum(int index) {
 		return enums._get(index);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setEnums(Collection<Object> enums) {
 		this.enums._set(enums);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setEnum(int index, Object enumValue) {
 		enums._set(index, enumValue);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void addEnum(Object enumValue) {
 		enums._add(enumValue);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void insertEnum(int index, Object enumValue) {
 		enums._insert(index, enumValue);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeEnum(int index) {
 		enums._remove(index);
 	}
 
 	// Type
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public String getType() {
 		return type._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public String getType(boolean elaborate) {
-		return type._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setType(String type) {
 		this.type._set(type);
 	}
 
 	// AllOfSchema
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Collection<Schema> getAllOfSchemas() {
 		return allOfSchemas._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Collection<Schema> getAllOfSchemas(boolean elaborate) {
-		return allOfSchemas._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasAllOfSchemas() {
 		return allOfSchemas._isPresent();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Schema getAllOfSchema(int index) {
 		return allOfSchemas._get(index);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setAllOfSchemas(Collection<Schema> allOfSchemas) {
 		this.allOfSchemas._set(allOfSchemas);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setAllOfSchema(int index, Schema allOfSchema) {
 		allOfSchemas._set(index, allOfSchema);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void addAllOfSchema(Schema allOfSchema) {
 		allOfSchemas._add(allOfSchema);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void insertAllOfSchema(int index, Schema allOfSchema) {
 		allOfSchemas._insert(index, allOfSchema);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeAllOfSchema(int index) {
 		allOfSchemas._remove(index);
 	}
 
 	// OneOfSchema
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Collection<Schema> getOneOfSchemas() {
 		return oneOfSchemas._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Collection<Schema> getOneOfSchemas(boolean elaborate) {
-		return oneOfSchemas._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasOneOfSchemas() {
 		return oneOfSchemas._isPresent();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Schema getOneOfSchema(int index) {
 		return oneOfSchemas._get(index);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setOneOfSchemas(Collection<Schema> oneOfSchemas) {
 		this.oneOfSchemas._set(oneOfSchemas);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setOneOfSchema(int index, Schema oneOfSchema) {
 		oneOfSchemas._set(index, oneOfSchema);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void addOneOfSchema(Schema oneOfSchema) {
 		oneOfSchemas._add(oneOfSchema);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void insertOneOfSchema(int index, Schema oneOfSchema) {
 		oneOfSchemas._insert(index, oneOfSchema);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeOneOfSchema(int index) {
 		oneOfSchemas._remove(index);
 	}
 
 	// AnyOfSchema
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Collection<Schema> getAnyOfSchemas() {
 		return anyOfSchemas._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Collection<Schema> getAnyOfSchemas(boolean elaborate) {
-		return anyOfSchemas._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasAnyOfSchemas() {
 		return anyOfSchemas._isPresent();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Schema getAnyOfSchema(int index) {
 		return anyOfSchemas._get(index);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setAnyOfSchemas(Collection<Schema> anyOfSchemas) {
 		this.anyOfSchemas._set(anyOfSchemas);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setAnyOfSchema(int index, Schema anyOfSchema) {
 		anyOfSchemas._set(index, anyOfSchema);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void addAnyOfSchema(Schema anyOfSchema) {
 		anyOfSchemas._add(anyOfSchema);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void insertAnyOfSchema(int index, Schema anyOfSchema) {
 		anyOfSchemas._insert(index, anyOfSchema);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeAnyOfSchema(int index) {
 		anyOfSchemas._remove(index);
 	}
 
 	// NotSchema
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Schema getNotSchema() {
 		return notSchema._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Schema getNotSchema(boolean elaborate) {
 		return notSchema._get(elaborate);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setNotSchema(Schema notSchema) {
 		this.notSchema._set(notSchema);
 	}
 
 	// ItemsSchema
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Schema getItemsSchema() {
 		return itemsSchema._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Schema getItemsSchema(boolean elaborate) {
 		return itemsSchema._get(elaborate);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setItemsSchema(Schema itemsSchema) {
 		this.itemsSchema._set(itemsSchema);
 	}
 
 	// Property
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Map<String, Schema> getProperties() {
 		return properties._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Map<String, Schema> getProperties(boolean elaborate) {
-		return properties._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasProperty(String name) {
 		return properties.containsKey(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Schema getProperty(String name) {
 		return properties._get(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setProperties(Map<String, Schema> properties) {
 		this.properties._set(properties);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setProperty(String name, Schema property) {
 		properties._set(name, property);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeProperty(String name) {
 		properties._remove(name);
 	}
 
 	// AdditionalPropertiesSchema
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Schema getAdditionalPropertiesSchema() {
 		return additionalPropertiesSchema._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Schema getAdditionalPropertiesSchema(boolean elaborate) {
 		return additionalPropertiesSchema._get(elaborate);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setAdditionalPropertiesSchema(Schema additionalPropertiesSchema) {
 		this.additionalPropertiesSchema._set(additionalPropertiesSchema);
 	}
 
 	// AdditionalProperties
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Boolean getAdditionalProperties() {
 		return additionalProperties._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Boolean getAdditionalProperties(boolean elaborate) {
-		return additionalProperties._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean isAdditionalProperties() {
 		return additionalProperties._get() != null ? additionalProperties._get() : false;
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setAdditionalProperties(Boolean additionalProperties) {
 		this.additionalProperties._set(additionalProperties);
 	}
 
 	// Description
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public String getDescription() {
 		return description._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public String getDescription(boolean elaborate) {
-		return description._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setDescription(String description) {
 		this.description._set(description);
 	}
 
 	// Format
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public String getFormat() {
 		return format._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public String getFormat(boolean elaborate) {
-		return format._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setFormat(String format) {
 		this.format._set(format);
 	}
 
 	// Default
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Object getDefault() {
 		return defaultValue._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Object getDefault(boolean elaborate) {
-		return defaultValue._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setDefault(Object defaultValue) {
 		this.defaultValue._set(defaultValue);
 	}
 
 	// Nullable
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Boolean getNullable() {
 		return nullable._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Boolean getNullable(boolean elaborate) {
-		return nullable._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean isNullable() {
 		return nullable._get() != null ? nullable._get() : false;
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setNullable(Boolean nullable) {
 		this.nullable._set(nullable);
 	}
 
 	// Discriminator
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public String getDiscriminator() {
 		return discriminator._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public String getDiscriminator(boolean elaborate) {
-		return discriminator._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setDiscriminator(String discriminator) {
 		this.discriminator._set(discriminator);
 	}
 
 	// ReadOnly
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Boolean getReadOnly() {
 		return readOnly._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Boolean getReadOnly(boolean elaborate) {
-		return readOnly._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean isReadOnly() {
 		return readOnly._get() != null ? readOnly._get() : false;
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setReadOnly(Boolean readOnly) {
 		this.readOnly._set(readOnly);
 	}
 
 	// WriteOnly
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Boolean getWriteOnly() {
 		return writeOnly._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Boolean getWriteOnly(boolean elaborate) {
-		return writeOnly._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean isWriteOnly() {
 		return writeOnly._get() != null ? writeOnly._get() : false;
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setWriteOnly(Boolean writeOnly) {
 		this.writeOnly._set(writeOnly);
 	}
 
 	// Xml
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Xml getXml() {
 		return xml._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Xml getXml(boolean elaborate) {
 		return xml._get(elaborate);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setXml(Xml xml) {
 		this.xml._set(xml);
 	}
 
 	// ExternalDocs
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public ExternalDocs getExternalDocs() {
 		return externalDocs._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public ExternalDocs getExternalDocs(boolean elaborate) {
 		return externalDocs._get(elaborate);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setExternalDocs(ExternalDocs externalDocs) {
 		this.externalDocs._set(externalDocs);
 	}
 
 	// Example
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Map<String, Example> getExamples() {
 		return examples._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Map<String, Example> getExamples(boolean elaborate) {
-		return examples._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasExample(String name) {
 		return examples.containsKey(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Example getExample(String name) {
 		return examples._get(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setExamples(Map<String, Example> examples) {
 		this.examples._set(examples);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setExample(String name, Example example) {
 		examples._set(name, example);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeExample(String name) {
 		examples._remove(name);
 	}
 
 	// Example
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Object getExample() {
 		return example._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Object getExample(boolean elaborate) {
-		return example._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setExample(Object example) {
 		this.example._set(example);
 	}
 
 	// Deprecated
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Boolean getDeprecated() {
 		return deprecated._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Boolean getDeprecated(boolean elaborate) {
-		return deprecated._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean isDeprecated() {
 		return deprecated._get() != null ? deprecated._get() : false;
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setDeprecated(Boolean deprecated) {
 		this.deprecated._set(deprecated);
 	}
 
 	// Extension
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Map<String, Object> getExtensions() {
 		return extensions._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Map<String, Object> getExtensions(boolean elaborate) {
-		return extensions._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasExtension(String name) {
 		return extensions.containsKey(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Object getExtension(String name) {
 		return extensions._get(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setExtensions(Map<String, Object> extensions) {
 		this.extensions._set(extensions);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setExtension(String name, Object extension) {
 		extensions._set(name, extension);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeExtension(String name) {
 		extensions._remove(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	protected void elaborateChildren() {
 		super.elaborateChildren();
 		title = createChild("title", this, StringOverlay.factory);
@@ -1228,7 +1030,7 @@ public class SchemaImpl extends PropertiesOverlay<Schema> implements Schema {
 		extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public static OverlayFactory<Schema> factory = new OverlayFactory<Schema>() {
 
 		@Override
@@ -1255,12 +1057,12 @@ public class SchemaImpl extends PropertiesOverlay<Schema> implements Schema {
 		}
 	};
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private static Class<? extends Schema> getSubtypeOf(Schema schema) {
 		return Schema.class;
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private static Class<? extends Schema> getSubtypeOf(JsonNode json) {
 		return Schema.class;
 	}

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/SecurityParameterImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/SecurityParameterImpl.java
@@ -21,82 +21,76 @@ public class SecurityParameterImpl extends PropertiesOverlay<SecurityParameter> 
 		return json.isMissingNode() ? jsonArray() : json;
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public SecurityParameterImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
 		super(json, parent, refReg);
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public SecurityParameterImpl(SecurityParameter securityParameter, JsonOverlay<?> parent, ReferenceRegistry refReg) {
 		super(securityParameter, parent, refReg);
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildListOverlay<String> parameters;
 
 	// Parameter
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Collection<String> getParameters() {
 		return parameters._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Collection<String> getParameters(boolean elaborate) {
-		return parameters._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasParameters() {
 		return parameters._isPresent();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public String getParameter(int index) {
 		return parameters._get(index);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setParameters(Collection<String> parameters) {
 		this.parameters._set(parameters);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setParameter(int index, String parameter) {
 		parameters._set(index, parameter);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void addParameter(String parameter) {
 		parameters._add(parameter);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void insertParameter(int index, String parameter) {
 		parameters._insert(index, parameter);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeParameter(int index) {
 		parameters._remove(index);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	protected void elaborateChildren() {
 		super.elaborateChildren();
 		parameters = createChildList("", this, StringOverlay.factory);
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public static OverlayFactory<SecurityParameter> factory = new OverlayFactory<SecurityParameter>() {
 
 		@Override
@@ -124,12 +118,12 @@ public class SecurityParameterImpl extends PropertiesOverlay<SecurityParameter> 
 		}
 	};
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private static Class<? extends SecurityParameter> getSubtypeOf(SecurityParameter securityParameter) {
 		return SecurityParameter.class;
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private static Class<? extends SecurityParameter> getSubtypeOf(JsonNode json) {
 		return SecurityParameter.class;
 	}

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/SecurityRequirementImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/SecurityRequirementImpl.java
@@ -16,71 +16,65 @@ import com.reprezen.kaizen.oasparser.model3.SecurityRequirement;
 
 public class SecurityRequirementImpl extends PropertiesOverlay<SecurityRequirement> implements SecurityRequirement {
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public SecurityRequirementImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
 		super(json, parent, refReg);
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public SecurityRequirementImpl(SecurityRequirement securityRequirement, JsonOverlay<?> parent,
 			ReferenceRegistry refReg) {
 		super(securityRequirement, parent, refReg);
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildMapOverlay<SecurityParameter> requirements;
 
 	// Requirement
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Map<String, SecurityParameter> getRequirements() {
 		return requirements._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Map<String, SecurityParameter> getRequirements(boolean elaborate) {
-		return requirements._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasRequirement(String name) {
 		return requirements.containsKey(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public SecurityParameter getRequirement(String name) {
 		return requirements._get(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setRequirements(Map<String, SecurityParameter> requirements) {
 		this.requirements._set(requirements);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setRequirement(String name, SecurityParameter requirement) {
 		requirements._set(name, requirement);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeRequirement(String name) {
 		requirements._remove(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	protected void elaborateChildren() {
 		super.elaborateChildren();
 		requirements = createChildMap("", this, SecurityParameterImpl.factory, "[a-zA-Z0-9\\._-]+");
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public static OverlayFactory<SecurityRequirement> factory = new OverlayFactory<SecurityRequirement>() {
 
 		@Override
@@ -109,12 +103,12 @@ public class SecurityRequirementImpl extends PropertiesOverlay<SecurityRequireme
 		}
 	};
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private static Class<? extends SecurityRequirement> getSubtypeOf(SecurityRequirement securityRequirement) {
 		return SecurityRequirement.class;
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private static Class<? extends SecurityRequirement> getSubtypeOf(JsonNode json) {
 		return SecurityRequirement.class;
 	}

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/SecuritySchemeImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/SecuritySchemeImpl.java
@@ -19,352 +19,298 @@ import com.reprezen.kaizen.oasparser.model3.SecurityScheme;
 
 public class SecuritySchemeImpl extends PropertiesOverlay<SecurityScheme> implements SecurityScheme {
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public SecuritySchemeImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
 		super(json, parent, refReg);
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public SecuritySchemeImpl(SecurityScheme securityScheme, JsonOverlay<?> parent, ReferenceRegistry refReg) {
 		super(securityScheme, parent, refReg);
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<String> type;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<String> description;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<String> name;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<String> in;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<String> scheme;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<String> bearerFormat;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<OAuthFlow> implicitOAuthFlow;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<OAuthFlow> passwordOAuthFlow;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<OAuthFlow> clientCredentialsOAuthFlow;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<OAuthFlow> authorizationCodeOAuthFlow;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildMapOverlay<Object> oAuthFlowsExtensions;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<String> openIdConnectUrl;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildMapOverlay<Object> extensions;
 
 	// Type
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public String getType() {
 		return type._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public String getType(boolean elaborate) {
-		return type._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setType(String type) {
 		this.type._set(type);
 	}
 
 	// Description
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public String getDescription() {
 		return description._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public String getDescription(boolean elaborate) {
-		return description._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setDescription(String description) {
 		this.description._set(description);
 	}
 
 	// Name
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public String getName() {
 		return name._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public String getName(boolean elaborate) {
-		return name._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setName(String name) {
 		this.name._set(name);
 	}
 
 	// In
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public String getIn() {
 		return in._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public String getIn(boolean elaborate) {
-		return in._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setIn(String in) {
 		this.in._set(in);
 	}
 
 	// Scheme
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public String getScheme() {
 		return scheme._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public String getScheme(boolean elaborate) {
-		return scheme._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setScheme(String scheme) {
 		this.scheme._set(scheme);
 	}
 
 	// BearerFormat
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public String getBearerFormat() {
 		return bearerFormat._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public String getBearerFormat(boolean elaborate) {
-		return bearerFormat._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setBearerFormat(String bearerFormat) {
 		this.bearerFormat._set(bearerFormat);
 	}
 
 	// ImplicitOAuthFlow
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public OAuthFlow getImplicitOAuthFlow() {
 		return implicitOAuthFlow._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public OAuthFlow getImplicitOAuthFlow(boolean elaborate) {
 		return implicitOAuthFlow._get(elaborate);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setImplicitOAuthFlow(OAuthFlow implicitOAuthFlow) {
 		this.implicitOAuthFlow._set(implicitOAuthFlow);
 	}
 
 	// PasswordOAuthFlow
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public OAuthFlow getPasswordOAuthFlow() {
 		return passwordOAuthFlow._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public OAuthFlow getPasswordOAuthFlow(boolean elaborate) {
 		return passwordOAuthFlow._get(elaborate);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setPasswordOAuthFlow(OAuthFlow passwordOAuthFlow) {
 		this.passwordOAuthFlow._set(passwordOAuthFlow);
 	}
 
 	// ClientCredentialsOAuthFlow
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public OAuthFlow getClientCredentialsOAuthFlow() {
 		return clientCredentialsOAuthFlow._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public OAuthFlow getClientCredentialsOAuthFlow(boolean elaborate) {
 		return clientCredentialsOAuthFlow._get(elaborate);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setClientCredentialsOAuthFlow(OAuthFlow clientCredentialsOAuthFlow) {
 		this.clientCredentialsOAuthFlow._set(clientCredentialsOAuthFlow);
 	}
 
 	// AuthorizationCodeOAuthFlow
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public OAuthFlow getAuthorizationCodeOAuthFlow() {
 		return authorizationCodeOAuthFlow._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public OAuthFlow getAuthorizationCodeOAuthFlow(boolean elaborate) {
 		return authorizationCodeOAuthFlow._get(elaborate);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setAuthorizationCodeOAuthFlow(OAuthFlow authorizationCodeOAuthFlow) {
 		this.authorizationCodeOAuthFlow._set(authorizationCodeOAuthFlow);
 	}
 
 	// OAuthFlowsExtension
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Map<String, Object> getOAuthFlowsExtensions() {
 		return oAuthFlowsExtensions._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Map<String, Object> getOAuthFlowsExtensions(boolean elaborate) {
-		return oAuthFlowsExtensions._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasOAuthFlowsExtension(String name) {
 		return oAuthFlowsExtensions.containsKey(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Object getOAuthFlowsExtension(String name) {
 		return oAuthFlowsExtensions._get(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setOAuthFlowsExtensions(Map<String, Object> oAuthFlowsExtensions) {
 		this.oAuthFlowsExtensions._set(oAuthFlowsExtensions);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setOAuthFlowsExtension(String name, Object oAuthFlowsExtension) {
 		oAuthFlowsExtensions._set(name, oAuthFlowsExtension);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeOAuthFlowsExtension(String name) {
 		oAuthFlowsExtensions._remove(name);
 	}
 
 	// OpenIdConnectUrl
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public String getOpenIdConnectUrl() {
 		return openIdConnectUrl._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public String getOpenIdConnectUrl(boolean elaborate) {
-		return openIdConnectUrl._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setOpenIdConnectUrl(String openIdConnectUrl) {
 		this.openIdConnectUrl._set(openIdConnectUrl);
 	}
 
 	// Extension
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Map<String, Object> getExtensions() {
 		return extensions._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Map<String, Object> getExtensions(boolean elaborate) {
-		return extensions._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasExtension(String name) {
 		return extensions.containsKey(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Object getExtension(String name) {
 		return extensions._get(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setExtensions(Map<String, Object> extensions) {
 		this.extensions._set(extensions);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setExtension(String name, Object extension) {
 		extensions._set(name, extension);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeExtension(String name) {
 		extensions._remove(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	protected void elaborateChildren() {
 		super.elaborateChildren();
 		type = createChild("type", this, StringOverlay.factory);
@@ -382,7 +328,7 @@ public class SecuritySchemeImpl extends PropertiesOverlay<SecurityScheme> implem
 		extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public static OverlayFactory<SecurityScheme> factory = new OverlayFactory<SecurityScheme>() {
 
 		@Override
@@ -410,12 +356,12 @@ public class SecuritySchemeImpl extends PropertiesOverlay<SecurityScheme> implem
 		}
 	};
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private static Class<? extends SecurityScheme> getSubtypeOf(SecurityScheme securityScheme) {
 		return SecurityScheme.class;
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private static Class<? extends SecurityScheme> getSubtypeOf(JsonNode json) {
 		return SecurityScheme.class;
 	}

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ServerImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ServerImpl.java
@@ -19,200 +19,170 @@ import com.reprezen.kaizen.oasparser.model3.ServerVariable;
 
 public class ServerImpl extends PropertiesOverlay<Server> implements Server {
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public ServerImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
 		super(json, parent, refReg);
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public ServerImpl(Server server, JsonOverlay<?> parent, ReferenceRegistry refReg) {
 		super(server, parent, refReg);
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<String> url;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<String> description;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildMapOverlay<ServerVariable> serverVariables;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildMapOverlay<Object> variablesExtensions;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildMapOverlay<Object> extensions;
 
 	// Url
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public String getUrl() {
 		return url._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public String getUrl(boolean elaborate) {
-		return url._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setUrl(String url) {
 		this.url._set(url);
 	}
 
 	// Description
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public String getDescription() {
 		return description._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public String getDescription(boolean elaborate) {
-		return description._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setDescription(String description) {
 		this.description._set(description);
 	}
 
 	// ServerVariable
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Map<String, ServerVariable> getServerVariables() {
 		return serverVariables._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Map<String, ServerVariable> getServerVariables(boolean elaborate) {
-		return serverVariables._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasServerVariable(String name) {
 		return serverVariables.containsKey(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public ServerVariable getServerVariable(String name) {
 		return serverVariables._get(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setServerVariables(Map<String, ServerVariable> serverVariables) {
 		this.serverVariables._set(serverVariables);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setServerVariable(String name, ServerVariable serverVariable) {
 		serverVariables._set(name, serverVariable);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeServerVariable(String name) {
 		serverVariables._remove(name);
 	}
 
 	// VariablesExtension
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Map<String, Object> getVariablesExtensions() {
 		return variablesExtensions._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Map<String, Object> getVariablesExtensions(boolean elaborate) {
-		return variablesExtensions._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasVariablesExtension(String name) {
 		return variablesExtensions.containsKey(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Object getVariablesExtension(String name) {
 		return variablesExtensions._get(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setVariablesExtensions(Map<String, Object> variablesExtensions) {
 		this.variablesExtensions._set(variablesExtensions);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setVariablesExtension(String name, Object variablesExtension) {
 		variablesExtensions._set(name, variablesExtension);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeVariablesExtension(String name) {
 		variablesExtensions._remove(name);
 	}
 
 	// Extension
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Map<String, Object> getExtensions() {
 		return extensions._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Map<String, Object> getExtensions(boolean elaborate) {
-		return extensions._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasExtension(String name) {
 		return extensions.containsKey(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Object getExtension(String name) {
 		return extensions._get(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setExtensions(Map<String, Object> extensions) {
 		this.extensions._set(extensions);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setExtension(String name, Object extension) {
 		extensions._set(name, extension);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeExtension(String name) {
 		extensions._remove(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	protected void elaborateChildren() {
 		super.elaborateChildren();
 		url = createChild("url", this, StringOverlay.factory);
@@ -222,7 +192,7 @@ public class ServerImpl extends PropertiesOverlay<Server> implements Server {
 		extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public static OverlayFactory<Server> factory = new OverlayFactory<Server>() {
 
 		@Override
@@ -249,12 +219,12 @@ public class ServerImpl extends PropertiesOverlay<Server> implements Server {
 		}
 	};
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private static Class<? extends Server> getSubtypeOf(Server server) {
 		return Server.class;
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private static Class<? extends Server> getSubtypeOf(JsonNode json) {
 		return Server.class;
 	}

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ServerVariableImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/ServerVariableImpl.java
@@ -21,166 +21,142 @@ import com.reprezen.kaizen.oasparser.model3.ServerVariable;
 
 public class ServerVariableImpl extends PropertiesOverlay<ServerVariable> implements ServerVariable {
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public ServerVariableImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
 		super(json, parent, refReg);
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public ServerVariableImpl(ServerVariable serverVariable, JsonOverlay<?> parent, ReferenceRegistry refReg) {
 		super(serverVariable, parent, refReg);
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildListOverlay<Object> enumValues;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<Object> defaultValue;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<String> description;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildMapOverlay<Object> extensions;
 
 	// EnumValue
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Collection<Object> getEnumValues() {
 		return enumValues._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Collection<Object> getEnumValues(boolean elaborate) {
-		return enumValues._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasEnumValues() {
 		return enumValues._isPresent();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Object getEnumValue(int index) {
 		return enumValues._get(index);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setEnumValues(Collection<Object> enumValues) {
 		this.enumValues._set(enumValues);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setEnumValue(int index, Object enumValue) {
 		enumValues._set(index, enumValue);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void addEnumValue(Object enumValue) {
 		enumValues._add(enumValue);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void insertEnumValue(int index, Object enumValue) {
 		enumValues._insert(index, enumValue);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeEnumValue(int index) {
 		enumValues._remove(index);
 	}
 
 	// Default
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Object getDefault() {
 		return defaultValue._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Object getDefault(boolean elaborate) {
-		return defaultValue._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setDefault(Object defaultValue) {
 		this.defaultValue._set(defaultValue);
 	}
 
 	// Description
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public String getDescription() {
 		return description._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public String getDescription(boolean elaborate) {
-		return description._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setDescription(String description) {
 		this.description._set(description);
 	}
 
 	// Extension
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Map<String, Object> getExtensions() {
 		return extensions._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Map<String, Object> getExtensions(boolean elaborate) {
-		return extensions._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasExtension(String name) {
 		return extensions.containsKey(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Object getExtension(String name) {
 		return extensions._get(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setExtensions(Map<String, Object> extensions) {
 		this.extensions._set(extensions);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setExtension(String name, Object extension) {
 		extensions._set(name, extension);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeExtension(String name) {
 		extensions._remove(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	protected void elaborateChildren() {
 		super.elaborateChildren();
 		enumValues = createChildList("enum", this, PrimitiveOverlay.factory);
@@ -189,7 +165,7 @@ public class ServerVariableImpl extends PropertiesOverlay<ServerVariable> implem
 		extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public static OverlayFactory<ServerVariable> factory = new OverlayFactory<ServerVariable>() {
 
 		@Override
@@ -217,12 +193,12 @@ public class ServerVariableImpl extends PropertiesOverlay<ServerVariable> implem
 		}
 	};
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private static Class<? extends ServerVariable> getSubtypeOf(ServerVariable serverVariable) {
 		return ServerVariable.class;
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private static Class<? extends ServerVariable> getSubtypeOf(JsonNode json) {
 		return ServerVariable.class;
 	}

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/TagImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/TagImpl.java
@@ -19,130 +19,112 @@ import com.reprezen.kaizen.oasparser.model3.Tag;
 
 public class TagImpl extends PropertiesOverlay<Tag> implements Tag {
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public TagImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
 		super(json, parent, refReg);
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public TagImpl(Tag tag, JsonOverlay<?> parent, ReferenceRegistry refReg) {
 		super(tag, parent, refReg);
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<String> name;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<String> description;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<ExternalDocs> externalDocs;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildMapOverlay<Object> extensions;
 
 	// Name
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public String getName() {
 		return name._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public String getName(boolean elaborate) {
-		return name._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setName(String name) {
 		this.name._set(name);
 	}
 
 	// Description
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public String getDescription() {
 		return description._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public String getDescription(boolean elaborate) {
-		return description._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setDescription(String description) {
 		this.description._set(description);
 	}
 
 	// ExternalDocs
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public ExternalDocs getExternalDocs() {
 		return externalDocs._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public ExternalDocs getExternalDocs(boolean elaborate) {
 		return externalDocs._get(elaborate);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setExternalDocs(ExternalDocs externalDocs) {
 		this.externalDocs._set(externalDocs);
 	}
 
 	// Extension
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Map<String, Object> getExtensions() {
 		return extensions._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Map<String, Object> getExtensions(boolean elaborate) {
-		return extensions._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasExtension(String name) {
 		return extensions.containsKey(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Object getExtension(String name) {
 		return extensions._get(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setExtensions(Map<String, Object> extensions) {
 		this.extensions._set(extensions);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setExtension(String name, Object extension) {
 		extensions._set(name, extension);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeExtension(String name) {
 		extensions._remove(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	protected void elaborateChildren() {
 		super.elaborateChildren();
 		name = createChild("name", this, StringOverlay.factory);
@@ -151,7 +133,7 @@ public class TagImpl extends PropertiesOverlay<Tag> implements Tag {
 		extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public static OverlayFactory<Tag> factory = new OverlayFactory<Tag>() {
 
 		@Override
@@ -178,12 +160,12 @@ public class TagImpl extends PropertiesOverlay<Tag> implements Tag {
 		}
 	};
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private static Class<? extends Tag> getSubtypeOf(Tag tag) {
 		return Tag.class;
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private static Class<? extends Tag> getSubtypeOf(JsonNode json) {
 		return Tag.class;
 	}

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/XmlImpl.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/ovl3/XmlImpl.java
@@ -19,186 +19,150 @@ import com.reprezen.kaizen.oasparser.model3.Xml;
 
 public class XmlImpl extends PropertiesOverlay<Xml> implements Xml {
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public XmlImpl(JsonNode json, JsonOverlay<?> parent, ReferenceRegistry refReg) {
 		super(json, parent, refReg);
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public XmlImpl(Xml xml, JsonOverlay<?> parent, ReferenceRegistry refReg) {
 		super(xml, parent, refReg);
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<String> name;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<String> namespace;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<String> prefix;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<Boolean> attribute;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildOverlay<Boolean> wrapped;
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private ChildMapOverlay<Object> extensions;
 
 	// Name
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public String getName() {
 		return name._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public String getName(boolean elaborate) {
-		return name._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setName(String name) {
 		this.name._set(name);
 	}
 
 	// Namespace
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public String getNamespace() {
 		return namespace._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public String getNamespace(boolean elaborate) {
-		return namespace._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setNamespace(String namespace) {
 		this.namespace._set(namespace);
 	}
 
 	// Prefix
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public String getPrefix() {
 		return prefix._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public String getPrefix(boolean elaborate) {
-		return prefix._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setPrefix(String prefix) {
 		this.prefix._set(prefix);
 	}
 
 	// Attribute
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Boolean getAttribute() {
 		return attribute._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Boolean getAttribute(boolean elaborate) {
-		return attribute._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean isAttribute() {
 		return attribute._get() != null ? attribute._get() : false;
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setAttribute(Boolean attribute) {
 		this.attribute._set(attribute);
 	}
 
 	// Wrapped
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Boolean getWrapped() {
 		return wrapped._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Boolean getWrapped(boolean elaborate) {
-		return wrapped._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean isWrapped() {
 		return wrapped._get() != null ? wrapped._get() : false;
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setWrapped(Boolean wrapped) {
 		this.wrapped._set(wrapped);
 	}
 
 	// Extension
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Map<String, Object> getExtensions() {
 		return extensions._get();
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
-	public Map<String, Object> getExtensions(boolean elaborate) {
-		return extensions._get(elaborate);
-	}
-
-	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public boolean hasExtension(String name) {
 		return extensions.containsKey(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public Object getExtension(String name) {
 		return extensions._get(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setExtensions(Map<String, Object> extensions) {
 		this.extensions._set(extensions);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void setExtension(String name, Object extension) {
 		extensions._set(name, extension);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public void removeExtension(String name) {
 		extensions._remove(name);
 	}
 
 	@Override
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	protected void elaborateChildren() {
 		super.elaborateChildren();
 		name = createChild("name", this, StringOverlay.factory);
@@ -209,7 +173,7 @@ public class XmlImpl extends PropertiesOverlay<Xml> implements Xml {
 		extensions = createChildMap("", this, ObjectOverlay.factory, "x-.+");
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	public static OverlayFactory<Xml> factory = new OverlayFactory<Xml>() {
 
 		@Override
@@ -236,12 +200,12 @@ public class XmlImpl extends PropertiesOverlay<Xml> implements Xml {
 		}
 	};
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private static Class<? extends Xml> getSubtypeOf(Xml xml) {
 		return Xml.class;
 	}
 
-	@Generated("com.reprezen.gen.CodeGenerator")
+	@Generated("com.reprezen.jsonoverlay.gen.CodeGenerator")
 	private static Class<? extends Xml> getSubtypeOf(JsonNode json) {
 		return Xml.class;
 	}

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/CallbackValidator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/CallbackValidator.java
@@ -19,13 +19,13 @@ import com.reprezen.kaizen.oasparser.val.Validator;
 
 public class CallbackValidator extends ObjectValidatorBase<Callback> {
 
-    @Inject
-    private Validator<Path> pathValidator;
+	@Inject
+	private Validator<Path> pathValidator;
 
-    @Override
-    public void validateObject(Callback callback, ValidationResults results) {
-        validateMap(callback.getCallbackPaths(false), results, false, null, Regexes.NOEXT_REGEX, pathValidator);
-        validateExtensions(callback.getExtensions(false), results);
-    }
+	@Override
+	public void validateObject(Callback callback, ValidationResults results) {
+		validateMap(callback.getCallbackPaths(), results, false, null, Regexes.NOEXT_REGEX, pathValidator);
+		validateExtensions(callback.getExtensions(), results);
+	}
 
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/ContactValidator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/ContactValidator.java
@@ -16,11 +16,11 @@ import com.reprezen.kaizen.oasparser.val.ValidationResults;
 
 public class ContactValidator extends ObjectValidatorBase<Contact> {
 
-    @Override
-    public void validateObject(Contact contact, ValidationResults results) {
-        validateUrl(contact.getUrl(false), results, false, "url");
-        validateEmail(contact.getEmail(false), results, false, "email");
-        validateExtensions(contact.getExtensions(false), results);
-    }
+	@Override
+	public void validateObject(Contact contact, ValidationResults results) {
+		validateUrl(contact.getUrl(), results, false, "url");
+		validateEmail(contact.getEmail(), results, false, "email");
+		validateExtensions(contact.getExtensions(), results);
+	}
 
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/EncodingPropertyValidator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/EncodingPropertyValidator.java
@@ -16,13 +16,14 @@ import com.reprezen.kaizen.oasparser.val.ValidationResults;
 
 public class EncodingPropertyValidator extends ObjectValidatorBase<EncodingProperty> {
 
-    @Override
-    public void validateObject(EncodingProperty encodingProperty, ValidationResults results) {
-        // no validation for: contentType, explode
-        // TODO Q: spec says "Headers" (capitalized) for peroperty name -assuming it's a typo
-        validateMap(encodingProperty.getHeaders(false), results, false, "headers", Regexes.NOEXT_REGEX, null);
-        validateString(encodingProperty.getStyle(false), results, false, Regexes.STYLE_REGEX, "style");
-        validateExtensions(encodingProperty.getExtensions(false), results);
-    }
+	@Override
+	public void validateObject(EncodingProperty encodingProperty, ValidationResults results) {
+		// no validation for: contentType, explode
+		// TODO Q: spec says "Headers" (capitalized) for peroperty name -assuming it's a
+		// typo
+		validateMap(encodingProperty.getHeaders(), results, false, "headers", Regexes.NOEXT_REGEX, null);
+		validateString(encodingProperty.getStyle(), results, false, Regexes.STYLE_REGEX, "style");
+		validateExtensions(encodingProperty.getExtensions(), results);
+	}
 
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/ExampleValidator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/ExampleValidator.java
@@ -16,9 +16,9 @@ import com.reprezen.kaizen.oasparser.val.ValidationResults;
 
 public class ExampleValidator extends ObjectValidatorBase<Example> {
 
-    @Override
-    public void validateObject(Example object, ValidationResults results) {
-        // TODO Auto-generated method stub
-    }
+	@Override
+	public void validateObject(Example object, ValidationResults results) {
+		// TODO Auto-generated method stub
+	}
 
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/ExternalDocsValidator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/ExternalDocsValidator.java
@@ -16,11 +16,11 @@ import com.reprezen.kaizen.oasparser.val.ValidationResults;
 
 public class ExternalDocsValidator extends ObjectValidatorBase<ExternalDocs> {
 
-    @Override
-    public void validateObject(ExternalDocs externalDocs, ValidationResults results) {
-        // no validation for: description
-        validateUrl(externalDocs.getUrl(false), results, true, "externalDocs");
-        validateExtensions(externalDocs.getExtensions(false), results);
-    }
+	@Override
+	public void validateObject(ExternalDocs externalDocs, ValidationResults results) {
+		// no validation for: description
+		validateUrl(externalDocs.getUrl(), results, true, "externalDocs");
+		validateExtensions(externalDocs.getExtensions(), results);
+	}
 
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/HeaderValidator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/HeaderValidator.java
@@ -25,65 +25,64 @@ import com.reprezen.kaizen.oasparser.val.Validator;
 
 public class HeaderValidator extends ObjectValidatorBase<Header> {
 
-    @Inject
-    private Validator<Schema> schemaValidator;
-    @Inject
-    private Validator<MediaType> mediaTypeValidator;
+	@Inject
+	private Validator<Schema> schemaValidator;
+	@Inject
+	private Validator<MediaType> mediaTypeValidator;
 
-    @Override
-    public void validateObject(Header header, ValidationResults results) {
-        // no validations for: description, deprecated, allowEmptyValue, explode,
-        // example, examples
-        validateString(header.getName(false), results, false, "name");
-        validateString(header.getIn(false), results, false, Regexes.PARAM_IN_REGEX, "in");
-        checkPathParam(header, results);
-        checkRequired(header, results);
-        validateString(header.getStyle(false), results, false, Regexes.STYLE_REGEX, "style");
-        checkAllowReserved(header, results);
-        // TODO Q: Should schema be required in header object?
-        validateField(header.getSchema(false), results, false, "schema", schemaValidator);
-        validateMap(header.getContentMediaTypes(false), results, false, "content", Regexes.NOEXT_REGEX,
-                mediaTypeValidator);
-        validateExtensions(header.getExtensions(false), results);
-    }
+	@Override
+	public void validateObject(Header header, ValidationResults results) {
+		// no validations for: description, deprecated, allowEmptyValue, explode,
+		// example, examples
+		validateString(header.getName(), results, false, "name");
+		validateString(header.getIn(), results, false, Regexes.PARAM_IN_REGEX, "in");
+		checkPathParam(header, results);
+		checkRequired(header, results);
+		validateString(header.getStyle(), results, false, Regexes.STYLE_REGEX, "style");
+		checkAllowReserved(header, results);
+		// TODO Q: Should schema be required in header object?
+		validateField(header.getSchema(false), results, false, "schema", schemaValidator);
+		validateMap(header.getContentMediaTypes(), results, false, "content", Regexes.NOEXT_REGEX, mediaTypeValidator);
+		validateExtensions(header.getExtensions(), results);
+	}
 
-    private void checkPathParam(Header header, ValidationResults results) {
-        if (header.getIn(false) != null && header.getIn(false).equals("path") && header.getName(false) != null) {
-            String path = getPathString(header);
-            if (path != null) {
-                if (!path.matches(".*/\\{" + header.getName(false) + "\\}(/.*)?")) {
-                    results.addError(m.msg("MissingPathTplt|No template for path parameter in path string",
-                            header.getName(false), path), "name");
-                }
-            } else {
-                results.addWarning(m.msg("NoPath|Could not locate path for parameter", header.getName(false),
-                        header.getIn(false)));
-            }
-        }
-    }
+	private void checkPathParam(Header header, ValidationResults results) {
+		if (header.getIn() != null && header.getIn().equals("path") && header.getName() != null) {
+			String path = getPathString(header);
+			if (path != null) {
+				if (!path.matches(".*/\\{" + header.getName() + "\\}(/.*)?")) {
+					results.addError(m.msg("MissingPathTplt|No template for path parameter in path string",
+							header.getName(), path), "name");
+				}
+			} else {
+				results.addWarning(
+						m.msg("NoPath|Could not locate path for parameter", header.getName(), header.getIn()));
+			}
+		}
+	}
 
-    private void checkRequired(Header header, ValidationResults results) {
-        if ("path".equals(header.getIn(false))) {
-            if (header.getRequired(false) != Boolean.TRUE) {
-                results.addError(
-                        m.msg("PathParamReq|Path param must have 'required' property set true", header.getName(false)),
-                        "required");
-            }
-        }
-    }
+	private void checkRequired(Header header, ValidationResults results) {
+		if ("path".equals(header.getIn())) {
+			if (header.getRequired() != Boolean.TRUE) {
+				results.addError(
+						m.msg("PathParamReq|Path param must have 'required' property set true", header.getName()),
+						"required");
+			}
+		}
+	}
 
-    private void checkAllowReserved(Header header, ValidationResults results) {
-        if (header.isAllowReserved() && !"query".equals(header.getIn(false))) {
-            results.addWarning(m.msg("NonQryAllowRsvd|AllowReserved is ignored for non-query parameter",
-                    header.getName(false), header.getIn(false)), "allowReserved");
-        }
-    }
+	private void checkAllowReserved(Header header, ValidationResults results) {
+		if (header.isAllowReserved() && !"query".equals(header.getIn())) {
+			results.addWarning(m.msg("NonQryAllowRsvd|AllowReserved is ignored for non-query parameter",
+					header.getName(), header.getIn()), "allowReserved");
+		}
+	}
 
-    private String getPathString(Header header) {
-        PropertiesOverlay<?> parent = Overlay.getParentPropertiesOverlay(header);
-        while (parent != null && !(parent instanceof Path)) {
-            parent = Overlay.of(parent).getParentPropertiesOverlay();
-        }
-        return parent != null && parent instanceof Path ? Overlay.getPathInParent(parent) : null;
-    }
+	private String getPathString(Header header) {
+		PropertiesOverlay<?> parent = Overlay.getParentPropertiesOverlay(header);
+		while (parent != null && !(parent instanceof Path)) {
+			parent = Overlay.of(parent).getParentPropertiesOverlay();
+		}
+		return parent != null && parent instanceof Path ? Overlay.getPathInParent(parent) : null;
+	}
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/InfoValidator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/InfoValidator.java
@@ -20,17 +20,17 @@ import com.reprezen.kaizen.oasparser.val.Validator;
 
 public class InfoValidator extends ObjectValidatorBase<Info> {
 
-    @Inject
-    private Validator<Contact> contactValidator;
-    @Inject
-    private Validator<License> licenseValidator;
+	@Inject
+	private Validator<Contact> contactValidator;
+	@Inject
+	private Validator<License> licenseValidator;
 
-    @Override
-    public void validateObject(Info info, ValidationResults results) {
-        validateString(info.getTitle(false), results, true, "title");
-        validateField(info.getContact(false), results, false, "contact", contactValidator);
-        validateField(info.getLicense(false), results, false, "license", licenseValidator);
-        validateString(info.getVersion(false), results, true, "version");
-        validateExtensions(info.getExtensions(false), results);
-    }
+	@Override
+	public void validateObject(Info info, ValidationResults results) {
+		validateString(info.getTitle(), results, true, "title");
+		validateField(info.getContact(false), results, false, "contact", contactValidator);
+		validateField(info.getLicense(false), results, false, "license", licenseValidator);
+		validateString(info.getVersion(), results, true, "version");
+		validateExtensions(info.getExtensions(), results);
+	}
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/LicenseValidator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/LicenseValidator.java
@@ -16,11 +16,11 @@ import com.reprezen.kaizen.oasparser.val.ValidationResults;
 
 public class LicenseValidator extends ObjectValidatorBase<License> {
 
-    @Override
-    public void validateObject(License license, ValidationResults results) {
-        validateString(license.getName(false), results, true, "name");
-        validateUrl(license.getUrl(false), results, false, "url");
-        validateExtensions(license.getExtensions(false), results);
-    }
+	@Override
+	public void validateObject(License license, ValidationResults results) {
+		validateString(license.getName(), results, true, "name");
+		validateUrl(license.getUrl(), results, false, "url");
+		validateExtensions(license.getExtensions(), results);
+	}
 
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/LinkValidator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/LinkValidator.java
@@ -42,13 +42,13 @@ public class LinkValidator extends ObjectValidatorBase<Link> {
 		if (op != null) {
 			checkParameters(link, op, results);
 		}
-		validateMap(link.getHeaders(false), results, false, "headers", Regexes.NOEXT_REGEX, headerValidator);
-		validateExtensions(link.getExtensions(false), results);
+		validateMap(link.getHeaders(), results, false, "headers", Regexes.NOEXT_REGEX, headerValidator);
+		validateExtensions(link.getExtensions(), results);
 	}
 
 	private Operation checkValidOperation(Link link, ValidationResults results) {
-		String opId = link.getOperationId(false);
-		String operationRef = link.getOperationRef(false);
+		String opId = link.getOperationId();
+		String operationRef = link.getOperationRef();
 		Operation op = null;
 		if (opId == null && operationRef == null) {
 			results.addError(
@@ -83,8 +83,8 @@ public class LinkValidator extends ObjectValidatorBase<Link> {
 		// TODO Q: parameter name is not sufficient to identify param in operation; will
 		// allow if it's unique, warn if
 		// it's not
-		Map<String, Integer> opParamCounts = getParamNameCounts(op.getParameters(false));
-		for (String paramName : link.getParameters(false).keySet()) {
+		Map<String, Integer> opParamCounts = getParamNameCounts(op.getParameters());
+		for (String paramName : link.getParameters().keySet()) {
 			int count = opParamCounts.get(paramName);
 			if (count == 0) {
 				results.addError(m.msg("BadLinkParam|Link parameter does not appear in linked operation", paramName),
@@ -99,9 +99,9 @@ public class LinkValidator extends ObjectValidatorBase<Link> {
 	}
 
 	private Operation findOperationById(OpenApi3 model, String operationId) {
-		for (Path path : model.getPaths(false).values()) {
-			for (Operation op : path.getOperations(false).values()) {
-				if (operationId.equals(op.getOperationId(false))) {
+		for (Path path : model.getPaths().values()) {
+			for (Operation op : path.getOperations().values()) {
+				if (operationId.equals(op.getOperationId())) {
 					return op;
 				}
 			}
@@ -125,7 +125,7 @@ public class LinkValidator extends ObjectValidatorBase<Link> {
 	private Map<String, Integer> getParamNameCounts(Collection<? extends Parameter> parameters) {
 		Map<String, Integer> counts = Maps.newHashMap();
 		for (Parameter parameter : parameters) {
-			String name = parameter.getName(false);
+			String name = parameter.getName();
 			if (counts.containsKey(name)) {
 				counts.put(name, 1 + counts.get(name));
 			} else {

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/MediaTypeValidator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/MediaTypeValidator.java
@@ -38,12 +38,11 @@ public class MediaTypeValidator extends ObjectValidatorBase<MediaType> {
 		// no validation for: example, examples
 		// TODO Q: Should schema be required in media type?
 		validateField(mediaType.getSchema(false), results, false, "schema", schemaValidator);
-		validateMap(mediaType.getEncodingProperties(false), results, false, "encoding", Regexes.NOEXT_NAME_REGEX,
+		validateMap(mediaType.getEncodingProperties(), results, false, "encoding", Regexes.NOEXT_NAME_REGEX,
 				encodingPropertyValidator);
 		checkEncodingPropsAreProps(mediaType, results);
-		validateExtensions(mediaType.getExtensions(false), results);
-		validateMap(mediaType.getExamples(false), results, false, "examples", Regexes.NOEXT_NAME_REGEX,
-				exampleValidator);
+		validateExtensions(mediaType.getExtensions(), results);
+		validateMap(mediaType.getExamples(), results, false, "examples", Regexes.NOEXT_NAME_REGEX, exampleValidator);
 	}
 
 	void checkEncodingPropsAreProps(MediaType mediaType, ValidationResults results) {
@@ -51,8 +50,8 @@ public class MediaTypeValidator extends ObjectValidatorBase<MediaType> {
 		// additionalProperties?
 		Schema schema = mediaType.getSchema(false);
 		if (Overlay.isElaborated(schema)) {
-			Set<String> propNames = schema.getProperties(false).keySet();
-			for (String encodingPropertyName : mediaType.getEncodingProperties(false).keySet()) {
+			Set<String> propNames = schema.getProperties().keySet();
+			for (String encodingPropertyName : mediaType.getEncodingProperties().keySet()) {
 				if (!propNames.contains(encodingPropertyName)) {
 					results.addError(m.msg(
 							"EncPropNotSchemaProp|Encoding property does not name a schema property for the media type",

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/OAuthFlowValidator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/OAuthFlowValidator.java
@@ -16,13 +16,13 @@ import com.reprezen.kaizen.oasparser.val.ValidationResults;
 
 public class OAuthFlowValidator extends ObjectValidatorBase<OAuthFlow> {
 
-    @Override
-    public void validateObject(OAuthFlow oauthFlow, ValidationResults results) {
-        validateUrl(oauthFlow.getAuthorizationUrl(false), results, true, "authorizationUrl");
-        validateUrl(oauthFlow.getTokenUrl(false), results, true, "tokenUrl");
-        validateUrl(oauthFlow.getRefreshUrl(false), results, true, "refreshUrl");
-        validateMap(oauthFlow.getScopes(false), results, true, "scopes", Regexes.NOEXT_REGEX, null);
-        validateExtensions(oauthFlow.getExtensions(false), results);
-    }
+	@Override
+	public void validateObject(OAuthFlow oauthFlow, ValidationResults results) {
+		validateUrl(oauthFlow.getAuthorizationUrl(), results, true, "authorizationUrl");
+		validateUrl(oauthFlow.getTokenUrl(), results, true, "tokenUrl");
+		validateUrl(oauthFlow.getRefreshUrl(), results, true, "refreshUrl");
+		validateMap(oauthFlow.getScopes(), results, true, "scopes", Regexes.NOEXT_REGEX, null);
+		validateExtensions(oauthFlow.getExtensions(), results);
+	}
 
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/OpenApi3Validator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/OpenApi3Validator.java
@@ -36,66 +36,66 @@ import com.reprezen.kaizen.oasparser.val.Validator;
 
 public class OpenApi3Validator extends ObjectValidatorBase<OpenApi3> {
 
-    @Inject
-    private Validator<Info> infoValidator;
-    @Inject
-    private Validator<Server> serverValidator;
-    @Inject
-    private Validator<Path> pathValidator;
-    @Inject
-    private Validator<Schema> schemaValidator;
-    @Inject
-    private Validator<Response> responseValidator;
-    @Inject
-    private Validator<Parameter> parameterValidator;
-    @Inject
-    private Validator<RequestBody> requestBodyValidator;
-    @Inject
-    private Validator<Header> headerValidator;
-    @Inject
-    private Validator<SecurityScheme> securitySchemeValidator;
-    @Inject
-    private Validator<Link> linkValidator;
-    @Inject
-    private Validator<Callback> callbackValidator;
-    @Inject
-    private Validator<SecurityRequirement> securityRequirementValidator;
-    @Inject
-    private Validator<Tag> tagValidator;
-    @Inject
-    private Validator<ExternalDocs> externalDocsValidator;
+	@Inject
+	private Validator<Info> infoValidator;
+	@Inject
+	private Validator<Server> serverValidator;
+	@Inject
+	private Validator<Path> pathValidator;
+	@Inject
+	private Validator<Schema> schemaValidator;
+	@Inject
+	private Validator<Response> responseValidator;
+	@Inject
+	private Validator<Parameter> parameterValidator;
+	@Inject
+	private Validator<RequestBody> requestBodyValidator;
+	@Inject
+	private Validator<Header> headerValidator;
+	@Inject
+	private Validator<SecurityScheme> securitySchemeValidator;
+	@Inject
+	private Validator<Link> linkValidator;
+	@Inject
+	private Validator<Callback> callbackValidator;
+	@Inject
+	private Validator<SecurityRequirement> securityRequirementValidator;
+	@Inject
+	private Validator<Tag> tagValidator;
+	@Inject
+	private Validator<ExternalDocs> externalDocsValidator;
 
-    @Override
-    public void validateObject(final OpenApi3 swagger, final ValidationResults results) {
-        results.withCrumb("model", new Runnable() {
-            @Override
-            public void run() {
-                validateString(swagger.getOpenApi(false), results, true, "3\\.\\d+(\\.\\d+.*)?", "openapi");
-                validateField(swagger.getInfo(false), results, true, "info", infoValidator);
-                validateList(swagger.getServers(false), swagger.hasServers(), results, false, "servers", serverValidator);
-                validateMap(swagger.getPaths(false), results, true, "paths", PATH_REGEX, pathValidator);
-                validateMap(swagger.getPathsExtensions(false), results, false, "paths", EXT_REGEX, null);
-                validateMap(swagger.getSchemas(false), results, false, "collections/schemas", NAME_REGEX, schemaValidator);
-                validateMap(swagger.getResponses(false), results, false, "collections/responses", NAME_REGEX,
-                        responseValidator);
-                validateMap(swagger.getParameters(false), results, false, "collections/parameters", NAME_REGEX,
-                        parameterValidator);
-                validateMap(swagger.getExamples(false), results, false, "collections/examples", NAME_REGEX, null);
-                validateMap(swagger.getRequestBodies(false), results, false, "collection/requestBodies", NAME_REGEX,
-                        requestBodyValidator);
-                validateMap(swagger.getHeaders(false), results, false, "collections/headers", NAME_REGEX, headerValidator);
-                validateMap(swagger.getSecuritySchemes(false), results, false, "collections/securitySchemes", NAME_REGEX,
-                        securitySchemeValidator);
-                validateMap(swagger.getLinks(false), results, false, "collections/links", NAME_REGEX, linkValidator);
-                validateMap(swagger.getCallbacks(false), results, false, "collections/callbacks", NAME_REGEX,
-                        callbackValidator);
-                validateMap(swagger.getComponentsExtensions(false), results, false, "collections", EXT_REGEX, null);
-                validateList(swagger.getSecurityRequirements(false), swagger.hasSecurityRequirements(), results, false,
-                        "security", securityRequirementValidator);
-                validateList(swagger.getTags(false), swagger.hasTags(), results, false, "tags", tagValidator);
-                validateField(swagger.getExternalDocs(false), results, false, "externalDocs", externalDocsValidator);
-                validateExtensions(swagger.getExtensions(false), results);
-            }
-        });
-    }
+	@Override
+	public void validateObject(final OpenApi3 swagger, final ValidationResults results) {
+		results.withCrumb("model", new Runnable() {
+			@Override
+			public void run() {
+				validateString(swagger.getOpenApi(), results, true, "3\\.\\d+(\\.\\d+.*)?", "openapi");
+				validateField(swagger.getInfo(false), results, true, "info", infoValidator);
+				validateList(swagger.getServers(), swagger.hasServers(), results, false, "servers", serverValidator);
+				validateMap(swagger.getPaths(), results, true, "paths", PATH_REGEX, pathValidator);
+				validateMap(swagger.getPathsExtensions(), results, false, "paths", EXT_REGEX, null);
+				validateMap(swagger.getSchemas(), results, false, "collections/schemas", NAME_REGEX, schemaValidator);
+				validateMap(swagger.getResponses(), results, false, "collections/responses", NAME_REGEX,
+						responseValidator);
+				validateMap(swagger.getParameters(), results, false, "collections/parameters", NAME_REGEX,
+						parameterValidator);
+				validateMap(swagger.getExamples(), results, false, "collections/examples", NAME_REGEX, null);
+				validateMap(swagger.getRequestBodies(), results, false, "collection/requestBodies", NAME_REGEX,
+						requestBodyValidator);
+				validateMap(swagger.getHeaders(), results, false, "collections/headers", NAME_REGEX, headerValidator);
+				validateMap(swagger.getSecuritySchemes(), results, false, "collections/securitySchemes", NAME_REGEX,
+						securitySchemeValidator);
+				validateMap(swagger.getLinks(), results, false, "collections/links", NAME_REGEX, linkValidator);
+				validateMap(swagger.getCallbacks(), results, false, "collections/callbacks", NAME_REGEX,
+						callbackValidator);
+				validateMap(swagger.getComponentsExtensions(), results, false, "collections", EXT_REGEX, null);
+				validateList(swagger.getSecurityRequirements(), swagger.hasSecurityRequirements(), results, false,
+						"security", securityRequirementValidator);
+				validateList(swagger.getTags(), swagger.hasTags(), results, false, "tags", tagValidator);
+				validateField(swagger.getExternalDocs(false), results, false, "externalDocs", externalDocsValidator);
+				validateExtensions(swagger.getExtensions(), results);
+			}
+		});
+	}
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/OperationValidator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/OperationValidator.java
@@ -27,43 +27,44 @@ import com.reprezen.kaizen.oasparser.val.Validator;
 
 public class OperationValidator extends ObjectValidatorBase<Operation> {
 
-    @Inject
-    private Validator<ExternalDocs> externalDocsValidator;
-    @Inject
-    private Validator<Parameter> parameterValidator;
-    @Inject
-    private Validator<RequestBody> requestBodyValidator;
-    @Inject
-    private Validator<Response> responseValidator;
-    @Inject
-    private Validator<Callback> callbackValidator;
-    @Inject
-    private Validator<SecurityRequirement> securityRequirementValidator;
-    @Inject
-    private Validator<Server> serverValidator;
+	@Inject
+	private Validator<ExternalDocs> externalDocsValidator;
+	@Inject
+	private Validator<Parameter> parameterValidator;
+	@Inject
+	private Validator<RequestBody> requestBodyValidator;
+	@Inject
+	private Validator<Response> responseValidator;
+	@Inject
+	private Validator<Callback> callbackValidator;
+	@Inject
+	private Validator<SecurityRequirement> securityRequirementValidator;
+	@Inject
+	private Validator<Server> serverValidator;
 
-    @Override
-    public void validateObject(Operation operation, ValidationResults results) {
-        // no validation for: tags, description, deprecated
-        checkSummaryLength(operation, results);
-        validateField(operation.getExternalDocs(false), results, false, "externalDocs", externalDocsValidator);
-        // TODO Q: Not marked as required in spec, but spec says they all must be unique within the API. Seems like it
-        // should be required.
-        validateString(operation.getOperationId(false), results, false, "operationId");
-        validateList(operation.getParameters(false), operation.hasParameters(), results, false, "parameters",
-                parameterValidator);
-        validateField(operation.getRequestBody(false), results, false, "requestBody", requestBodyValidator);
-        validateMap(operation.getResponses(false), results, true, "responses", Regexes.RESPONSE_REGEX, responseValidator);
-        validateMap(operation.getCallbacks(false), results, false, "callbacks", Regexes.NOEXT_REGEX, callbackValidator);
-        validateList(operation.getSecurityRequirements(false), operation.hasSecurityRequirements(), results, false,
-                "security", securityRequirementValidator);
-        validateList(operation.getServers(false), operation.hasServers(), results, false, "servers", serverValidator);
-    }
+	@Override
+	public void validateObject(Operation operation, ValidationResults results) {
+		// no validation for: tags, description, deprecated
+		checkSummaryLength(operation, results);
+		validateField(operation.getExternalDocs(false), results, false, "externalDocs", externalDocsValidator);
+		// TODO Q: Not marked as required in spec, but spec says they all must be unique
+		// within the API. Seems like it
+		// should be required.
+		validateString(operation.getOperationId(), results, false, "operationId");
+		validateList(operation.getParameters(), operation.hasParameters(), results, false, "parameters",
+				parameterValidator);
+		validateField(operation.getRequestBody(false), results, false, "requestBody", requestBodyValidator);
+		validateMap(operation.getResponses(), results, true, "responses", Regexes.RESPONSE_REGEX, responseValidator);
+		validateMap(operation.getCallbacks(), results, false, "callbacks", Regexes.NOEXT_REGEX, callbackValidator);
+		validateList(operation.getSecurityRequirements(), operation.hasSecurityRequirements(), results, false,
+				"security", securityRequirementValidator);
+		validateList(operation.getServers(), operation.hasServers(), results, false, "servers", serverValidator);
+	}
 
-    private void checkSummaryLength(Operation operation, ValidationResults results) {
-        String summary = operation.getSummary(false);
-        if (summary != null && summary.length() > 120) {
-            results.addWarning(m.msg("LongSummary|Sumamry exceeds recommended limit of 120 chars"), "summary");
-        }
-    }
+	private void checkSummaryLength(Operation operation, ValidationResults results) {
+		String summary = operation.getSummary();
+		if (summary != null && summary.length() > 120) {
+			results.addWarning(m.msg("LongSummary|Sumamry exceeds recommended limit of 120 chars"), "summary");
+		}
+	}
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/ParameterValidator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/ParameterValidator.java
@@ -25,65 +25,65 @@ import com.reprezen.kaizen.oasparser.val.Validator;
 
 public class ParameterValidator extends ObjectValidatorBase<Parameter> {
 
-    @Inject
-    private Validator<Schema> schemaValidator;
-    @Inject
-    private Validator<MediaType> mediaTypeValidator;
+	@Inject
+	private Validator<Schema> schemaValidator;
+	@Inject
+	private Validator<MediaType> mediaTypeValidator;
 
-    @Override
-    public void validateObject(Parameter parameter, ValidationResults results) {
-        // no validations for: description, deprecated, allowEmptyValue, explode,
-        // example, examples
-        validateString(parameter.getName(false), results, true, "name");
-        validateString(parameter.getIn(false), results, true, Regexes.PARAM_IN_REGEX, "in");
-        checkPathParam(parameter, results);
-        checkRequired(parameter, results);
-        validateString(parameter.getStyle(false), results, false, Regexes.STYLE_REGEX, "style");
-        checkAllowReserved(parameter, results);
-        // TODO Q: Should schema be required in parameter object?
-        validateField(parameter.getSchema(false), results, false, "schema", schemaValidator);
-        validateMap(parameter.getContentMediaTypes(false), results, false, "content", Regexes.NOEXT_REGEX,
-                mediaTypeValidator);
-        validateExtensions(parameter.getExtensions(false), results);
-    }
+	@Override
+	public void validateObject(Parameter parameter, ValidationResults results) {
+		// no validations for: description, deprecated, allowEmptyValue, explode,
+		// example, examples
+		validateString(parameter.getName(), results, true, "name");
+		validateString(parameter.getIn(), results, true, Regexes.PARAM_IN_REGEX, "in");
+		checkPathParam(parameter, results);
+		checkRequired(parameter, results);
+		validateString(parameter.getStyle(), results, false, Regexes.STYLE_REGEX, "style");
+		checkAllowReserved(parameter, results);
+		// TODO Q: Should schema be required in parameter object?
+		validateField(parameter.getSchema(false), results, false, "schema", schemaValidator);
+		validateMap(parameter.getContentMediaTypes(), results, false, "content", Regexes.NOEXT_REGEX,
+				mediaTypeValidator);
+		validateExtensions(parameter.getExtensions(), results);
+	}
 
-    private void checkPathParam(Parameter parameter, ValidationResults results) {
-        if (parameter.getIn(false) != null && parameter.getIn(false).equals("path")
-                && parameter.getName(false) != null) {
-            String path = getPathString(parameter);
-            if (path != null) {
-                if (!path.matches(".*/\\{" + parameter.getName(false) + "\\}(/.*)?")) {
-                    results.addError(m.msg("MissingPathTplt|No template for path parameter in path string",
-                            parameter.getName(false), path), "name");
-                }
-            } else {
-                results.addWarning(m.msg("NoPath|Could not locate path for parameter", parameter.getName(false),
-                        parameter.getIn(false)));
-            }
-        }
-    }
+	private void checkPathParam(Parameter parameter, ValidationResults results) {
+		if (parameter.getIn() != null && parameter.getIn().equals("path") && parameter.getName() != null) {
+			String path = getPathString(parameter);
+			if (path != null) {
+				if (!path.matches(".*/\\{" + parameter.getName() + "\\}(/.*)?")) {
+					results.addError(m.msg("MissingPathTplt|No template for path parameter in path string",
+							parameter.getName(), path), "name");
+				}
+			} else {
+				results.addWarning(
+						m.msg("NoPath|Could not locate path for parameter", parameter.getName(), parameter.getIn()));
+			}
+		}
+	}
 
-    private void checkRequired(Parameter parameter, ValidationResults results) {
-        if ("path".equals(parameter.getIn(false))) {
-            if (parameter.getRequired(false) != Boolean.TRUE) {
-                results.addError(m.msg("PathParamReq|Path param must have 'required' property set true",
-                        parameter.getName(false)), "required");
-            }
-        }
-    }
+	private void checkRequired(Parameter parameter, ValidationResults results) {
+		if ("path".equals(parameter.getIn())) {
+			if (parameter.getRequired() != Boolean.TRUE) {
+				results.addError(
+						m.msg("PathParamReq|Path param must have 'required' property set true", parameter.getName()),
+						"required");
+			}
+		}
+	}
 
-    private void checkAllowReserved(Parameter parameter, ValidationResults results) {
-        if (parameter.isAllowReserved() && !"query".equals(parameter.getIn(false))) {
-            results.addWarning(m.msg("NonQryAllowRsvd|AllowReserved is ignored for non-query parameter",
-                    parameter.getName(false), parameter.getIn(false)), "allowReserved");
-        }
-    }
+	private void checkAllowReserved(Parameter parameter, ValidationResults results) {
+		if (parameter.isAllowReserved() && !"query".equals(parameter.getIn())) {
+			results.addWarning(m.msg("NonQryAllowRsvd|AllowReserved is ignored for non-query parameter",
+					parameter.getName(), parameter.getIn()), "allowReserved");
+		}
+	}
 
-    private String getPathString(Parameter parameter) {
-        PropertiesOverlay<?> parent = Overlay.getParentPropertiesOverlay(parameter);
-        while (parent != null && !(parent instanceof Path)) {
-            parent = Overlay.of(parent).getParentPropertiesOverlay();
-        }
-        return parent != null && parent instanceof Path ? Overlay.getPathInParent(parent) : null;
-    }
+	private String getPathString(Parameter parameter) {
+		PropertiesOverlay<?> parent = Overlay.getParentPropertiesOverlay(parameter);
+		while (parent != null && !(parent instanceof Path)) {
+			parent = Overlay.of(parent).getParentPropertiesOverlay();
+		}
+		return parent != null && parent instanceof Path ? Overlay.getPathInParent(parent) : null;
+	}
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/PathValidator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/PathValidator.java
@@ -21,19 +21,19 @@ import com.reprezen.kaizen.oasparser.val.Validator;
 
 public class PathValidator extends ObjectValidatorBase<Path> {
 
-    @Inject
-    private Validator<Operation> operationValidator;
-    @Inject
-    private Validator<Server> serverValidator;
-    @Inject
-    private Validator<Parameter> parameterValidator;
+	@Inject
+	private Validator<Operation> operationValidator;
+	@Inject
+	private Validator<Server> serverValidator;
+	@Inject
+	private Validator<Parameter> parameterValidator;
 
-    @Override
-    public void validateObject(Path path, ValidationResults results) {
-        // no validation for: summary, description
-        validateMap(path.getOperations(false), results, false, null, Regexes.METHOD_REGEX, operationValidator);
-        validateList(path.getServers(false), path.hasServers(), results, false, "servers", serverValidator);
-        validateList(path.getParameters(false), path.hasParameters(), results, false, "parameters", parameterValidator);
-        validateExtensions(path.getExtensions(false), results);
-    }
+	@Override
+	public void validateObject(Path path, ValidationResults results) {
+		// no validation for: summary, description
+		validateMap(path.getOperations(), results, false, null, Regexes.METHOD_REGEX, operationValidator);
+		validateList(path.getServers(), path.hasServers(), results, false, "servers", serverValidator);
+		validateList(path.getParameters(), path.hasParameters(), results, false, "parameters", parameterValidator);
+		validateExtensions(path.getExtensions(), results);
+	}
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/Regexes.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/Regexes.java
@@ -14,14 +14,14 @@ import java.util.regex.Pattern;
 
 public class Regexes {
 
-    public static final Pattern PATH_REGEX = Pattern.compile("/.*");
-    public static final Pattern EXT_REGEX = Pattern.compile("x-.+");
-    public static final Pattern NOEXT_REGEX = Pattern.compile("(?!x-).*");
-    public static final Pattern NAME_REGEX = Pattern.compile("[a-zA-Z0-9\\._-]+");
-    public static final Pattern NOEXT_NAME_REGEX = Pattern.compile("(?!x-)[a-zA-Z0-9\\._-]+");
-    public static final Pattern METHOD_REGEX = Pattern.compile("get|put|post|delete|options|head|patch|trace");
-    public static final Pattern PARAM_IN_REGEX = Pattern.compile("path|query|header|cookie");
-    public static final Pattern STYLE_REGEX = Pattern
-            .compile("matrix|label|form|simple|spaceDelimited|pipeDelimited|deepObject");
-    public static final Pattern RESPONSE_REGEX = Pattern.compile("default|\\d\\d\\d");
+	public static final Pattern PATH_REGEX = Pattern.compile("/.*");
+	public static final Pattern EXT_REGEX = Pattern.compile("x-.+");
+	public static final Pattern NOEXT_REGEX = Pattern.compile("(?!x-).*");
+	public static final Pattern NAME_REGEX = Pattern.compile("[a-zA-Z0-9\\._-]+");
+	public static final Pattern NOEXT_NAME_REGEX = Pattern.compile("(?!x-)[a-zA-Z0-9\\._-]+");
+	public static final Pattern METHOD_REGEX = Pattern.compile("get|put|post|delete|options|head|patch|trace");
+	public static final Pattern PARAM_IN_REGEX = Pattern.compile("path|query|header|cookie");
+	public static final Pattern STYLE_REGEX = Pattern
+			.compile("matrix|label|form|simple|spaceDelimited|pipeDelimited|deepObject");
+	public static final Pattern RESPONSE_REGEX = Pattern.compile("default|\\d\\d\\d");
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/RequestBodyValidator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/RequestBodyValidator.java
@@ -19,15 +19,15 @@ import com.reprezen.kaizen.oasparser.val.Validator;
 
 public class RequestBodyValidator extends ObjectValidatorBase<RequestBody> {
 
-    @Inject
-    private Validator<MediaType> mediaTypeValidator;
+	@Inject
+	private Validator<MediaType> mediaTypeValidator;
 
-    @Override
-    public void validateObject(RequestBody requestBody, ValidationResults results) {
-        // no validation for: description, required
-        validateMap(requestBody.getContentMediaTypes(false), results, false, "content", Regexes.NOEXT_REGEX,
-                mediaTypeValidator);
-        validateExtensions(requestBody.getExtensions(false), results);
-    }
+	@Override
+	public void validateObject(RequestBody requestBody, ValidationResults results) {
+		// no validation for: description, required
+		validateMap(requestBody.getContentMediaTypes(), results, false, "content", Regexes.NOEXT_REGEX,
+				mediaTypeValidator);
+		validateExtensions(requestBody.getExtensions(), results);
+	}
 
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/ResponseValidator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/ResponseValidator.java
@@ -21,19 +21,19 @@ import com.reprezen.kaizen.oasparser.val.Validator;
 
 public class ResponseValidator extends ObjectValidatorBase<Response> {
 
-    @Inject
-    private Validator<Header> headerValidator;
-    @Inject
-    private Validator<MediaType> mediaTypeValidator;
-    @Inject
-    private Validator<Link> linkValidator;
+	@Inject
+	private Validator<Header> headerValidator;
+	@Inject
+	private Validator<MediaType> mediaTypeValidator;
+	@Inject
+	private Validator<Link> linkValidator;
 
-    @Override
-    public void validateObject(Response response, ValidationResults results) {
-        validateMap(response.getHeaders(false), results, false, "headers", null, headerValidator);
-        validateMap(response.getContentMediaTypes(false), results, false, "content", Regexes.NOEXT_REGEX,
-                mediaTypeValidator);
-        validateMap(response.getLinks(false), results, false, "links", Regexes.NOEXT_NAME_REGEX, linkValidator);
-        validateExtensions(response.getExtensions(false), results);
-    }
+	@Override
+	public void validateObject(Response response, ValidationResults results) {
+		validateMap(response.getHeaders(), results, false, "headers", null, headerValidator);
+		validateMap(response.getContentMediaTypes(), results, false, "content", Regexes.NOEXT_REGEX,
+				mediaTypeValidator);
+		validateMap(response.getLinks(), results, false, "links", Regexes.NOEXT_NAME_REGEX, linkValidator);
+		validateExtensions(response.getExtensions(), results);
+	}
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/SchemaValidator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/SchemaValidator.java
@@ -24,69 +24,71 @@ import com.reprezen.kaizen.oasparser.val.Validator;
 
 public class SchemaValidator extends ObjectValidatorBase<Schema> {
 
-    @Inject
-    private Validator<Xml> xmlValidator;
-    @Inject
-    private Validator<ExternalDocs> externalDocsValidator;
-    @Inject
-    private Validator<Example> exampleValidator;
+	@Inject
+	private Validator<Xml> xmlValidator;
+	@Inject
+	private Validator<ExternalDocs> externalDocsValidator;
+	@Inject
+	private Validator<Example> exampleValidator;
 
-    @Override
-    public void validateObject(Schema schema, ValidationResults results) {
-        // no validation for: title, description, maximum, exclusiveMaximum, minimum exclusiveMinimum, uniqueItems,
-        // nullable, example, deprecated
-        validatePositive(schema.getMultipleOf(false), results, false, "multipleOf");
-        validateNonNegative(schema.getMaxLength(false), results, false, "maxLength");
-        validateNonNegative(schema.getMinLength(false), results, false, "minLength");
-        validatePattern(schema.getPattern(false), results, false, "pattern");
-        validateNonNegative(schema.getMaximum(false), results, false, "maxItems");
-        validateNonNegative(schema.getMaximum(false), results, false, "minItems");
-        validateNonNegative(schema.getMaxProperties(false), results, false, "maxProperties");
-        validateNonNegative(schema.getMinProperties(false), results, false, "minProperties");
-        validateUnique(schema.getRequiredFields(false), results, "required");
-        validateList(schema.getEnums(false), schema.hasEnums(), results, false, "enum", null);
-        validateNonEmpty(schema.getEnums(false), schema.hasEnums(), results, "enum");
-        validateUnique(schema.getEnums(false), results, "enum");
-        validateString(schema.getType(false), results, false, "boolean|object|array|number|integer|string", "type");
-        validateList(schema.getAllOfSchemas(false), schema.hasAllOfSchemas(), results, false, "allOf", this);
-        validateList(schema.getOneOfSchemas(false), schema.hasOneOfSchemas(), results, false, "oneOf", this);
-        validateList(schema.getAnyOfSchemas(false), schema.hasAnyOfSchemas(), results, false, "anyOf", this);
-        if (schema.getNotSchema(false) != null && Overlay.isPresent(schema.getNotSchema(false))) {
-            validate(schema.getNotSchema(false), results, "not");
-        }
-        if (schema.getItemsSchema(false) != null && Overlay.isPresent(schema.getItemsSchema(false))) {
-            validate(schema.getItemsSchema(false), results, "items");
-        }
-        validateMap(schema.getProperties(false), results, false, "properties", null, this);
-        validateFormat(schema.getFormat(false), schema.getType(false), results, "format");
-        validateDefault(schema.getDefault(false), schema.getType(false), results, "default");
-        checkDiscriminator(schema, results, "discriminator");
-        checkReadWrite(schema, results);
-        validateField(schema.getXml(false), results, false, "xml", xmlValidator);
-        validateField(schema.getExternalDocs(false), results, false, "externalDocs", externalDocsValidator);
-        validateMap(schema.getExamples(false), results, false, "examples", Regexes.NOEXT_NAME_REGEX, exampleValidator);
-        validateExtensions(schema.getExtensions(false), results);
-    }
+	@Override
+	public void validateObject(Schema schema, ValidationResults results) {
+		// no validation for: title, description, maximum, exclusiveMaximum, minimum
+		// exclusiveMinimum, uniqueItems,
+		// nullable, example, deprecated
+		validatePositive(schema.getMultipleOf(), results, false, "multipleOf");
+		validateNonNegative(schema.getMaxLength(), results, false, "maxLength");
+		validateNonNegative(schema.getMinLength(), results, false, "minLength");
+		validatePattern(schema.getPattern(), results, false, "pattern");
+		validateNonNegative(schema.getMaximum(), results, false, "maxItems");
+		validateNonNegative(schema.getMaximum(), results, false, "minItems");
+		validateNonNegative(schema.getMaxProperties(), results, false, "maxProperties");
+		validateNonNegative(schema.getMinProperties(), results, false, "minProperties");
+		validateUnique(schema.getRequiredFields(), results, "required");
+		validateList(schema.getEnums(), schema.hasEnums(), results, false, "enum", null);
+		validateNonEmpty(schema.getEnums(), schema.hasEnums(), results, "enum");
+		validateUnique(schema.getEnums(), results, "enum");
+		validateString(schema.getType(), results, false, "boolean|object|array|number|integer|string", "type");
+		validateList(schema.getAllOfSchemas(), schema.hasAllOfSchemas(), results, false, "allOf", this);
+		validateList(schema.getOneOfSchemas(), schema.hasOneOfSchemas(), results, false, "oneOf", this);
+		validateList(schema.getAnyOfSchemas(), schema.hasAnyOfSchemas(), results, false, "anyOf", this);
+		if (schema.getNotSchema(false) != null && Overlay.isPresent(schema.getNotSchema(false))) {
+			validate(schema.getNotSchema(false), results, "not");
+		}
+		if (schema.getItemsSchema(false) != null && Overlay.isPresent(schema.getItemsSchema(false))) {
+			validate(schema.getItemsSchema(false), results, "items");
+		}
+		validateMap(schema.getProperties(), results, false, "properties", null, this);
+		validateFormat(schema.getFormat(), schema.getType(), results, "format");
+		validateDefault(schema.getDefault(), schema.getType(), results, "default");
+		checkDiscriminator(schema, results, "discriminator");
+		checkReadWrite(schema, results);
+		validateField(schema.getXml(false), results, false, "xml", xmlValidator);
+		validateField(schema.getExternalDocs(false), results, false, "externalDocs", externalDocsValidator);
+		validateMap(schema.getExamples(), results, false, "examples", Regexes.NOEXT_NAME_REGEX, exampleValidator);
+		validateExtensions(schema.getExtensions(), results);
+	}
 
-    private void checkDiscriminator(Schema schema, ValidationResults results, String crumb) {
-        String discriminator = schema.getDiscriminator(false);
-        if (discriminator != null) {
-            if (!schema.getProperties(false).keySet().contains(discriminator)) {
-                results.addError(m.msg("DiscNotProp|The discriminator is not a property of this schema", discriminator),
-                        crumb);
-            }
-            if (!schema.getRequiredFields(false).contains(discriminator)) {
-                results.addError(
-                        m.msg("DiscNotReq|The discriminator property is not required in this schema", discriminator),
-                        crumb);
-            }
-        }
-    }
+	private void checkDiscriminator(Schema schema, ValidationResults results, String crumb) {
+		String discriminator = schema.getDiscriminator();
+		if (discriminator != null) {
+			if (!schema.getProperties().keySet().contains(discriminator)) {
+				results.addError(m.msg("DiscNotProp|The discriminator is not a property of this schema", discriminator),
+						crumb);
+			}
+			if (!schema.getRequiredFields().contains(discriminator)) {
+				results.addError(
+						m.msg("DiscNotReq|The discriminator property is not required in this schema", discriminator),
+						crumb);
+			}
+		}
+	}
 
-    private void checkReadWrite(Schema schema, ValidationResults results) {
-        if (schema.isReadOnly() && schema.isWriteOnly()) {
-            // don't set crumb... this validation involves multiple fields so is tied to schema
-            results.addError(m.msg("ROnlyAndWOnly|Schema cannot be both ReadOnly and WriteOnly"));
-        }
-    }
+	private void checkReadWrite(Schema schema, ValidationResults results) {
+		if (schema.isReadOnly() && schema.isWriteOnly()) {
+			// don't set crumb... this validation involves multiple fields so is tied to
+			// schema
+			results.addError(m.msg("ROnlyAndWOnly|Schema cannot be both ReadOnly and WriteOnly"));
+		}
+	}
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/SecurityRequirementValidator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/SecurityRequirementValidator.java
@@ -28,8 +28,8 @@ public class SecurityRequirementValidator extends ObjectValidatorBase<SecurityRe
 	@Override
 	public void validateObject(SecurityRequirement securityRequirement, ValidationResults results) {
 		OpenApi3 model = Overlay.getModel(securityRequirement);
-		Set<String> definedSchemes = model.getSecuritySchemes(false).keySet();
-		for (Entry<String, ? extends SecurityParameter> entry : securityRequirement.getRequirements(false).entrySet()) {
+		Set<String> definedSchemes = model.getSecuritySchemes().keySet();
+		for (Entry<String, ? extends SecurityParameter> entry : securityRequirement.getRequirements().entrySet()) {
 			if (!definedSchemes.contains(entry.getKey())) {
 				results.addError(
 						m.msg("UnkSecScheme|Security scheme not defined in components object", entry.getKey()));
@@ -41,7 +41,7 @@ public class SecurityRequirementValidator extends ObjectValidatorBase<SecurityRe
 					// TODO Q: anything to test here? do we know what the allowed scope names are?
 					break;
 				default:
-					if (!entry.getValue().getParameters(false).isEmpty()) {
+					if (!entry.getValue().getParameters().isEmpty()) {
 						results.addError(Messages.m.msg(
 								"NonEmptySecReqParms|Security requirement parameters must be empty unless scheme type is oauth2 or openIdConnect",
 								entry.getKey(), type));

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/SecuritySchemeValidator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/SecuritySchemeValidator.java
@@ -19,34 +19,38 @@ import com.reprezen.kaizen.oasparser.val.Validator;
 
 public class SecuritySchemeValidator extends ObjectValidatorBase<SecurityScheme> {
 
-    @Inject
-    private Validator<OAuthFlow> oauthFlowValidator;
+	@Inject
+	private Validator<OAuthFlow> oauthFlowValidator;
 
-    @Override
-    public void validateObject(SecurityScheme securityScheme, ValidationResults results) {
-        // no validation for: description, bearerFormat
-        validateString(securityScheme.getType(false), results, true, "apiKey|http|oauth2|openIdConnect", "type");
-        switch (securityScheme.getType(false)) {
-            case "http":
-            	validateString(securityScheme.getScheme(false), results, true, "scheme");
-                // If bearer validate bearerFormat
-                break;
-            case "apiKey":
-                validateString(securityScheme.getName(false), results, true, "name");
-                validateString(securityScheme.getIn(false), results, true, "query|header|cookie", "in");
-                break;
-            case "oauth2":
-                validateField(securityScheme.getImplicitOAuthFlow(false), results, false, "flow.implicit", oauthFlowValidator);
-                validateField(securityScheme.getImplicitOAuthFlow(false), results, false, "flow.password", oauthFlowValidator);
-                validateField(securityScheme.getImplicitOAuthFlow(false), results, false, "flow.clientCredentials", oauthFlowValidator);
-                validateField(securityScheme.getImplicitOAuthFlow(false), results, false, "authorizationCode", oauthFlowValidator);
-                validateExtensions(securityScheme.getOAuthFlowsExtensions(false), results, "flow");
-                break;
-            case "openIdConnect":
-                validateUrl(securityScheme.getOpenIdConnectUrl(false), results, true, "openIdConnectUrl");
-                break;
-        }
-        validateExtensions(securityScheme.getExtensions(false), results);
-    }
+	@Override
+	public void validateObject(SecurityScheme securityScheme, ValidationResults results) {
+		// no validation for: description, bearerFormat
+		validateString(securityScheme.getType(), results, true, "apiKey|http|oauth2|openIdConnect", "type");
+		switch (securityScheme.getType()) {
+		case "http":
+			validateString(securityScheme.getScheme(), results, true, "scheme");
+			// If bearer validate bearerFormat
+			break;
+		case "apiKey":
+			validateString(securityScheme.getName(), results, true, "name");
+			validateString(securityScheme.getIn(), results, true, "query|header|cookie", "in");
+			break;
+		case "oauth2":
+			validateField(securityScheme.getImplicitOAuthFlow(false), results, false, "flow.implicit",
+					oauthFlowValidator);
+			validateField(securityScheme.getImplicitOAuthFlow(false), results, false, "flow.password",
+					oauthFlowValidator);
+			validateField(securityScheme.getImplicitOAuthFlow(false), results, false, "flow.clientCredentials",
+					oauthFlowValidator);
+			validateField(securityScheme.getImplicitOAuthFlow(false), results, false, "authorizationCode",
+					oauthFlowValidator);
+			validateExtensions(securityScheme.getOAuthFlowsExtensions(), results, "flow");
+			break;
+		case "openIdConnect":
+			validateUrl(securityScheme.getOpenIdConnectUrl(), results, true, "openIdConnectUrl");
+			break;
+		}
+		validateExtensions(securityScheme.getExtensions(), results);
+	}
 
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/ServerValidator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/ServerValidator.java
@@ -21,14 +21,14 @@ import com.reprezen.kaizen.oasparser.val.Validator;
 
 public class ServerValidator extends ObjectValidatorBase<Server> {
 
-    @Inject
-    private Validator<ServerVariable> serverVariableValidator;
+	@Inject
+	private Validator<ServerVariable> serverVariableValidator;
 
-    @Override
-    public void validateObject(Server server, ValidationResults results) {
-        // no validation for: description
-        validateUrl(server.getUrl(false), results, false, "url", true);
-        validateMap(server.getServerVariables(false), results, false, "variables", NAME_REGEX, serverVariableValidator);
-        validateExtensions(server.getExtensions(false), results);
-    }
+	@Override
+	public void validateObject(Server server, ValidationResults results) {
+		// no validation for: description
+		validateUrl(server.getUrl(), results, false, "url", true);
+		validateMap(server.getServerVariables(), results, false, "variables", NAME_REGEX, serverVariableValidator);
+		validateExtensions(server.getExtensions(), results);
+	}
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/ServerVariableValidator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/ServerVariableValidator.java
@@ -19,39 +19,39 @@ import com.reprezen.kaizen.oasparser.val.ValidationResults;
 
 public class ServerVariableValidator extends ObjectValidatorBase<ServerVariable> {
 
-    @Override
-    public void validateObject(final ServerVariable variable, final ValidationResults results) {
-        results.withCrumb("enum", new Runnable() {
-            @Override
-            public void run() {
-                int i = 0;
-                for (Object primitive : variable.getEnumValues(false)) {
-                    checkPrimitive(primitive, results, i++);
-                }
-            }
-        });
-        results.withCrumb("default", new Runnable() {
-            @Override
-            public void run() {
-                checkPrimitive(variable.getDefault(false), results, "default");
-            }
-        });
-        validateString(variable.getDescription(false), results, false, "description");
-    }
+	@Override
+	public void validateObject(final ServerVariable variable, final ValidationResults results) {
+		results.withCrumb("enum", new Runnable() {
+			@Override
+			public void run() {
+				int i = 0;
+				for (Object primitive : variable.getEnumValues()) {
+					checkPrimitive(primitive, results, i++);
+				}
+			}
+		});
+		results.withCrumb("default", new Runnable() {
+			@Override
+			public void run() {
+				checkPrimitive(variable.getDefault(), results, "default");
+			}
+		});
+		validateString(variable.getDescription(), results, false, "description");
+	}
 
-    private void checkPrimitive(Object primitive, ValidationResults results, int index) {
-        checkPrimitive(primitive, results, "[" + index + "]");
-    }
+	private void checkPrimitive(Object primitive, ValidationResults results, int index) {
+		checkPrimitive(primitive, results, "[" + index + "]");
+	}
 
-    private void checkPrimitive(final Object primitive, ValidationResults results, String crumb) {
-        if (!(primitive instanceof String || primitive instanceof Number || primitive instanceof Boolean)) {
-            results.withCrumb(crumb, new Runnable() {
-                @Override
-                public void run() {
-                    Messages.m.msg("BadPrimitive|Invalid primitive value", String.valueOf(primitive),
-                            (primitive != null ? primitive.getClass() : NullType.class).getName());
-                }
-            });
-        }
-    }
+	private void checkPrimitive(final Object primitive, ValidationResults results, String crumb) {
+		if (!(primitive instanceof String || primitive instanceof Number || primitive instanceof Boolean)) {
+			results.withCrumb(crumb, new Runnable() {
+				@Override
+				public void run() {
+					Messages.m.msg("BadPrimitive|Invalid primitive value", String.valueOf(primitive),
+							(primitive != null ? primitive.getClass() : NullType.class).getName());
+				}
+			});
+		}
+	}
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/TagValidator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/TagValidator.java
@@ -19,14 +19,14 @@ import com.reprezen.kaizen.oasparser.val.Validator;
 
 public class TagValidator extends ObjectValidatorBase<Tag> {
 
-    @Inject
-    private Validator<ExternalDocs> externalDocsValidator;
+	@Inject
+	private Validator<ExternalDocs> externalDocsValidator;
 
-    @Override
-    public void validateObject(Tag tag, ValidationResults results) {
-        validateString(tag.getName(false), results, true, "name");
-        validateField(tag.getExternalDocs(false), results, false, "externalDocs", externalDocsValidator);
-        validateExtensions(tag.getExtensions(false), results);
-    }
+	@Override
+	public void validateObject(Tag tag, ValidationResults results) {
+		validateString(tag.getName(), results, true, "name");
+		validateField(tag.getExternalDocs(false), results, false, "externalDocs", externalDocsValidator);
+		validateExtensions(tag.getExtensions(), results);
+	}
 
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/ValidationConfigurator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/ValidationConfigurator.java
@@ -40,59 +40,59 @@ import com.reprezen.kaizen.oasparser.val.Validator;
 
 public abstract class ValidationConfigurator extends AbstractModule {
 
-    @Override
-    protected void configure() {
-        bind(new TypeLiteral<Validator<Callback>>() {
-        }).to(CallbackValidator.class);
-        bind(new TypeLiteral<Validator<Contact>>() {
-        }).to(ContactValidator.class);
-        bind(new TypeLiteral<Validator<EncodingProperty>>() {
-        }).to(EncodingPropertyValidator.class);
-        bind(new TypeLiteral<Validator<Example>>() {
-        }).to(ExampleValidator.class);
-        bind(new TypeLiteral<Validator<ExternalDocs>>() {
-        }).to(ExternalDocsValidator.class);
-        bind(new TypeLiteral<Validator<Header>>() {
-        }).to(HeaderValidator.class);
-        bind(new TypeLiteral<Validator<Info>>() {
-        }).to(InfoValidator.class);
-        bind(new TypeLiteral<Validator<License>>() {
-        }).to(LicenseValidator.class);
-        bind(new TypeLiteral<Validator<Link>>() {
-        }).to(LinkValidator.class);
-        bind(new TypeLiteral<Validator<MediaType>>() {
-        }).to(MediaTypeValidator.class);
-        bind(new TypeLiteral<Validator<OAuthFlow>>() {
-        }).to(OAuthFlowValidator.class);
-        bind(new TypeLiteral<Validator<Operation>>() {
-        }).to(OperationValidator.class);
-        bind(new TypeLiteral<Validator<Parameter>>() {
-        }).to(ParameterValidator.class);
-        bind(new TypeLiteral<Validator<Path>>() {
-        }).to(PathValidator.class);
-        bind(new TypeLiteral<Validator<RequestBody>>() {
-        }).to(RequestBodyValidator.class);
-        bind(new TypeLiteral<Validator<Response>>() {
-        }).to(ResponseValidator.class);
-        bind(new TypeLiteral<Validator<Schema>>() {
-        }).to(SchemaValidator.class);
-        bind(new TypeLiteral<Validator<SecurityRequirement>>() {
-        }).to(SecurityRequirementValidator.class);
-        bind(new TypeLiteral<Validator<SecurityScheme>>() {
-        }).to(SecuritySchemeValidator.class);
-        bind(new TypeLiteral<Validator<Server>>() {
-        }).to(ServerValidator.class);
-        bind(new TypeLiteral<Validator<ServerVariable>>() {
-        }).to(ServerVariableValidator.class);
-        bind(new TypeLiteral<Validator<OpenApi3>>() {
-        }).to(OpenApi3Validator.class);
-        bind(new TypeLiteral<Validator<Tag>>() {
-        }).to(TagValidator.class);
-        bind(new TypeLiteral<Validator<Xml>>() {
-        }).to(XmlValidator.class);
+	@Override
+	protected void configure() {
+		bind(new TypeLiteral<Validator<Callback>>() {
+		}).to(CallbackValidator.class);
+		bind(new TypeLiteral<Validator<Contact>>() {
+		}).to(ContactValidator.class);
+		bind(new TypeLiteral<Validator<EncodingProperty>>() {
+		}).to(EncodingPropertyValidator.class);
+		bind(new TypeLiteral<Validator<Example>>() {
+		}).to(ExampleValidator.class);
+		bind(new TypeLiteral<Validator<ExternalDocs>>() {
+		}).to(ExternalDocsValidator.class);
+		bind(new TypeLiteral<Validator<Header>>() {
+		}).to(HeaderValidator.class);
+		bind(new TypeLiteral<Validator<Info>>() {
+		}).to(InfoValidator.class);
+		bind(new TypeLiteral<Validator<License>>() {
+		}).to(LicenseValidator.class);
+		bind(new TypeLiteral<Validator<Link>>() {
+		}).to(LinkValidator.class);
+		bind(new TypeLiteral<Validator<MediaType>>() {
+		}).to(MediaTypeValidator.class);
+		bind(new TypeLiteral<Validator<OAuthFlow>>() {
+		}).to(OAuthFlowValidator.class);
+		bind(new TypeLiteral<Validator<Operation>>() {
+		}).to(OperationValidator.class);
+		bind(new TypeLiteral<Validator<Parameter>>() {
+		}).to(ParameterValidator.class);
+		bind(new TypeLiteral<Validator<Path>>() {
+		}).to(PathValidator.class);
+		bind(new TypeLiteral<Validator<RequestBody>>() {
+		}).to(RequestBodyValidator.class);
+		bind(new TypeLiteral<Validator<Response>>() {
+		}).to(ResponseValidator.class);
+		bind(new TypeLiteral<Validator<Schema>>() {
+		}).to(SchemaValidator.class);
+		bind(new TypeLiteral<Validator<SecurityRequirement>>() {
+		}).to(SecurityRequirementValidator.class);
+		bind(new TypeLiteral<Validator<SecurityScheme>>() {
+		}).to(SecuritySchemeValidator.class);
+		bind(new TypeLiteral<Validator<Server>>() {
+		}).to(ServerValidator.class);
+		bind(new TypeLiteral<Validator<ServerVariable>>() {
+		}).to(ServerVariableValidator.class);
+		bind(new TypeLiteral<Validator<OpenApi3>>() {
+		}).to(OpenApi3Validator.class);
+		bind(new TypeLiteral<Validator<Tag>>() {
+		}).to(TagValidator.class);
+		bind(new TypeLiteral<Validator<Xml>>() {
+		}).to(XmlValidator.class);
 
-        configureImplValidators();
-    }
+		configureImplValidators();
+	}
 
-    protected abstract void configureImplValidators();
+	protected abstract void configureImplValidators();
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/XmlValidator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/XmlValidator.java
@@ -18,11 +18,11 @@ import com.reprezen.kaizen.oasparser.val.ValidationResults;
 
 public class XmlValidator extends ObjectValidatorBase<Xml> {
 
-    @Override
-    public void validateObject(Xml xml, ValidationResults results) {
-        // no validation for: name, prefix, attribute, wrapped
-        validateUrl(xml.getNamespace(false), results, false, "namespace", false, Severity.WARNING);
-        validateExtensions(xml.getExtensions(false), results);
-    }
+	@Override
+	public void validateObject(Xml xml, ValidationResults results) {
+		// no validation for: name, prefix, attribute, wrapped
+		validateUrl(xml.getNamespace(), results, false, "namespace", false, Severity.WARNING);
+		validateExtensions(xml.getExtensions(), results);
+	}
 
 }


### PR DESCRIPTION
Regenerated all sources, removed boolean params from most `get` methods
in validator classes, because the elaboration-suppressing methods are no
longer generated for maps, lists, and primitive overlays (they never had
any impact in the past).

Bumped version to 2.0, as this is a breaking change.