### PR TITLE
ZEN-4862 Adapt KZOP for maven-release-plugin

### DIFF
--- a/kaizen-openapi-parser/pom.xml
+++ b/kaizen-openapi-parser/pom.xml
@@ -9,7 +9,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.reprezen.kaizen</groupId>
     <artifactId>openapi-parser</artifactId>
-    <version>4.0.1</version>
+    <version>4.0.2-SNAPSHOT</version>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>KaiZen OpenAPI Parser by RepreZen</description>
     <url>https://github.com/RepreZen/KaiZen-OpenAPI-Parser</url>
@@ -87,7 +87,6 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>19.0</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.reprezen.jsonoverlay</groupId>
@@ -132,42 +131,6 @@
                                 <include>**/oasparser/GenOpenApi3.java</include>
                             </includes>
                         </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
-            <id>sign</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>exec-maven-plugin</artifactId>
-                        <version>1.6.0</version>
-                        <executions>
-                            <execution>
-                                <id>remote-sign</id>
-                                <goals>
-                                    <goal>exec</goal>
-                                </goals>
-                                <configuration>
-                                    <executable>bash</executable>
-                                    <arguments>
-                                        <argument>${sign.content.script}</argument>
-                                        <argument>--endpoint</argument>
-                                        <argument>${code.sign.endpoint}</argument>
-                                        <argument>--exclude</argument>
-                                        <argument>*-sources.jar</argument>
-                                        <argument>--exclude</argument>
-                                        <argument>*-javadoc.jar</argument>
-                                        <argument>--exclude</argument>
-                                        <argument>surefire*.jar</argument>
-                                        <argument>${project.build.directory}</argument>
-                                    </arguments>
-                                </configuration>
-                                <phase>package</phase>
-                            </execution>
-                        </executions>
                     </plugin>
                 </plugins>
             </build>
@@ -220,6 +183,18 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>2.5.3</version>
+                <configuration>
+                    <tagNameFormat>v@{project.version}</tagNameFormat>
+                    <autoVersionSubmodules>true</autoVersionSubmodules>
+                    <!-- We don't use release:perform - deployment is done in TeamCity. 
+						This just makes an errant perform operation harmless -->
+                    <goals>clean</goals>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
                 <version>1.6.7</version>
@@ -234,12 +209,12 @@
         </plugins>
     </build>
     <properties>
-        <json-overlay-version>[4.0,5.0)</json-overlay-version>
+        <json-overlay-version>4.0.4-SNAPSHOT</json-overlay-version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <nexus.autorelease>false</nexus.autorelease>
         <nexus.autodrop>true</nexus.autodrop>
-        <jackson-version>2.6.2</jackson-version>
+        <jackson-version>2.9.8</jackson-version>
     </properties>
 </project>

--- a/kaizen-openapi-parser/pom.xml
+++ b/kaizen-openapi-parser/pom.xml
@@ -209,7 +209,7 @@
         </plugins>
     </build>
     <properties>
-        <json-overlay-version>4.0.4-SNAPSHOT</json-overlay-version>
+        <json-overlay-version>4.0.3</json-overlay-version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Going forward, release management will use the
maven-release-plugin. We'll no longer use date-time stamps as version
qualifiers.

Version releases will be performed directly in master branch. PRs should
never change project version.

We have disabled the release:perform goal, becuase we do deployments
from RepreZen's (private) TeamCity installation. That may change in the
future.

Proper sequence to move to a new release is:
* Be in clean, up-to-date master branch
* run: mvn release:prepare, specifying new release as appropriate and
  accepting defaults for everything else
* run mvn release:clean
* push to github