### PR TITLE
ZNE-4675 configure for snapshots

### DIFF
--- a/kaizen-openapi-parser/pom.xml
+++ b/kaizen-openapi-parser/pom.xml
@@ -154,6 +154,18 @@
                 </plugins>
             </build>
         </profile>
+		<profile>
+			<id>snap</id>
+			<repositories>
+				<repository>
+					<id>sonatype-snapshots</id>
+					<url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+					<layout>default</layout>
+					<releases><enabled>false</enabled></releases>
+					<snapshots><enabled>true</enabled></snapshots>
+				</repository>
+			</repositories>
+		</profile>
     </profiles>
     <build>
         <plugins>
@@ -207,6 +219,15 @@
             </plugin>
         </plugins>
     </build>
+    <distributionManagement>
+        <snapshotRepository>
+            <uniqueVersion>false</uniqueVersion>
+            <id>sonatype-nexus-snapshots</id>
+            <name>Sonatype OSS Snapshots</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+            <layout>legacy</layout>
+        </snapshotRepository>
+    </distributionManagement>
     <properties>
         <json-overlay-version>4.0.3</json-overlay-version>
         <maven.compiler.source>1.8</maven.compiler.source>


### PR DESCRIPTION
Added distributionManagement elemnent to define the target repo for
snapshot deployment.

Also created a profile, `snap`, that can be activated to make the
sonatype snapshots repo available