### PR TITLE
Fix generated import packages in MANIFEST

### DIFF
--- a/kaizen-openapi-parser/p2/pom.xml
+++ b/kaizen-openapi-parser/p2/pom.xml
@@ -22,7 +22,7 @@
 		<artifact>
 		  <id>com.reprezen.kaizen:openapi-parser:${kzop-version}</id>
 		  <instructions>
-		    <Import-Package>*;resolution=optional</Import-Package>
+		    <Import-Package>*, javax.mail.internet</Import-Package>
 		    <Export-Package>
 		      com.reprezen.kaizen.oasparser,
 		      com.reprezen.kaizen.oasparser.model3,
@@ -34,6 +34,7 @@
 		<artifact>
 		  <id>com.reprezen.jsonoverlay:jsonoverlay:${jovl-version}</id>
 		  <instructions>
+		    <Import-Package>*</Import-Package>
 		    <Export-Package>
 		      com.reprezen.jsonoverlay,
 		      com.reprezen.jsonoverlay.gen


### PR DESCRIPTION
This commit removes the optional resolution for KZOP import packages in the MANIFEST that is causing dependencies to not be resolved when used in an Eclipse environment. It also adds the missing javax.mail package, and adds missing import packages for JsonOverlay.