### PR TITLE
Check that param type is present via either schema or content

### DIFF
--- a/kaizen-openapi-parser/src/test/java/com/reprezen/kaizen/oasparser/val3/ParameterValidatorTest.java
+++ b/kaizen-openapi-parser/src/test/java/com/reprezen/kaizen/oasparser/val3/ParameterValidatorTest.java
@@ -42,6 +42,15 @@ public class ParameterValidatorTest {
 	}
 
 	@Test
+	public void shouldFail_OnInValidParamType() throws Exception {
+		OpenApi3 model = new OpenApi3Parser().parse(getClass().getResource("/models/params/invalidParamType.yaml"), true);
+
+		assertEquals(1, model.getValidationItems().size());
+		assertEquals("Exactly one of schema|content must be present", model.getValidationItems().iterator().next().getMsg() );
+		assertFalse(model.isValid());
+	}
+
+	@Test
 	public void shouldAllow_HybridPathParam() throws Exception {
 		OpenApi3 model = new OpenApi3Parser().parse(getClass().getResource("/models/params/hybridParam.yaml"), true);
 

--- a/kaizen-openapi-parser/src/test/resources/models/params/hybridParam.yaml
+++ b/kaizen-openapi-parser/src/test/resources/models/params/hybridParam.yaml
@@ -10,6 +10,8 @@ paths:
       - in: path
         name: params
         required: true
+        schema:
+          type: string
       responses:
         200:
           description: Ok

--- a/kaizen-openapi-parser/src/test/resources/models/params/invalidParamType.yaml
+++ b/kaizen-openapi-parser/src/test/resources/models/params/invalidParamType.yaml
@@ -4,7 +4,7 @@ info:
   version: 1.0.0
   title: My API Spec
 paths:
-  /{id:
+  /{id}:
     get:
       parameters:
       - in: path
@@ -12,6 +12,10 @@ paths:
         required: true
         schema:
           type: string
+        content:
+          application/json:
+            schema:
+              type: string
       responses:
         200:
           description: Ok

--- a/kaizen-openapi-parser/src/test/resources/models/params/multiHybridParam.yaml
+++ b/kaizen-openapi-parser/src/test/resources/models/params/multiHybridParam.yaml
@@ -10,9 +10,13 @@ paths:
       - in: path
         name: customerID
         required: true
+        schema:
+          type: string
       - in: path
         name: orderID
         required: true
+        schema:
+          type: integer
       responses:
         200:
           description: Ok

--- a/kaizen-openapi-parser/src/test/resources/models/params/pathParamNotRequired.yaml
+++ b/kaizen-openapi-parser/src/test/resources/models/params/pathParamNotRequired.yaml
@@ -9,6 +9,8 @@ paths:
       parameters:
       - in: path
         name: id
+        schema:
+          type: string
       responses:
         200:
           description: Ok

--- a/kaizen-openapi-parser/src/test/resources/models/params/validParam.yaml
+++ b/kaizen-openapi-parser/src/test/resources/models/params/validParam.yaml
@@ -10,6 +10,8 @@ paths:
       - in: path
         name: id
         required: true
+        schema:
+          type: string
       responses:
         200:
           description: Ok


### PR DESCRIPTION
According to https://swagger.io/docs/specification/describing-parameters/ a param needs to have a data type that is defined by either `schema` or `content`:

> Describing Parameters
> In OpenAPI 3.0, parameters are defined in the parameters section of an operation or path. To describe a parameter, you specify its name, location (in), data type (defined by either schema or content) 

This PR checks that one of  `schema` or `content` are present. If not an error is reported.

E.g.:

```
http://0.0.0.0:8081/api/custom-policies/v1.0/openapi.json[72:9]: Exactly one of schema|content must be present
http://0.0.0.0:8081/api/custom-policies/v1.0/openapi.json[76:9]: Exactly one of schema|content must be present
http://0.0.0.0:8081/api/custom-policies/v1.0/openapi.json[80:9]: Exactly one of schema|content must be present
```
