### PR TITLE
ZEN 4322: OAS3 Validation: Update current parser and validations to latest OpenAPI spec

### DIFF
--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/types3.yaml
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/types3.yaml
@@ -176,10 +176,10 @@ types:
     fields:
       enum:
         name: EnumValue
-        type: Primitive
+        type: String
         structure: collection
       default:
-        type: Primitive
+        type: String
       description: {}
       *extName: *extDef
         
@@ -317,9 +317,7 @@ types:
       parameters:
         type: String
         structure: map
-      headers:
-        type: Header
-        structure: map
+      requestBody: {}
       description: {}
       server:
         type: Server
@@ -487,10 +485,6 @@ types:
         type: Boolean
       xml: {}
       externalDocs: {}
-      examples:
-        type: Example
-        structure: map
-        keyPattern: *namePat
       example:
         type: Object
       deprecated:

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val/ValidatorBase.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val/ValidatorBase.java
@@ -215,7 +215,22 @@ public abstract class ValidatorBase<T> implements Validator<T> {
 			String crumb) {
 		validateMap(extensions, results, false, crumb, null, null);
 	}
+	
+    public void validateExample(final Object example, final ValidationResults results) {
+        //
+    }
 
+    public void validateDescription(String description, ValidationResults results) {
+       validateString(description, results, false, "description");
+    }
+    
+    public void validateSummary(String summary, ValidationResults results) {
+        if (summary != null && summary.length() > 120) {
+            // Why 120? Why not 160? I didn't find it in the spec
+            results.addWarning(m.msg("LongSummary|Sumamry exceeds recommended limit of 120 chars"), "summary");
+        }
+    }
+    
 	public void validateFormat(String format, String type, ValidationResults results, String crumb) {
 		if (format != null && type != null) {
 			String normalType = null;

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/CallbackValidator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/CallbackValidator.java
@@ -24,8 +24,8 @@ public class CallbackValidator extends ObjectValidatorBase<Callback> {
 
     @Override
     public void validateObject(Callback callback, ValidationResults results) {
-	validateMap(callback.getCallbackPaths(), results, false, null, Regexes.NOEXT_REGEX, pathValidator);
-	validateExtensions(callback.getExtensions(), results);
+        validateMap(callback.getCallbackPaths(), results, false, null, Regexes.NOEXT_REGEX, pathValidator);
+        validateExtensions(callback.getExtensions(), results);
     }
 
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/ContactValidator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/ContactValidator.java
@@ -18,9 +18,10 @@ public class ContactValidator extends ObjectValidatorBase<Contact> {
 
     @Override
     public void validateObject(Contact contact, ValidationResults results) {
-	validateUrl(contact.getUrl(), results, false, "url");
-	validateEmail(contact.getEmail(), results, false, "email");
-	validateExtensions(contact.getExtensions(), results);
+        validateString(contact.getName(), results, false, "name");
+        validateUrl(contact.getUrl(), results, false, "url");
+        validateEmail(contact.getEmail(), results, false, "email");
+        validateExtensions(contact.getExtensions(), results);
     }
 
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/EncodingPropertyValidator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/EncodingPropertyValidator.java
@@ -18,13 +18,10 @@ public class EncodingPropertyValidator extends ObjectValidatorBase<EncodingPrope
 
     @Override
     public void validateObject(EncodingProperty encodingProperty, ValidationResults results) {
-	// no validation for: contentType, explode
-	// TODO Q: spec says "Headers" (capitalized) for peroperty name
-	// -assuming it's a
-	// typo
-	validateMap(encodingProperty.getHeaders(), results, false, "headers", Regexes.NOEXT_REGEX, null);
-	validateString(encodingProperty.getStyle(), results, false, Regexes.STYLE_REGEX, "style");
-	validateExtensions(encodingProperty.getExtensions(), results);
+        // no validation for: contentType, explode, allowReserved
+        validateMap(encodingProperty.getHeaders(), results, false, "headers", Regexes.NOEXT_REGEX, null);
+        validateString(encodingProperty.getStyle(), results, false, Regexes.STYLE_REGEX, "style");
+        validateExtensions(encodingProperty.getExtensions(), results);
     }
 
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/ExampleValidator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/ExampleValidator.java
@@ -17,8 +17,10 @@ import com.reprezen.kaizen.oasparser.val.ValidationResults;
 public class ExampleValidator extends ObjectValidatorBase<Example> {
 
     @Override
-    public void validateObject(Example object, ValidationResults results) {
-	// TODO Auto-generated method stub
+    public void validateObject(Example example, ValidationResults results) {
+        // TODO validators for value, externalValue
+        validateSummary(example.getSummary(), results);
+        validateDescription(example.getDescription(), results);
     }
 
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/ExternalDocsValidator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/ExternalDocsValidator.java
@@ -18,9 +18,9 @@ public class ExternalDocsValidator extends ObjectValidatorBase<ExternalDocs> {
 
     @Override
     public void validateObject(ExternalDocs externalDocs, ValidationResults results) {
-	// no validation for: description
-	validateUrl(externalDocs.getUrl(), results, true, "externalDocs");
-	validateExtensions(externalDocs.getExtensions(), results);
+        validateUrl(externalDocs.getUrl(), results, true, "externalDocs");
+        validateDescription(externalDocs.getDescription(), results);
+        validateExtensions(externalDocs.getExtensions(), results);
     }
 
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/InfoValidator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/InfoValidator.java
@@ -27,10 +27,12 @@ public class InfoValidator extends ObjectValidatorBase<Info> {
 
     @Override
     public void validateObject(Info info, ValidationResults results) {
-	validateString(info.getTitle(), results, true, "title");
-	validateField(info.getContact(false), results, false, "contact", contactValidator);
-	validateField(info.getLicense(false), results, false, "license", licenseValidator);
-	validateString(info.getVersion(), results, true, "version");
-	validateExtensions(info.getExtensions(), results);
+        validateString(info.getTitle(), results, true, "title");
+        validateDescription(info.getDescription(), results);
+        validateUrl(info.getTermsOfService(), results, false, "termsOfService");
+        validateField(info.getContact(false), results, false, "contact", contactValidator);
+        validateField(info.getLicense(false), results, false, "license", licenseValidator);
+        validateString(info.getVersion(), results, true, "version");
+        validateExtensions(info.getExtensions(), results);
     }
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/LinkValidator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/LinkValidator.java
@@ -24,6 +24,7 @@ import com.reprezen.kaizen.oasparser.model3.OpenApi3;
 import com.reprezen.kaizen.oasparser.model3.Operation;
 import com.reprezen.kaizen.oasparser.model3.Parameter;
 import com.reprezen.kaizen.oasparser.model3.Path;
+import com.reprezen.kaizen.oasparser.model3.Server;
 import com.reprezen.kaizen.oasparser.val.ObjectValidatorBase;
 import com.reprezen.kaizen.oasparser.val.ValidationResults;
 import com.reprezen.kaizen.oasparser.val.Validator;
@@ -31,108 +32,116 @@ import com.reprezen.kaizen.oasparser.val.Validator;
 public class LinkValidator extends ObjectValidatorBase<Link> {
 
     @Inject
-    private Validator<Header> headerValidator;
+    private Validator<Server> serverValidator;
 
     @Override
     public void validateObject(Link link, ValidationResults results) {
-	// no validation for: description
-	// TODO: Validate operationRef value (why didn't they must make it a ref
-	// object???!)
-	Operation op = checkValidOperation(link, results);
-	if (op != null) {
-	    checkParameters(link, op, results);
-	}
-	validateMap(link.getHeaders(), results, false, "headers", Regexes.NOEXT_REGEX, headerValidator);
-	validateExtensions(link.getExtensions(), results);
+        // TODO: Validate operationRef value (why didn't they must make it a ref
+        // object???!)
+        Operation op = checkValidOperation(link, results);
+        if (op != null) {
+            checkParameters(link, op, results);
+        }
+        
+        // TODO I don't see "header" in the spec. Remove it
+        //validateMap(link.getHeaders(), results, false, "headers", Regexes.NOEXT_REGEX, headerValidator);
+        
+        // TODO validate requestBody (which doesn't exist in parser API)
+        validateDescription(link.getDescription(), results);
+        validateField(link.getServer(), results, false, "server", serverValidator);
+        
+        validateExtensions(link.getExtensions(), results);
     }
 
     private Operation checkValidOperation(Link link, ValidationResults results) {
-	String opId = link.getOperationId();
-	String operationRef = link.getOperationRef();
-	Operation op = null;
-	if (opId == null && operationRef == null) {
-	    results.addError(
-		    m.msg("NoOpIdNoOpRefInLink|Link must contain eitehr 'operationRef' or 'operationId' properties"));
-	} else if (opId != null && operationRef != null) {
-	    results.addError(
-		    m.msg("OpIdAndOpRefInLink|Link may not contain both 'operationRef' and 'operationId' properties"));
-	}
-	if (opId != null) {
-	    op = findOperationById(Overlay.of(link).getModel(), opId);
-	    if (op == null) {
-		results.addError(
-			m.msg("OpIdNotFound|OperationId in Link does not identify an operation in the containing model",
-				opId),
-			"operationId");
-	    }
-	}
-	String relativePath = getRelativePath(operationRef, results);
-	if (relativePath != null) {
-	    op = findOperationByPath(Overlay.of(link).getModel(), relativePath, results);
-	    if (op == null) {
-		results.addError(m.msg(
-			"OpPathNotFound|Relative OperationRef in Link does not identify a GET operation in the containing model",
-			operationRef), "operationRef");
-	    }
-	    //
-	}
-	return op;
+        String opId = link.getOperationId();
+        String operationRef = link.getOperationRef();
+        Operation op = null;
+        if (opId == null && operationRef == null) {
+            results.addError(
+                    m.msg("NoOpIdNoOpRefInLink|Link must contain eitehr 'operationRef' or 'operationId' properties"));
+        } else if (opId != null && operationRef != null) {
+            results.addError(
+                    m.msg("OpIdAndOpRefInLink|Link may not contain both 'operationRef' and 'operationId' properties"));
+        }
+        if (opId != null) {
+            op = findOperationById(Overlay.of(link).getModel(), opId);
+            if (op == null) {
+                results.addError(
+                        m.msg("OpIdNotFound|OperationId in Link does not identify an operation in the containing model",
+                                opId),
+                        "operationId");
+            }
+        }
+        String relativePath = getRelativePath(operationRef, results);
+        if (relativePath != null) {
+            // TODO: the spec says "relative or absolute reference"
+            op = findOperationByPath(Overlay.of(link).getModel(), relativePath, results);
+            if (op == null) {
+                results.addError(
+                        m.msg("OpPathNotFound|Relative OperationRef in Link does not identify a GET operation in the containing model",
+                                operationRef),
+                        "operationRef");
+            }
+            //
+        }
+        return op;
     }
 
     private void checkParameters(Link link, Operation op, ValidationResults results) {
-	// TODO Q: parameter name is not sufficient to identify param in
-	// operation; will
-	// allow if it's unique, warn if
-	// it's not
-	Map<String, Integer> opParamCounts = getParamNameCounts(op.getParameters());
-	for (String paramName : link.getParameters().keySet()) {
-	    int count = opParamCounts.get(paramName);
-	    if (count == 0) {
-		results.addError(m.msg("BadLinkParam|Link parameter does not appear in linked operation", paramName),
-			paramName);
-	    } else if (count > 1) {
-		results.addWarning(
-			m.msg("AmbigLinkParam|Link parameter name appears more than once in linked operation",
-				paramName),
-			paramName);
-	    }
-	}
+        // TODO Q: parameter name is not sufficient to identify param in
+        // operation; will
+        // allow if it's unique, warn if
+        // it's not
+        Map<String, Integer> opParamCounts = getParamNameCounts(op.getParameters());
+        for (String paramName : link.getParameters().keySet()) {
+            int count = opParamCounts.get(paramName);
+            if (count == 0) {
+                results.addError(m.msg("BadLinkParam|Link parameter does not appear in linked operation", paramName),
+                        paramName);
+            } else if (count > 1) {
+                results.addWarning(
+                        m.msg("AmbigLinkParam|Link parameter name appears more than once in linked operation",
+                                paramName),
+                        paramName);
+            }
+        }
     }
 
     private Operation findOperationById(OpenApi3 model, String operationId) {
-	for (Path path : model.getPaths().values()) {
-	    for (Operation op : path.getOperations().values()) {
-		if (operationId.equals(op.getOperationId())) {
-		    return op;
-		}
-	    }
-	}
-	return null;
+        for (Path path : model.getPaths().values()) {
+            for (Operation op : path.getOperations().values()) {
+                if (operationId.equals(op.getOperationId())) {
+                    return op;
+                }
+            }
+        }
+        return null;
     }
 
     private Operation findOperationByPath(OpenApi3 model, String relativePath, ValidationResults results) {
-	Path path = model.getPath(relativePath);
-	return path != null ? path.getGet(false) : null;
+        Path path = model.getPath(relativePath);
+        return path != null ? path.getGet(false) : null;
     }
 
     private String getRelativePath(String operationRef, ValidationResults results) {
-	// TODO Q: will braces be pct-encoded as required for URIs?
-	if (operationRef != null) {
-	    results.addWarning("OperationRefUnSupp|Link.operationRef is not yet supported", "operationRef");
-	}
-	return null;
+        // TODO Q: will braces be pct-encoded as required for URIs?
+        if (operationRef != null) {
+            results.addWarning("OperationRefUnSupp|Link.operationRef is not yet supported", "operationRef");
+        }
+        return null;
     }
 
     private Map<String, Integer> getParamNameCounts(Collection<? extends Parameter> parameters) {
-	Map<String, Integer> counts = Maps.newHashMap();
-	for (Parameter parameter : parameters) {
-	    String name = parameter.getName();
-	    if (counts.containsKey(name)) {
-		counts.put(name, 1 + counts.get(name));
-	    } else {
-		counts.put(name, 1);
-	    }
-	}
-	return counts;
+        Map<String, Integer> counts = Maps.newHashMap();
+        for (Parameter parameter : parameters) {
+            String name = parameter.getName();
+            if (counts.containsKey(name)) {
+                counts.put(name, 1 + counts.get(name));
+            } else {
+                counts.put(name, 1);
+            }
+        }
+        return counts;
     }
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/MediaTypeValidator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/MediaTypeValidator.java
@@ -35,29 +35,30 @@ public class MediaTypeValidator extends ObjectValidatorBase<MediaType> {
 
     @Override
     public void validateObject(MediaType mediaType, ValidationResults results) {
-	// no validation for: example, examples
-	// TODO Q: Should schema be required in media type?
-	validateField(mediaType.getSchema(false), results, false, "schema", schemaValidator);
-	validateMap(mediaType.getEncodingProperties(), results, false, "encoding", Regexes.NOEXT_NAME_REGEX,
-		encodingPropertyValidator);
-	checkEncodingPropsAreProps(mediaType, results);
-	validateExtensions(mediaType.getExtensions(), results);
-	validateMap(mediaType.getExamples(), results, false, "examples", Regexes.NOEXT_NAME_REGEX, exampleValidator);
+        // TODO Q: Should schema be required in media type?
+        validateField(mediaType.getSchema(false), results, false, "schema", schemaValidator);
+        validateMap(mediaType.getEncodingProperties(), results, false, "encoding", Regexes.NOEXT_NAME_REGEX,
+                encodingPropertyValidator);
+        checkEncodingPropsAreProps(mediaType, results);
+        validateExtensions(mediaType.getExtensions(), results);
+        validateMap(mediaType.getExamples(), results, false, "examples", Regexes.NOEXT_NAME_REGEX, exampleValidator);
+        validateExample(mediaType.getExample(), results);
     }
 
     void checkEncodingPropsAreProps(MediaType mediaType, ValidationResults results) {
-	// TODO Q: do allOf, anyOf, oneOf schemas participate? what about
-	// additionalProperties?
-	Schema schema = mediaType.getSchema(false);
-	if (Overlay.of(schema).isElaborated()) {
-	    Set<String> propNames = schema.getProperties().keySet();
-	    for (String encodingPropertyName : mediaType.getEncodingProperties().keySet()) {
-		if (!propNames.contains(encodingPropertyName)) {
-		    results.addError(m.msg(
-			    "EncPropNotSchemaProp|Encoding property does not name a schema property for the media type",
-			    encodingPropertyName), encodingPropertyName);
-		}
-	    }
-	}
+        // TODO Q: do allOf, anyOf, oneOf schemas participate? what about
+        // additionalProperties?
+        Schema schema = mediaType.getSchema(false);
+        if (Overlay.of(schema).isElaborated()) {
+            Set<String> propNames = schema.getProperties().keySet();
+            for (String encodingPropertyName : mediaType.getEncodingProperties().keySet()) {
+                if (!propNames.contains(encodingPropertyName)) {
+                    results.addError(
+                            m.msg("EncPropNotSchemaProp|Encoding property does not name a schema property for the media type",
+                                    encodingPropertyName),
+                            encodingPropertyName);
+                }
+            }
+        }
     }
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/OAuthFlowValidator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/OAuthFlowValidator.java
@@ -18,11 +18,14 @@ public class OAuthFlowValidator extends ObjectValidatorBase<OAuthFlow> {
 
     @Override
     public void validateObject(OAuthFlow oauthFlow, ValidationResults results) {
-	validateUrl(oauthFlow.getAuthorizationUrl(), results, true, "authorizationUrl");
-	validateUrl(oauthFlow.getTokenUrl(), results, true, "tokenUrl");
-	validateUrl(oauthFlow.getRefreshUrl(), results, true, "refreshUrl");
-	validateMap(oauthFlow.getScopes(), results, true, "scopes", Regexes.NOEXT_REGEX, null);
-	validateExtensions(oauthFlow.getExtensions(), results);
+        // TODO why are they all *required*? and why are they *always* required?
+        // e.g., authorizationUrl only applies to oauth2("implicit", "authorizationCode") 
+        // and does NOT apply to "password" and "clientCredentials"
+        validateUrl(oauthFlow.getAuthorizationUrl(), results, true, "authorizationUrl");
+        validateUrl(oauthFlow.getTokenUrl(), results, true, "tokenUrl");
+        validateUrl(oauthFlow.getRefreshUrl(), results, true, "refreshUrl");
+        validateMap(oauthFlow.getScopes(), results, true, "scopes", Regexes.NOEXT_REGEX, null);
+        validateExtensions(oauthFlow.getExtensions(), results);
     }
 
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/OperationValidator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/OperationValidator.java
@@ -10,8 +10,6 @@
  *******************************************************************************/
 package com.reprezen.kaizen.oasparser.val3;
 
-import static com.reprezen.kaizen.oasparser.val.Messages.m;
-
 import com.google.inject.Inject;
 import com.reprezen.kaizen.oasparser.model3.Callback;
 import com.reprezen.kaizen.oasparser.model3.ExternalDocs;
@@ -44,28 +42,24 @@ public class OperationValidator extends ObjectValidatorBase<Operation> {
 
     @Override
     public void validateObject(Operation operation, ValidationResults results) {
-	// no validation for: tags, description, deprecated
-	checkSummaryLength(operation, results);
-	validateField(operation.getExternalDocs(false), results, false, "externalDocs", externalDocsValidator);
-	// TODO Q: Not marked as required in spec, but spec says they all must
-	// be unique
-	// within the API. Seems like it
-	// should be required.
-	validateString(operation.getOperationId(), results, false, "operationId");
-	validateList(operation.getParameters(), operation.hasParameters(), results, false, "parameters",
-		parameterValidator);
-	validateField(operation.getRequestBody(false), results, false, "requestBody", requestBodyValidator);
-	validateMap(operation.getResponses(), results, true, "responses", Regexes.RESPONSE_REGEX, responseValidator);
-	validateMap(operation.getCallbacks(), results, false, "callbacks", Regexes.NOEXT_REGEX, callbackValidator);
-	validateList(operation.getSecurityRequirements(), operation.hasSecurityRequirements(), results, false,
-		"security", securityRequirementValidator);
-	validateList(operation.getServers(), operation.hasServers(), results, false, "servers", serverValidator);
+        // no validation for: deprecated (boolean)
+        validateList(operation.getTags(), operation.hasTags(), results, false, "tags", null);
+        validateSummary(operation.getSummary(), results);
+        validateDescription(operation.getDescription(), results);
+        validateField(operation.getExternalDocs(false), results, false, "externalDocs", externalDocsValidator);
+        // TODO Q: Not marked as required in spec, but spec says they all must be unique
+        // within the API. Seems like it
+        // should be required.
+        validateString(operation.getOperationId(), results, false, "operationId");
+        validateList(operation.getParameters(), operation.hasParameters(), results, false, "parameters",
+                parameterValidator);
+        validateField(operation.getRequestBody(false), results, false, "requestBody", requestBodyValidator);
+        validateMap(operation.getResponses(), results, true, "responses", Regexes.RESPONSE_REGEX, responseValidator);
+        validateMap(operation.getCallbacks(), results, false, "callbacks", Regexes.NOEXT_REGEX, callbackValidator);
+        validateList(operation.getSecurityRequirements(), operation.hasSecurityRequirements(), results, false,
+                "security", securityRequirementValidator);
+        validateList(operation.getServers(), operation.hasServers(), results, false, "servers", serverValidator);
+        validateExtensions(operation.getExtensions(), results);
     }
 
-    private void checkSummaryLength(Operation operation, ValidationResults results) {
-	String summary = operation.getSummary();
-	if (summary != null && summary.length() > 120) {
-	    results.addWarning(m.msg("LongSummary|Sumamry exceeds recommended limit of 120 chars"), "summary");
-	}
-    }
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/ParameterValidator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/ParameterValidator.java
@@ -15,6 +15,7 @@ import static com.reprezen.kaizen.oasparser.val.Messages.m;
 import com.google.inject.Inject;
 import com.reprezen.jsonoverlay.Overlay;
 import com.reprezen.jsonoverlay.PropertiesOverlay;
+import com.reprezen.kaizen.oasparser.model3.Example;
 import com.reprezen.kaizen.oasparser.model3.MediaType;
 import com.reprezen.kaizen.oasparser.model3.Parameter;
 import com.reprezen.kaizen.oasparser.model3.Path;
@@ -29,62 +30,67 @@ public class ParameterValidator extends ObjectValidatorBase<Parameter> {
     private Validator<Schema> schemaValidator;
     @Inject
     private Validator<MediaType> mediaTypeValidator;
+    @Inject
+    private Validator<Example> exampleValidator;
 
     @Override
     public void validateObject(Parameter parameter, ValidationResults results) {
-	// no validations for: description, deprecated, allowEmptyValue,
-	// explode,
-	// example, examples
-	validateString(parameter.getName(), results, true, "name");
-	validateString(parameter.getIn(), results, true, Regexes.PARAM_IN_REGEX, "in");
-	checkPathParam(parameter, results);
-	checkRequired(parameter, results);
-	validateString(parameter.getStyle(), results, false, Regexes.STYLE_REGEX, "style");
-	checkAllowReserved(parameter, results);
-	// TODO Q: Should schema be required in parameter object?
-	validateField(parameter.getSchema(false), results, false, "schema", schemaValidator);
-	validateMap(parameter.getContentMediaTypes(), results, false, "content", Regexes.NOEXT_REGEX,
-		mediaTypeValidator);
-	validateExtensions(parameter.getExtensions(), results);
+        // no validations for: deprecated, allowEmptyValue, explode,
+        validateDescription(parameter.getDescription(), results);
+        validateString(parameter.getName(), results, true, "name");
+        validateString(parameter.getIn(), results, true, Regexes.PARAM_IN_REGEX, "in");
+        checkPathParam(parameter, results);
+        checkRequired(parameter, results);
+        validateString(parameter.getStyle(), results, false, Regexes.STYLE_REGEX, "style");
+        checkAllowReserved(parameter, results);
+        // TODO Q: Should schema be required in parameter object?
+        validateField(parameter.getSchema(false), results, false, "schema", schemaValidator);
+        validateMap(parameter.getContentMediaTypes(), results, false, "content", Regexes.NOEXT_REGEX,
+                mediaTypeValidator);
+        validateExtensions(parameter.getExtensions(), results);
+        
+        validateMap(parameter.getExamples(), results, false, "examples", Regexes.NOEXT_NAME_REGEX, exampleValidator);
+        validateExample(parameter.getExample(), results);
+        
     }
 
     private void checkPathParam(Parameter parameter, ValidationResults results) {
-	if (parameter.getIn() != null && parameter.getIn().equals("path") && parameter.getName() != null) {
-	    String path = getPathString(parameter);
-	    if (path != null) {
-		if (!path.matches(".*/\\{" + parameter.getName() + "\\}(/.*)?")) {
-		    results.addError(m.msg("MissingPathTplt|No template for path parameter in path string",
-			    parameter.getName(), path), "name");
-		}
-	    } else {
-		results.addWarning(
-			m.msg("NoPath|Could not locate path for parameter", parameter.getName(), parameter.getIn()));
-	    }
-	}
+        if (parameter.getIn() != null && parameter.getIn().equals("path") && parameter.getName() != null) {
+            String path = getPathString(parameter);
+            if (path != null) {
+                if (!path.matches(".*/\\{" + parameter.getName() + "\\}(/.*)?")) {
+                    results.addError(m.msg("MissingPathTplt|No template for path parameter in path string",
+                            parameter.getName(), path), "name");
+                }
+            } else {
+                results.addWarning(
+                        m.msg("NoPath|Could not locate path for parameter", parameter.getName(), parameter.getIn()));
+            }
+        }
     }
 
     private void checkRequired(Parameter parameter, ValidationResults results) {
-	if ("path".equals(parameter.getIn())) {
-	    if (parameter.getRequired() != Boolean.TRUE) {
-		results.addError(
-			m.msg("PathParamReq|Path param must have 'required' property set true", parameter.getName()),
-			"required");
-	    }
-	}
+        if ("path".equals(parameter.getIn())) {
+            if (parameter.getRequired() != Boolean.TRUE) {
+                results.addError(
+                        m.msg("PathParamReq|Path param must have 'required' property set true", parameter.getName()),
+                        "required");
+            }
+        }
     }
 
     private void checkAllowReserved(Parameter parameter, ValidationResults results) {
-	if (parameter.isAllowReserved() && !"query".equals(parameter.getIn())) {
-	    results.addWarning(m.msg("NonQryAllowRsvd|AllowReserved is ignored for non-query parameter",
-		    parameter.getName(), parameter.getIn()), "allowReserved");
-	}
+        if (parameter.isAllowReserved() && !"query".equals(parameter.getIn())) {
+            results.addWarning(m.msg("NonQryAllowRsvd|AllowReserved is ignored for non-query parameter",
+                    parameter.getName(), parameter.getIn()), "allowReserved");
+        }
     }
 
     private String getPathString(Parameter parameter) {
-	PropertiesOverlay<?> parent = Overlay.of(parameter).getParentPropertiesOverlay();
-	while (parent != null && !(parent instanceof Path)) {
-	    parent = Overlay.of(parent).getParentPropertiesOverlay();
-	}
-	return parent != null && parent instanceof Path ? Overlay.getPathInParent(parent) : null;
+        PropertiesOverlay<?> parent = Overlay.of(parameter).getParentPropertiesOverlay();
+        while (parent != null && !(parent instanceof Path)) {
+            parent = Overlay.of(parent).getParentPropertiesOverlay();
+        }
+        return parent != null && parent instanceof Path ? Overlay.getPathInParent(parent) : null;
     }
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/PathValidator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/PathValidator.java
@@ -30,10 +30,11 @@ public class PathValidator extends ObjectValidatorBase<Path> {
 
     @Override
     public void validateObject(Path path, ValidationResults results) {
-	// no validation for: summary, description
-	validateMap(path.getOperations(), results, false, null, Regexes.METHOD_REGEX, operationValidator);
-	validateList(path.getServers(), path.hasServers(), results, false, "servers", serverValidator);
-	validateList(path.getParameters(), path.hasParameters(), results, false, "parameters", parameterValidator);
-	validateExtensions(path.getExtensions(), results);
+        validateSummary(path.getSummary(), results);
+        validateDescription(path.getDescription(), results);
+        validateMap(path.getOperations(), results, false, null, Regexes.METHOD_REGEX, operationValidator);
+        validateList(path.getServers(), path.hasServers(), results, false, "servers", serverValidator);
+        validateList(path.getParameters(), path.hasParameters(), results, false, "parameters", parameterValidator);
+        validateExtensions(path.getExtensions(), results);
     }
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/Regexes.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/Regexes.java
@@ -22,6 +22,6 @@ public class Regexes {
     public static final Pattern METHOD_REGEX = Pattern.compile("get|put|post|delete|options|head|patch|trace");
     public static final Pattern PARAM_IN_REGEX = Pattern.compile("path|query|header|cookie");
     public static final Pattern STYLE_REGEX = Pattern
-	    .compile("matrix|label|form|simple|spaceDelimited|pipeDelimited|deepObject");
-    public static final Pattern RESPONSE_REGEX = Pattern.compile("default|\\d\\d\\d");
+            .compile("matrix|label|form|simple|spaceDelimited|pipeDelimited|deepObject");
+    public static final Pattern RESPONSE_REGEX = Pattern.compile("default|\\d[0-9X]{2}");
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/RequestBodyValidator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/RequestBodyValidator.java
@@ -24,10 +24,11 @@ public class RequestBodyValidator extends ObjectValidatorBase<RequestBody> {
 
     @Override
     public void validateObject(RequestBody requestBody, ValidationResults results) {
-	// no validation for: description, required
-	validateMap(requestBody.getContentMediaTypes(), results, false, "content", Regexes.NOEXT_REGEX,
-		mediaTypeValidator);
-	validateExtensions(requestBody.getExtensions(), results);
+        // no validation for: required
+        validateDescription(requestBody.getDescription(), results);
+        validateMap(requestBody.getContentMediaTypes(), results, true, "content", Regexes.NOEXT_REGEX,
+                mediaTypeValidator);
+        validateExtensions(requestBody.getExtensions(), results);
     }
 
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/ResponseValidator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/ResponseValidator.java
@@ -30,10 +30,11 @@ public class ResponseValidator extends ObjectValidatorBase<Response> {
 
     @Override
     public void validateObject(Response response, ValidationResults results) {
-	validateMap(response.getHeaders(), results, false, "headers", null, headerValidator);
-	validateMap(response.getContentMediaTypes(), results, false, "content", Regexes.NOEXT_REGEX,
-		mediaTypeValidator);
-	validateMap(response.getLinks(), results, false, "links", Regexes.NOEXT_NAME_REGEX, linkValidator);
-	validateExtensions(response.getExtensions(), results);
+        validateDescription(response.getDescription(), results);
+        validateMap(response.getHeaders(), results, false, "headers", null, headerValidator);
+        validateMap(response.getContentMediaTypes(), results, false, "content", Regexes.NOEXT_REGEX,
+                mediaTypeValidator);
+        validateMap(response.getLinks(), results, false, "links", Regexes.NOEXT_NAME_REGEX, linkValidator);
+        validateExtensions(response.getExtensions(), results);
     }
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/SchemaValidator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/SchemaValidator.java
@@ -14,7 +14,6 @@ import static com.reprezen.kaizen.oasparser.val.Messages.m;
 
 import com.google.inject.Inject;
 import com.reprezen.jsonoverlay.Overlay;
-import com.reprezen.kaizen.oasparser.model3.Example;
 import com.reprezen.kaizen.oasparser.model3.ExternalDocs;
 import com.reprezen.kaizen.oasparser.model3.Schema;
 import com.reprezen.kaizen.oasparser.model3.Xml;
@@ -29,14 +28,13 @@ public class SchemaValidator extends ObjectValidatorBase<Schema> {
 	private Validator<Xml> xmlValidator;
 	@Inject
 	private Validator<ExternalDocs> externalDocsValidator;
-	@Inject
-	private Validator<Example> exampleValidator;
 
 	@Override
 	public void validateObject(Schema schema, ValidationResults results) {
-		// no validation for: title, description, maximum, exclusiveMaximum, minimum
+		// no validation for: title, maximum, exclusiveMaximum, minimum
 		// exclusiveMinimum, uniqueItems,
-		// nullable, example, deprecated
+		// nullable, deprecated
+	    validateDescription(schema.getDescription(), results);
 		validatePositive(schema.getMultipleOf(), results, false, "multipleOf");
 		validateNonNegative(schema.getMaxLength(), results, false, "maxLength");
 		validateNonNegative(schema.getMinLength(), results, false, "minLength");
@@ -67,7 +65,7 @@ public class SchemaValidator extends ObjectValidatorBase<Schema> {
 		checkReadWrite(schema, results);
 		validateField(schema.getXml(false), results, false, "xml", xmlValidator);
 		validateField(schema.getExternalDocs(false), results, false, "externalDocs", externalDocsValidator);
-		validateMap(schema.getExamples(), results, false, "examples", Regexes.NOEXT_NAME_REGEX, exampleValidator);
+		validateExample(schema.getExample(), results);
 		validateExtensions(schema.getExtensions(), results);
 	}
 

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/SecurityRequirementValidator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/SecurityRequirementValidator.java
@@ -27,28 +27,28 @@ public class SecurityRequirementValidator extends ObjectValidatorBase<SecurityRe
 
     @Override
     public void validateObject(SecurityRequirement securityRequirement, ValidationResults results) {
-	OpenApi3 model = Overlay.of(securityRequirement).getModel();
-	Set<String> definedSchemes = model.getSecuritySchemes().keySet();
-	for (Entry<String, ? extends SecurityParameter> entry : securityRequirement.getRequirements().entrySet()) {
-	    if (!definedSchemes.contains(entry.getKey())) {
-		results.addError(
-			m.msg("UnkSecScheme|Security scheme not defined in components object", entry.getKey()));
-	    } else {
-		String type = model.getSecurityScheme(entry.getKey()).getType();
-		switch (type) {
-		case "oauth2":
-		case "openIdConnect":
-		    // TODO Q: anything to test here? do we know what the
-		    // allowed scope names are?
-		    break;
-		default:
-		    if (!entry.getValue().getParameters().isEmpty()) {
-			results.addError(Messages.m.msg(
-				"NonEmptySecReqParms|Security requirement parameters must be empty unless scheme type is oauth2 or openIdConnect",
-				entry.getKey(), type));
-		    }
-		}
-	    }
-	}
+        OpenApi3 model = Overlay.of(securityRequirement).getModel();
+        Set<String> definedSchemes = model.getSecuritySchemes().keySet();
+        for (Entry<String, ? extends SecurityParameter> entry : securityRequirement.getRequirements().entrySet()) {
+            if (!definedSchemes.contains(entry.getKey())) {
+                results.addError(
+                        m.msg("UnkSecScheme|Security scheme not defined in components object", entry.getKey()));
+            } else {
+                String type = model.getSecurityScheme(entry.getKey()).getType();
+                switch (type) {
+                case "oauth2":
+                case "openIdConnect":
+                    // TODO Q: anything to test here? do we know what the
+                    // allowed scope names are?
+                    break;
+                default:
+                    if (!entry.getValue().getParameters().isEmpty()) {
+                        results.addError(Messages.m.msg(
+                                "NonEmptySecReqParms|Security requirement parameters must be empty unless scheme type is oauth2 or openIdConnect",
+                                entry.getKey(), type));
+                    }
+                }
+            }
+        }
     }
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/SecuritySchemeValidator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/SecuritySchemeValidator.java
@@ -24,33 +24,35 @@ public class SecuritySchemeValidator extends ObjectValidatorBase<SecurityScheme>
 
     @Override
     public void validateObject(SecurityScheme securityScheme, ValidationResults results) {
-	// no validation for: description, bearerFormat
-	validateString(securityScheme.getType(), results, true, "apiKey|http|oauth2|openIdConnect", "type");
-	switch (securityScheme.getType()) {
-	case "http":
-	    validateString(securityScheme.getScheme(), results, true, "scheme");
-	    // If bearer validate bearerFormat
-	    break;
-	case "apiKey":
-	    validateString(securityScheme.getName(), results, true, "name");
-	    validateString(securityScheme.getIn(), results, true, "query|header|cookie", "in");
-	    break;
-	case "oauth2":
-	    validateField(securityScheme.getImplicitOAuthFlow(false), results, false, "flow.implicit",
-		    oauthFlowValidator);
-	    validateField(securityScheme.getImplicitOAuthFlow(false), results, false, "flow.password",
-		    oauthFlowValidator);
-	    validateField(securityScheme.getImplicitOAuthFlow(false), results, false, "flow.clientCredentials",
-		    oauthFlowValidator);
-	    validateField(securityScheme.getImplicitOAuthFlow(false), results, false, "authorizationCode",
-		    oauthFlowValidator);
-	    validateExtensions(securityScheme.getOAuthFlowsExtensions(), results, "flow");
-	    break;
-	case "openIdConnect":
-	    validateUrl(securityScheme.getOpenIdConnectUrl(), results, true, "openIdConnectUrl");
-	    break;
-	}
-	validateExtensions(securityScheme.getExtensions(), results);
+        // no validation for: bearerFormat
+        validateDescription(securityScheme.getDescription(), results);
+        validateString(securityScheme.getType(), results, true, "apiKey|http|oauth2|openIdConnect", "type");
+        // TODO: should we also add checks that scheme is NOT present for types other than http, etc?
+        switch (securityScheme.getType()) {
+        case "http":
+            validateString(securityScheme.getScheme(), results, true, "scheme");
+            // If scheme == bearer validate bearerFormat, bearerFormat(optional) is a string
+            break;
+        case "apiKey":
+            validateString(securityScheme.getName(), results, true, "name");
+            validateString(securityScheme.getIn(), results, true, "query|header|cookie", "in");
+            break;
+        case "oauth2":
+            validateField(securityScheme.getImplicitOAuthFlow(false), results, false, "flow.implicit",
+                    oauthFlowValidator);
+            validateField(securityScheme.getPasswordOAuthFlow(false), results, false, "flow.password",
+                    oauthFlowValidator);
+            validateField(securityScheme.getClientCredentialsOAuthFlow(false), results, false, "flow.clientCredentials",
+                    oauthFlowValidator);
+            validateField(securityScheme.getAuthorizationCodeOAuthFlow(false), results, false, "flow.authorizationCode",
+                    oauthFlowValidator);
+            validateExtensions(securityScheme.getOAuthFlowsExtensions(), results, "flow");
+            break;
+        case "openIdConnect":
+            validateUrl(securityScheme.getOpenIdConnectUrl(), results, true, "openIdConnectUrl");
+            break;
+        }
+        validateExtensions(securityScheme.getExtensions(), results);
     }
 
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/ServerValidator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/ServerValidator.java
@@ -26,9 +26,9 @@ public class ServerValidator extends ObjectValidatorBase<Server> {
 
     @Override
     public void validateObject(Server server, ValidationResults results) {
-	// no validation for: description
-	validateUrl(server.getUrl(), results, false, "url", true);
-	validateMap(server.getServerVariables(), results, false, "variables", NAME_REGEX, serverVariableValidator);
-	validateExtensions(server.getExtensions(), results);
+        validateUrl(server.getUrl(), results, true, "url", true);
+        validateDescription(server.getDescription(), results);
+        validateMap(server.getServerVariables(), results, false, "variables", NAME_REGEX, serverVariableValidator);
+        validateExtensions(server.getExtensions(), results);
     }
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/ServerVariableValidator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/ServerVariableValidator.java
@@ -15,43 +15,17 @@ import javax.lang.model.type.NullType;
 import com.reprezen.kaizen.oasparser.model3.ServerVariable;
 import com.reprezen.kaizen.oasparser.val.Messages;
 import com.reprezen.kaizen.oasparser.val.ObjectValidatorBase;
+import com.reprezen.kaizen.oasparser.val.StringValidator;
 import com.reprezen.kaizen.oasparser.val.ValidationResults;
 
 public class ServerVariableValidator extends ObjectValidatorBase<ServerVariable> {
 
     @Override
     public void validateObject(final ServerVariable variable, final ValidationResults results) {
-	results.withCrumb("enum", new Runnable() {
-	    @Override
-	    public void run() {
-		int i = 0;
-		for (Object primitive : variable.getEnumValues()) {
-		    checkPrimitive(primitive, results, i++);
-		}
-	    }
-	});
-	results.withCrumb("default", new Runnable() {
-	    @Override
-	    public void run() {
-		checkPrimitive(variable.getDefault(), results, "default");
-	    }
-	});
-	validateString(variable.getDescription(), results, false, "description");
+        validateList(variable.getEnumValues(), variable.hasEnumValues(), results, false, "enum", null);
+        validateString(variable.getDefault(), results, true, "default");
+        validateDescription(variable.getDescription(), results);
+        validateExtensions(variable.getExtensions(), results);
     }
 
-    private void checkPrimitive(Object primitive, ValidationResults results, int index) {
-	checkPrimitive(primitive, results, "[" + index + "]");
-    }
-
-    private void checkPrimitive(final Object primitive, ValidationResults results, String crumb) {
-	if (!(primitive instanceof String || primitive instanceof Number || primitive instanceof Boolean)) {
-	    results.withCrumb(crumb, new Runnable() {
-		@Override
-		public void run() {
-		    Messages.m.msg("BadPrimitive|Invalid primitive value", String.valueOf(primitive),
-			    (primitive != null ? primitive.getClass() : NullType.class).getName());
-		}
-	    });
-	}
-    }
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/TagValidator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/TagValidator.java
@@ -24,9 +24,10 @@ public class TagValidator extends ObjectValidatorBase<Tag> {
 
     @Override
     public void validateObject(Tag tag, ValidationResults results) {
-	validateString(tag.getName(), results, true, "name");
-	validateField(tag.getExternalDocs(false), results, false, "externalDocs", externalDocsValidator);
-	validateExtensions(tag.getExtensions(), results);
+        validateString(tag.getName(), results, true, "name");
+        validateDescription(tag.getDescription(), results);
+        validateField(tag.getExternalDocs(false), results, false, "externalDocs", externalDocsValidator);
+        validateExtensions(tag.getExtensions(), results);
     }
 
 }

--- a/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/XmlValidator.java
+++ b/kaizen-openapi-parser/src/main/java/com/reprezen/kaizen/oasparser/val3/XmlValidator.java
@@ -20,9 +20,9 @@ public class XmlValidator extends ObjectValidatorBase<Xml> {
 
     @Override
     public void validateObject(Xml xml, ValidationResults results) {
-	// no validation for: name, prefix, attribute, wrapped
-	validateUrl(xml.getNamespace(), results, false, "namespace", false, Severity.WARNING);
-	validateExtensions(xml.getExtensions(), results);
+        // no validation for: name, prefix, attribute, wrapped
+        validateUrl(xml.getNamespace(), results, false, "namespace", false, Severity.WARNING);
+        validateExtensions(xml.getExtensions(), results);
     }
 
 }


### PR DESCRIPTION
[Targeting task/180]

# Updated Parser for OAS 3.0.1 (types3.yaml)
Note: I did NOT generate-sources from types3.yaml as the diff produced by the generator is suspiciously big, I am using jsonoverlay-3.0.2-201808131204 . I will gladly regenerate them if you point me to the right version of Json Overlay

## Server Variable
* enum: Object* -> string*
* default: Object -> string

From
https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#serverVariableObject:
> enum	[string]	An enumeration of string values to be used if the
substitution options are from a limited set.

> default	string	REQUIRED. The default value to use for substitution,
and to send, if an alternate value is not supplied. Unlike the Schema
Object's default, this value MUST be provided by the consumer.

## Link
* Removed `headers`
* Added `requestBody`

From
https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#linkObject:
> requestBody	Any | {expression}	A literal value or {expression} to use
as a request body when calling the target operation.

* no "headers" - request headers should be declared in "parameters"

## Schema
* Removed `examples`

From
https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.1.md#schemaObject:
No "examples" (plural), only "example"(singular):
> example	Any	A free-form property to include an example of an instance
for this schema. To represent examples that cannot be naturally
represented in JSON or YAML, a string value can be used to contain the
example with escaping where necessary.

# Updated Validator
See d0cb178