### PR TITLE
[#180] Add position information to validation items

### DIFF
--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val/ValidatorBase.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val/ValidatorBase.java
@@ -89,20 +89,15 @@ public abstract class ValidatorBase<T> implements Validator<T> {
 		}
 	}
 
-	public void validateUrl(String value, ValidationResults results, boolean required, String crumb) {
-		validateUrl(value, results, required, crumb, false);
+	public <V> void validateUrl(String value, ValidationResults results, boolean required, String crumb, PropertiesOverlay<V> overlay) {
+		validateUrl(value, results, required, crumb, false, Severity.ERROR, overlay);
 	}
 
-	public void validateUrl(String value, ValidationResults results, boolean required, String crumb,
-			boolean allowVars) {
-		validateUrl(value, results, required, crumb, allowVars, Severity.ERROR);
-	}
-
-	public void validateUrl(final String value, final ValidationResults results, boolean required, String crumb,
-			final boolean allowVars, final Severity severity) {
+	public <V> void validateUrl(final String value, final ValidationResults results, boolean required, String crumb,
+	                        final boolean allowVars, final Severity severity, PropertiesOverlay<V> overlay) {
 		validateString(value, results, required, crumb);
 		if (value != null) {
-			checkUrl(value, results, allowVars, severity, crumb);
+			checkUrl(value, results, allowVars, severity, crumb, overlay);
 		}
 	}
 
@@ -290,7 +285,7 @@ public abstract class ValidatorBase<T> implements Validator<T> {
 			.substring(ValidatorBase.class.getPackage().getName().length() + 1);
 	private static boolean specialSchemeInited = false;
 
-	private void checkUrl(String url, ValidationResults results, boolean allowVars, Severity severity, String crumb) {
+	private void checkUrl(String url, ValidationResults results, boolean allowVars, Severity severity, String crumb, PropertiesOverlay<?> overlay) {
 		// TODO Q: Any help from spec in being able to validate URLs with vars? E.g is
 		// our treatment here valid? We
 		// assume vars can only appear where simple text can appear, so handling vars
@@ -315,7 +310,7 @@ public abstract class ValidatorBase<T> implements Validator<T> {
 		try {
 			new URL(url);
 		} catch (MalformedURLException e) {
-			results.addError(m.msg("BadUrl|Invalid URL", origUrl, e.toString()), crumb);
+			results.addError(m.msg("BadUrl|Invalid URL", origUrl, e.toString()), crumb, Overlay.of(overlay, crumb, String.class));
 		}
 	}
 

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/ContactValidator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/ContactValidator.java
@@ -11,16 +11,19 @@
 package com.reprezen.kaizen.oasparser.val3;
 
 import com.reprezen.kaizen.oasparser.model3.Contact;
+import com.reprezen.kaizen.oasparser.ovl3.ContactImpl;
 import com.reprezen.kaizen.oasparser.val.ObjectValidatorBase;
 import com.reprezen.kaizen.oasparser.val.ValidationResults;
 
+import javax.print.attribute.standard.Severity;
+
 public class ContactValidator extends ObjectValidatorBase<Contact> {
 
-    @Override
-    public void validateObject(Contact contact, ValidationResults results) {
-	validateUrl(contact.getUrl(), results, false, "url");
-	validateEmail(contact.getEmail(), results, false, "email");
-	validateExtensions(contact.getExtensions(), results);
-    }
+	@Override
+	public void validateObject(Contact contact, ValidationResults results) {
+		validateUrl(contact.getUrl(), results, false, "url", false, Severity.ERROR, (ContactImpl) contact);
+		validateEmail(contact.getEmail(), results, false, "email");
+		validateExtensions(contact.getExtensions(), results);
+	}
 
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/ExternalDocsValidator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/ExternalDocsValidator.java
@@ -11,16 +11,19 @@
 package com.reprezen.kaizen.oasparser.val3;
 
 import com.reprezen.kaizen.oasparser.model3.ExternalDocs;
+import com.reprezen.kaizen.oasparser.ovl3.ExternalDocsImpl;
 import com.reprezen.kaizen.oasparser.val.ObjectValidatorBase;
 import com.reprezen.kaizen.oasparser.val.ValidationResults;
 
+import javax.print.attribute.standard.Severity;
+
 public class ExternalDocsValidator extends ObjectValidatorBase<ExternalDocs> {
 
-    @Override
-    public void validateObject(ExternalDocs externalDocs, ValidationResults results) {
-	// no validation for: description
-	validateUrl(externalDocs.getUrl(), results, true, "externalDocs");
-	validateExtensions(externalDocs.getExtensions(), results);
-    }
+	@Override
+	public void validateObject(ExternalDocs externalDocs, ValidationResults results) {
+		// no validation for: description
+		validateUrl(externalDocs.getUrl(), results, true, "externalDocs", false, Severity.ERROR, (ExternalDocsImpl) externalDocs);
+		validateExtensions(externalDocs.getExtensions(), results);
+	}
 
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/LicenseValidator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/LicenseValidator.java
@@ -11,16 +11,17 @@
 package com.reprezen.kaizen.oasparser.val3;
 
 import com.reprezen.kaizen.oasparser.model3.License;
+import com.reprezen.kaizen.oasparser.ovl3.LicenseImpl;
 import com.reprezen.kaizen.oasparser.val.ObjectValidatorBase;
 import com.reprezen.kaizen.oasparser.val.ValidationResults;
 
 public class LicenseValidator extends ObjectValidatorBase<License> {
 
-    @Override
-    public void validateObject(License license, ValidationResults results) {
-	validateString(license.getName(), results, true, "name");
-	validateUrl(license.getUrl(), results, false, "url");
-	validateExtensions(license.getExtensions(), results);
-    }
+	@Override
+	public void validateObject(License license, ValidationResults results) {
+		validateString(license.getName(), results, true, "name");
+		validateUrl(license.getUrl(), results, false, "url", (LicenseImpl) license);
+		validateExtensions(license.getExtensions(), results);
+	}
 
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/OAuthFlowValidator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/OAuthFlowValidator.java
@@ -11,18 +11,21 @@
 package com.reprezen.kaizen.oasparser.val3;
 
 import com.reprezen.kaizen.oasparser.model3.OAuthFlow;
+import com.reprezen.kaizen.oasparser.ovl3.OAuthFlowImpl;
 import com.reprezen.kaizen.oasparser.val.ObjectValidatorBase;
 import com.reprezen.kaizen.oasparser.val.ValidationResults;
 
+import javax.print.attribute.standard.Severity;
+
 public class OAuthFlowValidator extends ObjectValidatorBase<OAuthFlow> {
 
-    @Override
-    public void validateObject(OAuthFlow oauthFlow, ValidationResults results) {
-	validateUrl(oauthFlow.getAuthorizationUrl(), results, true, "authorizationUrl");
-	validateUrl(oauthFlow.getTokenUrl(), results, true, "tokenUrl");
-	validateUrl(oauthFlow.getRefreshUrl(), results, true, "refreshUrl");
-	validateMap(oauthFlow.getScopes(), results, true, "scopes", Regexes.NOEXT_REGEX, null);
-	validateExtensions(oauthFlow.getExtensions(), results);
-    }
+	@Override
+	public void validateObject(OAuthFlow oauthFlow, ValidationResults results) {
+		validateUrl(oauthFlow.getAuthorizationUrl(), results, true, "authorizationUrl", false, Severity.ERROR, (OAuthFlowImpl) oauthFlow);
+		validateUrl(oauthFlow.getTokenUrl(), results, true, "tokenUrl", false, Severity.ERROR, (OAuthFlowImpl) oauthFlow);
+		validateUrl(oauthFlow.getRefreshUrl(), results, true, "refreshUrl", false, Severity.ERROR, (OAuthFlowImpl) oauthFlow);
+		validateMap(oauthFlow.getScopes(), results, true, "scopes", Regexes.NOEXT_REGEX, null);
+		validateExtensions(oauthFlow.getExtensions(), results);
+	}
 
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/SecuritySchemeValidator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/SecuritySchemeValidator.java
@@ -13,44 +13,47 @@ package com.reprezen.kaizen.oasparser.val3;
 import com.google.inject.Inject;
 import com.reprezen.kaizen.oasparser.model3.OAuthFlow;
 import com.reprezen.kaizen.oasparser.model3.SecurityScheme;
+import com.reprezen.kaizen.oasparser.ovl3.SecuritySchemeImpl;
 import com.reprezen.kaizen.oasparser.val.ObjectValidatorBase;
 import com.reprezen.kaizen.oasparser.val.ValidationResults;
 import com.reprezen.kaizen.oasparser.val.Validator;
 
+import javax.print.attribute.standard.Severity;
+
 public class SecuritySchemeValidator extends ObjectValidatorBase<SecurityScheme> {
 
-    @Inject
-    private Validator<OAuthFlow> oauthFlowValidator;
+	@Inject
+	private Validator<OAuthFlow> oauthFlowValidator;
 
-    @Override
-    public void validateObject(SecurityScheme securityScheme, ValidationResults results) {
-	// no validation for: description, bearerFormat
-	validateString(securityScheme.getType(), results, true, "apiKey|http|oauth2|openIdConnect", "type");
-	switch (securityScheme.getType()) {
-	case "http":
-	    validateString(securityScheme.getScheme(), results, true, "scheme");
-	    // If bearer validate bearerFormat
-	    break;
-	case "apiKey":
-	    validateString(securityScheme.getName(), results, true, "name");
-	    validateString(securityScheme.getIn(), results, true, "query|header|cookie", "in");
-	    break;
-	case "oauth2":
-	    validateField(securityScheme.getImplicitOAuthFlow(false), results, false, "flow.implicit",
-		    oauthFlowValidator);
-	    validateField(securityScheme.getImplicitOAuthFlow(false), results, false, "flow.password",
-		    oauthFlowValidator);
-	    validateField(securityScheme.getImplicitOAuthFlow(false), results, false, "flow.clientCredentials",
-		    oauthFlowValidator);
-	    validateField(securityScheme.getImplicitOAuthFlow(false), results, false, "authorizationCode",
-		    oauthFlowValidator);
-	    validateExtensions(securityScheme.getOAuthFlowsExtensions(), results, "flow");
-	    break;
-	case "openIdConnect":
-	    validateUrl(securityScheme.getOpenIdConnectUrl(), results, true, "openIdConnectUrl");
-	    break;
+	@Override
+	public void validateObject(SecurityScheme securityScheme, ValidationResults results) {
+		// no validation for: description, bearerFormat
+		validateString(securityScheme.getType(), results, true, "apiKey|http|oauth2|openIdConnect", "type");
+		switch (securityScheme.getType()) {
+			case "http":
+				validateString(securityScheme.getScheme(), results, true, "scheme");
+				// If bearer validate bearerFormat
+				break;
+			case "apiKey":
+				validateString(securityScheme.getName(), results, true, "name");
+				validateString(securityScheme.getIn(), results, true, "query|header|cookie", "in");
+				break;
+			case "oauth2":
+				validateField(securityScheme.getImplicitOAuthFlow(false), results, false, "flow.implicit",
+						oauthFlowValidator);
+				validateField(securityScheme.getImplicitOAuthFlow(false), results, false, "flow.password",
+						oauthFlowValidator);
+				validateField(securityScheme.getImplicitOAuthFlow(false), results, false, "flow.clientCredentials",
+						oauthFlowValidator);
+				validateField(securityScheme.getImplicitOAuthFlow(false), results, false, "authorizationCode",
+						oauthFlowValidator);
+				validateExtensions(securityScheme.getOAuthFlowsExtensions(), results, "flow");
+				break;
+			case "openIdConnect":
+				validateUrl(securityScheme.getOpenIdConnectUrl(), results, true, "openIdConnectUrl", false, Severity.ERROR, (SecuritySchemeImpl) securityScheme);
+				break;
+		}
+		validateExtensions(securityScheme.getExtensions(), results);
 	}
-	validateExtensions(securityScheme.getExtensions(), results);
-    }
 
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/ServerValidator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/ServerValidator.java
@@ -10,25 +10,28 @@
  *******************************************************************************/
 package com.reprezen.kaizen.oasparser.val3;
 
-import static com.reprezen.kaizen.oasparser.val3.Regexes.NAME_REGEX;
-
 import com.google.inject.Inject;
 import com.reprezen.kaizen.oasparser.model3.Server;
 import com.reprezen.kaizen.oasparser.model3.ServerVariable;
+import com.reprezen.kaizen.oasparser.ovl3.ServerImpl;
 import com.reprezen.kaizen.oasparser.val.ObjectValidatorBase;
 import com.reprezen.kaizen.oasparser.val.ValidationResults;
 import com.reprezen.kaizen.oasparser.val.Validator;
 
+import javax.print.attribute.standard.Severity;
+
+import static com.reprezen.kaizen.oasparser.val3.Regexes.NAME_REGEX;
+
 public class ServerValidator extends ObjectValidatorBase<Server> {
 
-    @Inject
-    private Validator<ServerVariable> serverVariableValidator;
+	@Inject
+	private Validator<ServerVariable> serverVariableValidator;
 
-    @Override
-    public void validateObject(Server server, ValidationResults results) {
-	// no validation for: description
-	validateUrl(server.getUrl(), results, false, "url", true);
-	validateMap(server.getServerVariables(), results, false, "variables", NAME_REGEX, serverVariableValidator);
-	validateExtensions(server.getExtensions(), results);
-    }
+	@Override
+	public void validateObject(Server server, ValidationResults results) {
+		// no validation for: description
+		validateUrl(server.getUrl(), results, false, "url", true, Severity.ERROR, (ServerImpl) server);
+		validateMap(server.getServerVariables(), results, false, "variables", NAME_REGEX, serverVariableValidator);
+		validateExtensions(server.getExtensions(), results);
+	}
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/XmlValidator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/XmlValidator.java
@@ -10,19 +10,20 @@
  *******************************************************************************/
 package com.reprezen.kaizen.oasparser.val3;
 
-import javax.print.attribute.standard.Severity;
-
 import com.reprezen.kaizen.oasparser.model3.Xml;
+import com.reprezen.kaizen.oasparser.ovl3.XmlImpl;
 import com.reprezen.kaizen.oasparser.val.ObjectValidatorBase;
 import com.reprezen.kaizen.oasparser.val.ValidationResults;
 
+import javax.print.attribute.standard.Severity;
+
 public class XmlValidator extends ObjectValidatorBase<Xml> {
 
-    @Override
-    public void validateObject(Xml xml, ValidationResults results) {
-	// no validation for: name, prefix, attribute, wrapped
-	validateUrl(xml.getNamespace(), results, false, "namespace", false, Severity.WARNING);
-	validateExtensions(xml.getExtensions(), results);
-    }
+	@Override
+	public void validateObject(Xml xml, ValidationResults results) {
+		// no validation for: name, prefix, attribute, wrapped
+		validateUrl(xml.getNamespace(), results, false, "namespace", false, Severity.WARNING, (XmlImpl) xml);
+		validateExtensions(xml.getExtensions(), results);
+	}
 
 }

--- a/kaizen-openapi-parser/src/test/java/com/reprezen/swaggerparser/test/ValidationTest.java
+++ b/kaizen-openapi-parser/src/test/java/com/reprezen/swaggerparser/test/ValidationTest.java
@@ -1,0 +1,19 @@
+package com.reprezen.swaggerparser.test;
+
+import com.google.common.io.Resources;
+import com.reprezen.kaizen.oasparser.OpenApi3Parser;
+import com.reprezen.kaizen.oasparser.model3.OpenApi3;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class ValidationTest {
+
+	@Test
+	public void testLicenceUrl() throws Exception {
+		OpenApi3 model = new OpenApi3Parser().parse(Resources.getResource("models/validationTest.yaml"), true);
+
+		assertEquals(1, model.getValidationItems().size());
+		assertEquals(7, model.getValidationResults().getItems().iterator().next().getPositionInfo().getLine());
+	}
+}

--- a/kaizen-openapi-parser/src/test/resources/models/validationTest.yaml
+++ b/kaizen-openapi-parser/src/test/resources/models/validationTest.yaml
@@ -1,0 +1,17 @@
+---
+openapi: 3.0.0
+info:
+  version: "1.0"
+  title: Foo
+  license:
+    url: htt
+    name: hello.world
+paths:
+  /foo:
+    get:
+      parameters:
+      - name: in
+        in: query
+      responses:
+        200:
+          description: "OK"


### PR DESCRIPTION
@andylowry I noted that some positions are missing when doing URL validations because overlays are not passed over during error creation. This PR includes changes to pass overlays for URL validation (Maybe other validations are also not passing overlays). Please feel free to look at it and merge if my changes are correct.